### PR TITLE
Layer1 settings with speed as enum

### DIFF
--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -10,33 +10,88 @@ components:
       description: >-
         A container for layer1 settings.
       type: object
-      required: [name, choice]
+      required: [name, port_names]
       properties:
         name: '../common/common.yaml#/components/x-inline/UniqueName'
         port_names:
           description: >- 
-            A list of unique names of a port objects that will share the 
+            A list of unique names of port objects that will share the
             choice settings. 
           type: array
           items:
             type: string
             x-constraint:
             - '/components/schemas/Port/properties/name'
-        choice:
+        speed:
           description: >-
-            The type of layer1 characteristics.
+            The speed of the port.
+            If the speed is not supported an error will be returned.
           type: string
-          enum: [one_hundred_gbe, ethernet, ethernet_virtual]
-        one_hundred_gbe:
-          $ref: '#/components/schemas/Layer1.OneHundredGbe'
+          enum:
+            - speed_10_mbps
+            - speed_100_mbps
+            - speed_1000_mbps
+            - speed_1_gbps
+            - speed_10_gbps
+            - speed_25_gbps
+            - speed_40_gbps
+            - speed_100_gbps
+            - speed_200_gbps
+            - speed_400_gbps
+          default: speed_10_gbps
+        media:
+          type: string
+          enum:
+          - copper
+          - fiber
+          - sgmii
+          default: copper
+        auto_negotiate:
+          type: boolean
+          default: true
         ethernet:
           $ref: '#/components/schemas/Layer1.Ethernet'
-        ethernet_virtual:
-          $ref: '#/components/schemas/Layer1.EthernetVirtual'
+        gigabit_ethernet:
+          $ref: '#/components/schemas/Layer1.GigabitEthernet'
+        virtual_ethernet:
+          $ref: '#/components/schemas/Layer1.VirtualEthernet'
+        flow_control:
+          $ref: '#/components/schemas/Layer1.FlowControl'
 
-    Layer1.OneHundredGbe:
+    Layer1.Ethernet:
       description: >-
-        Container for 100 gigabit ethernet settings
+        Container for 10/100/1000 ethernet settings
+      type: object
+      properties:
+        advertise_1000_mbps:
+          description: >-
+            If auto_negotiate is true then this speed will be advertised.
+          type: boolean
+          default: true
+        advertise_100_fd_mbps:
+          description: >-
+            If auto_negotiate is true then this speed will be advertised.
+          type: boolean
+          default: true
+        advertise_100_hd_mbps:
+          description: >-
+            If auto_negotiate is true then this speed will be advertised.
+          type: boolean
+          default: true
+        advertise_10_fd_mbps:
+          description: >-
+            If auto_negotiate is true then this speed will be advertised.
+          type: boolean
+          default: true
+        advertise_10_hd_mbps:
+          description: >-
+            If auto_negotiate is true then this speed will be advertised.
+          type: boolean
+          default: true
+
+    Layer1.GigabitEthernet:
+      description: >-
+        Container for gigabit ethernet settings
       type: object
       properties:
         ieee_media_defaults:
@@ -45,11 +100,6 @@ components:
             True will override the speed, auto_negotiate, link_training, rs_fec settings.
           type: boolean
           default: true
-        auto_negotiate:
-          description: >-
-            Enable/disable auto negotiation.
-          type: boolean
-          default: false
         link_training:
           description: >-
             Enable/disable link training.
@@ -60,74 +110,15 @@ components:
             Enable/disable reed solomon forward error correction (RS FEC).
           type: boolean
           default: false
-        speed:
-          description: >-
-            This is the speed that will be used if auto_negotiate is false.
-          type: string
-          enum: [one_hundred_gbps, fifty_gbps, forty_gbps, twenty_five_gpbs, ten_gbps]
-          default: one_hundred_gbps
-        flow_control:
-          $ref: '#/components/schemas/Layer1.FlowControl'
-    
-    Layer1.EthernetVirtual:
+
+    Layer1.VirtualEthernet:
       description: >-
         Container for virtual ethernet settings
       type: object
       properties:
-        speed:
-          description: >-
-            This is the speed that will be set on the virtual ethernet interface.
-          type: string
-          enum: [one_hundred_mbps, one_gbps, ten_gbps, twenty_five_gbps, fifty_gbps, one_hundred_gbps]
-          default: ten_gbps
-
-    Layer1.Ethernet:
-      description: >-
-        Container for 10/100/1000 ethernet settings
-      type: object
-      properties:
-        media:
-          type: string
-          enum: [copper, fiber]
-          default: copper
-        speed:
-          description: >-
-            This is the speed that will be used if auto_negotiate is false.
-          type: string
-          enum: [one_thousand_mbps, one_hundred_fd_mbps, one_hundred_hd_mbps, ten_fd_mbps, ten_hd_mbps]
-          default: one_thousand_mbps
-        auto_negotiate:
-          description: >-
-            Enable/disable auto negotiation.
+        promiscuous:
           type: boolean
-          default: true
-        advertise_one_thousand_mbps:
-          description: >-
-            If auto_negotiate is true then this speed will be advertised.
-          type: boolean
-          default: true
-        advertise_one_hundred_fd_mbps:
-          description: >-
-            If auto_negotiate is true then this speed will be advertised.
-          type: boolean
-          default: true
-        advertise_one_hundred_hd_mbps:
-          description: >-
-            If auto_negotiate is true then this speed will be advertised.
-          type: boolean
-          default: true
-        advertise_ten_fd_mbps:
-          description: >-
-            If auto_negotiate is true then this speed will be advertised.
-          type: boolean
-          default: true
-        advertise_ten_hd_mbps:
-          description: >-
-            If auto_negotiate is true then this speed will be advertised.
-          type: boolean
-          default: true
-        flow_control:
-          $ref: '#/components/schemas/Layer1.FlowControl'
+          default: false
 
     Layer1.FlowControl:
       description: >-

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -125,6 +125,9 @@ components:
         promiscuous:
           type: boolean
           default: false
+        mtu:
+          type: integer
+          default: 1500
 
     Layer1.FlowControl:
       description: >-

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -10,7 +10,7 @@ components:
       description: >-
         A container for layer1 settings.
       type: object
-      required: [name, port_names, choice]
+      required: [name, port_names]
       properties:
         name: '../common/common.yaml#/components/x-inline/UniqueName'
         port_names:
@@ -24,8 +24,7 @@ components:
             - '/components/schemas/Port/properties/name'
         speed:
           description: >-
-            The speed of the port.
-            If the speed is not supported an error will be returned.
+            Set the speed if supported.
           type: string
           enum:
             - speed_10_mbps
@@ -39,94 +38,84 @@ components:
             - speed_400_gbps
           default: speed_10_gbps
         media:
+          description: >-
+            Set the type of media interface if supported.
           type: string
           enum:
             - copper
             - fiber
             - sgmii
-          default: copper
-        auto_negotiate:
+        promiscuous:
+          description: >-
+            Enable promiscuous mode if supported.
+          type: boolean
+          default: false
+        mtu:
+          description: >-
+            Set the maximum transmission unit size if supported.
+          type: integer
+          default: 1500
+        ieee_media_defaults:
+          description: >-
+            Set to true to override the auto_negotiate, link_training
+            and rs_fec settings for gigabit ethernet interfaces.
           type: boolean
           default: true
-        choice:
-          type: string
-          enum:
-            - ethernet
-            - gigabit_ethernet
-            - virtual_ethernet
-        ethernet:
-          $ref: '#/components/schemas/Layer1.Ethernet'
-        gigabit_ethernet:
-          $ref: '#/components/schemas/Layer1.GigabitEthernet'
-        virtual_ethernet:
-          $ref: '#/components/schemas/Layer1.VirtualEthernet'
+        auto_negotiate:
+          description: >-
+            Enable/disable auto negotiation.
+          type: boolean
+          default: true
+        auto_negotiation:
+          $ref: '#/components/schemas/Layer1.AutoNegotiation'
         flow_control:
           $ref: '#/components/schemas/Layer1.FlowControl'
 
-    Layer1.Ethernet:
+    Layer1.AutoNegotiation:
       description: >-
-        Container for 10/100/1000 ethernet settings
+        Container for auto negotiation settings
       type: object
       properties:
         advertise_1000_mbps:
           description: >-
-            If auto_negotiate is true then this speed will be advertised.
+            If auto_negotiate is true and the interface supports this option
+            then this speed will be advertised.
           type: boolean
           default: true
         advertise_100_fd_mbps:
           description: >-
-            If auto_negotiate is true then this speed will be advertised.
+            If auto_negotiate is true and the interface supports this option
+            then this speed will be advertised.
           type: boolean
           default: true
         advertise_100_hd_mbps:
           description: >-
-            If auto_negotiate is true then this speed will be advertised.
+            If auto_negotiate is true and the interface supports this option
+            then this speed will be advertised.
           type: boolean
           default: true
         advertise_10_fd_mbps:
           description: >-
-            If auto_negotiate is true then this speed will be advertised.
+            If auto_negotiate is true and the interface supports this option
+            then this speed will be advertised.
           type: boolean
           default: true
         advertise_10_hd_mbps:
           description: >-
-            If auto_negotiate is true then this speed will be advertised.
-          type: boolean
-          default: true
-
-    Layer1.GigabitEthernet:
-      description: >-
-        Container for gigabit ethernet settings
-      type: object
-      properties:
-        ieee_media_defaults:
-          description: >-
-            Enable/disable ieee media default settings.
-            True will override the speed, auto_negotiate, link_training, rs_fec settings.
+            If auto_negotiate is true and the interface supports this option
+            then this speed will be advertised.
           type: boolean
           default: true
         link_training:
           description: >-
-            Enable/disable link training.
+            Enable/disable gigabit ethernet link training.
           type: boolean
           default: false
         rs_fec:
           description: >-
-            Enable/disable reed solomon forward error correction (RS FEC).
+            Enable/disable gigabit ethernet reed solomon forward error correction (RS FEC).
           type: boolean
           default: false
-
-    Layer1.VirtualEthernet:
-      description: >-
-        Container for virtual ethernet settings
-      type: object
-      properties:
-        promiscuous:
-          type: boolean
-          default: false
-        mtu:
-          type: integer
-          default: 1500
 
     Layer1.FlowControl:
       description: >-

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -10,7 +10,7 @@ components:
       description: >-
         A container for layer1 settings.
       type: object
-      required: [name, port_names]
+      required: [name, port_names, choice]
       properties:
         name: '../common/common.yaml#/components/x-inline/UniqueName'
         port_names:
@@ -42,13 +42,19 @@ components:
         media:
           type: string
           enum:
-          - copper
-          - fiber
-          - sgmii
+            - copper
+            - fiber
+            - sgmii
           default: copper
         auto_negotiate:
           type: boolean
           default: true
+        choice:
+          type: string
+          enum:
+            - ethernet
+            - gigabit_ethernet
+            - virtual_ethernet
         ethernet:
           $ref: '#/components/schemas/Layer1.Ethernet'
         gigabit_ethernet:

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -30,7 +30,6 @@ components:
           enum:
             - speed_10_mbps
             - speed_100_mbps
-            - speed_1000_mbps
             - speed_1_gbps
             - speed_10_gbps
             - speed_25_gbps


### PR DESCRIPTION
This is an alternate model approach proposed by @ashutshkumr to the multi-speed-gbe-proposal.
The intent is to have speed as an enum at the top level of layer1 with specific containers for ethernet, gigabit_ethernet and virtual_ethernet settings, and flow control.

