### PR TITLE
Proposal for alternate asynchronous control implementation (actions and status)

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -24,7 +24,7 @@ paths:
         - Config
       operationId: set_config
       description: >-
-        Sets the configuration on the traffic generator.
+        Creates new or updates existing traffic generator configuration.
       requestBody:
         required: true
         content:
@@ -34,75 +34,73 @@ paths:
       responses:
         '200':
           description: >-
-            A list of configuration errors.
+            A list of configuration validation errors.
             An empty list indicates there are no errors.
           content:
             application/json:
               schema:
                 $ref: '../result/result.yaml#/components/schemas/Result.Errors'
-          
-  /control/port/link:
-    description: >-
-      Control port link API
-    post:
+    get:
       tags:
-        - Control
-      operationId: set_port_link
+        - Config
+      operationId: get_config
       description: >-
-        Sets the port link state on the traffic generator.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '../control/control.yaml#/components/schemas/Control.PortLink'
+        Returns traffic generator configuration.
       responses:
-        '204':
+        '200':
           description: >-
-            No content
+            The most recent traffic generator configuration.
+            An empty configuration indicates that configuration does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '../config/config.yaml#/components/schemas/Config'
 
-  /control/port/capture:
+  /control/action:
     description: >-
-      Control port capture API
+      Control action API
     post:
       tags:
         - Control
-      operationId: set_port_capture
+      operationId: set_control_action
       description: >-
-        Starts a port capture on the traffic generator.
-        
-        Use the /results/capture API to stop a port capture and get the captured
-        results.
+        Applies a list of control actions on intended traffic generator resources
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '../control/control.yaml#/components/schemas/Control.PortCapture'
+              $ref: '../control/control.yaml#/components/schemas/Control.Action'
       responses:
-        '204':
+        '202':
           description: >-
-            No content
+            The request for intended control actions have been accepted and is in progress.
+            The response body will contain status url which will provide subsequent progress status.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status_url:
+                    type: string
 
-  /control/flow/transmit:
+  /control/status:
     description: >-
-      Control flow transmit API
-    post:
+      Control status API
+    get:
       tags:
         - Control
-      operationId: set_flow_transmit
+      operationId: get_control_status
       description: >-
-        Sets the flow transmit state on the traffic generator.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '../control/control.yaml#/components/schemas/Control.FlowTransmit'
+        Returns status for all supported control actions.
       responses:
-        '204':
+        '200':
           description: >-
-            No content
+            A key-value pair of each supported action and its corresponding status.
+          content:
+            application/json:
+              schema:
+                $ref: '../control/control.yaml#/components/schemas/Control.Status'
 
   /results/capabilities:
     description: >-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,6 +11,7 @@ components:
         A container for all models that are part of the configuration.
       type: object
       properties:
+        name: '../common/common.yaml#/components/x-inline/UniqueName'
         ports:
           description: >-
             The ports that will be configured on the traffic generator.

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -8,58 +8,150 @@ info:
 
 components:
   schemas:
-    Control.PortLink:
+    Control.Action:
       description: >-
-        Control port link state
-      type: object
-      properties:
-        port_names:
-          description: >-
-            The names of port objects to.
-            An empty list will control all port objects.
-          type: array
-          items:
-            type: string
-            x-constraint:
-            - '/components/schemas/Port/properties/name'
-        state:
-          description: >-
-            The link state.
-          type: string
-          enum: [up, down]
-
-    Control.FlowTransmit:
-      description: >-
-        Control flow transmit state
+        One or more control actions to be performed against intended resources.
       type: object
       properties:
         flow_names:
           description: >-
-            The names of flow objects to control.
-            An empty list will control all flow objects.
+            The names of flows to apply control actions on.
+            An empty list will apply control actions on all flows.
           type: array
           items:
             type: string
             x-constraint:
             - '/components/schemas/Flow/properties/name'
-        state:
-          description: >-
-            The transmit state.
-          type: string
-          enum: [start, stop, pause]
-
-    Control.PortCapture:
-      description: >-
-        Control port capture state
-      type: object
-      properties:
         port_names:
           description: >-
-            The name of a port to start capturing packets on.
-            Allows for capture to be started on multiple ports.
+            The names of ports to apply control actions on.
+            An empty list will apply control actions on all ports.
           type: array
           items:
             type: string
             x-constraint:
             - '/components/schemas/Port/properties/name'
+        actions:
+          description: >-
+            List of control actions. The actions prefixed with `o_` are granular actions.
+          type: array
+          items:
+            type: string
+            enum:
+              - start
+              - stop
+              - pause
+              - resume
+              - update
+              - o_connect
+              - o_disconnect
+              - o_update_layer1
+              - o_start_transmit
+              - o_stop_transmit
+              - o_start_capture
+              - o_stop_capture
+              - o_clear_stats
+              - o_start_devices
+              - o_stop_devices
 
+    Control.Status:
+      description: >-
+        Status of all supported control actions. Whenever a control action is
+        requested, its status is reset to `none` and updated to `done` or `failed`
+        only when the underlying operations associated with it succeeds or fails
+        respectively. The details of failure for a given action can be found in
+        list of errors.
+      type: object
+      properties:
+        start:
+          description: >-
+            Indicates whether traffic run has been successfully started.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        stop:
+          description: >-
+            Indicates whether traffic run has been successfully stopped.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        pause:
+          description: >-
+            Indicates whether traffic run has been successfully paused.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        resume:
+          description: >-
+            Indicates whether traffic run has been successfully resumed.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        update:
+          description: >-
+            Indicates whether traffic config has been successfully updated.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_connect:
+          description: >-
+            Indicates whether connection to intended traffic endpoints have been successfully established.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_disconnect:
+          description: >-
+            Indicates whether intended traffic endpoints have been successfully disconnected.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_update_layer1:
+          description: >-
+            Indicates whether layer1 configuration on intended traffic endpoints have been successfully updated.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_start_transmit:
+          description: >-
+            Indicates whether flow transmit has been successfully started.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_stop_transmit:
+          description: >-
+            Indicates whether flow transmit has been successfully stopped.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_start_capture:
+          description: >-
+            Indicates whether port capture has been successfully started.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_stop_capture:
+          description: >-
+            Indicates whether port capture has been successfully stopped.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_clear_stats:
+          description: >-
+            Indicates whether Tx / Rx stats have been successfully cleared.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_start_devices:
+          description: >-
+            Indicates whether intended emulated devices have been successfully started.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        o_stop_devices:
+          description: >-
+            Indicates whether intended emulated devices have been successfully stopped.
+          type: string
+          enum: [none, done, failed]
+          default: none
+        errors:
+          $ref: '../result/result.yaml#/components/schemas/Result.Errors'


### PR DESCRIPTION
What's new ?
- Rephrased purpose of POST /config: It will validate the Config and store it (and not actually apply it).
- Added GET /config: It will return Config per last successful POST.
- Added POST /control/action: For invoking a list of actions (mix of granular and composite actions)
- Added GET /control/status: For checking statuses of previously invoked actions

Motivation ?
- We should be agnostic of underlying transport and be more model driven
- Why can't we represent statuses of all possible controls just as a stat ? e.g. when traffic run is in progress, users know they need check port or flow stats to see the progress. Likewise, when control operation (or action) is in progress, users should check control stats (or status) to see the progress.

Example:
```python
from athena import *


config_api = ConfigApi()
control_api = ControlApi()
cfg = Config(name='test', ports=[Port(name='p1')], flows=[Flow(name='f1')])

# push configuration
errs = config_api.set_config(cfg)
# check for validation errors
assert len(errs.errors) == 0

# start traffic run
errs = control_api.set_control_action(ControlAction(actions=['start']))
# check for validation errors
assert len(errs.errors) == 0

# wait for traffic run to be started
while True:
    status = control_api.get_control_status()
    if status.start == 'done':
        break
    if status.start == 'failed':
        print("Traffic run failed: %s" % status.errors[-1].message)
        break
```

What's pending ?
- Currently, to implement tri-state (none, failed, done), each ControlStatus attribute has its own ENUM definition. I'd like to define ENUM separately and reuse it.
- Any suggestions for naming convention to be used for granular control actions ?
- We might want to incorporate some delay between each consecutive actions. How to deal with that ?