### PR TITLE
Multi speed gbe proposal

### DIFF
--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -15,7 +15,7 @@ components:
         name: '../common/common.yaml#/components/x-inline/UniqueName'
         port_names:
           description: >- 
-            A list of unique names of a port objects that will share the 
+            A list of unique names of port objects that will share the
             choice settings. 
           type: array
           items:
@@ -24,19 +24,42 @@ components:
             - '/components/schemas/Port/properties/name'
         choice:
           description: >-
-            The type of layer1 characteristics.
+            A choice of layer1 speed and setting containers.
           type: string
-          enum: [one_hundred_gbe, ethernet, ethernet_virtual]
-        one_hundred_gbe:
-          $ref: '#/components/schemas/Layer1.OneHundredGbe'
+          enum: [ethernet, ethernet_virtual, ten_gbe, forty_gbe, one_hundred_gbe]
         ethernet:
           $ref: '#/components/schemas/Layer1.Ethernet'
         ethernet_virtual:
           $ref: '#/components/schemas/Layer1.EthernetVirtual'
+        ten_gbe:
+          description: >-
+            802.3ae-2002 standard settings at a speed of 10gbps
+          $ref: '#/components/schemas/Layer1.TenGbe'
+        forty_gbe:
+          description: >-
+            802.3ba-2010 standard settings at a speed of 40gbps 
+          $ref: '#/components/schemas/Layer1.FortyGbe'
+        one_hundred_gbe:
+          description: >-
+            802.3ba-2010 standard settings at a speed of 100gbps
+          $ref: '#/components/schemas/Layer1.OneHundredGbe'
 
-    Layer1.OneHundredGbe:
+    Layer1.TenGbe:
       description: >-
-        Container for 100 gigabit ethernet settings
+        Container for ten gbe settings
+      type: object
+      properties:
+        auto_negotiate:
+          description: >-
+            Enable/disable auto negotiation.
+          type: boolean
+          default: false
+        flow_control:
+          $ref: '#/components/schemas/Layer1.FlowControl'
+
+    Layer1.FortyGbe:
+      description: >-
+        Container for forty gbe settings
       type: object
       properties:
         ieee_media_defaults:
@@ -60,12 +83,35 @@ components:
             Enable/disable reed solomon forward error correction (RS FEC).
           type: boolean
           default: false
-        speed:
+        flow_control:
+          $ref: '#/components/schemas/Layer1.FlowControl'
+
+    Layer1.OneHundredGbe:
+      description: >-
+        Container for one hundred gbe settings
+      type: object
+      properties:
+        ieee_media_defaults:
           description: >-
-            This is the speed that will be used if auto_negotiate is false.
-          type: string
-          enum: [one_hundred_gbps, fifty_gbps, forty_gbps, twenty_five_gpbs, ten_gbps]
-          default: one_hundred_gbps
+            Enable/disable ieee media default settings.
+            True will override the speed, auto_negotiate, link_training, rs_fec settings.
+          type: boolean
+          default: true
+        auto_negotiate:
+          description: >-
+            Enable/disable auto negotiation.
+          type: boolean
+          default: false
+        link_training:
+          description: >-
+            Enable/disable link training.
+          type: boolean
+          default: false
+        rs_fec:
+          description: >-
+            Enable/disable reed solomon forward error correction (RS FEC).
+          type: boolean
+          default: false
         flow_control:
           $ref: '#/components/schemas/Layer1.FlowControl'
     

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -49,6 +49,10 @@ components:
         Container for ten gbe settings
       type: object
       properties:
+        media:
+          type: string
+          enum: [copper, fiber]
+          default: copper
         auto_negotiate:
           description: >-
             Enable/disable auto negotiation.

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -52,7 +52,7 @@ components:
         media:
           type: string
           enum: [copper, fiber]
-          default: copper
+          default: fiber
         auto_negotiate:
           description: >-
             Enable/disable auto negotiation.


### PR DESCRIPTION
It has been raised during the sonic code review that the one_hundred_gbe with speed property is confusing.
To reduce confusion (speed and unused properties depending on speed) this PR splits creates individual objects for 10/40/100 gbe.
This allows for adding 200/400 gbe etc.