### PR TITLE
Added a few missing fields to TCP flow header

### DIFF
--- a/flow/packet-headers/tcp.yaml
+++ b/flow/packet-headers/tcp.yaml
@@ -20,12 +20,12 @@ components:
             Tcp destination port. 
             Max length is 2 bytes.
           $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
-        sequence_number:
+        seq_num:
           description: >-
             Tcp Sequence Number.
             Max length is 4 bytes.
           $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
-        acknowledgement_number:
+        ack_num:
           description: >-
             Tcp Acknowledgement Number.
             Max length is 4 bytes.

--- a/flow/packet-headers/tcp.yaml
+++ b/flow/packet-headers/tcp.yaml
@@ -20,6 +20,21 @@ components:
             Tcp destination port. 
             Max length is 2 bytes.
           $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
+        sequence_number:
+          description: >-
+            Tcp Sequence Number.
+            Max length is 4 bytes.
+          $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
+        acknowledgement_number:
+          description: >-
+            Tcp Acknowledgement Number.
+            Max length is 4 bytes.
+          $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
+        data_offset:
+          description: >-
+            The number of 32 bit words in the TCP header.  This indicates where the data begins.
+            Max length is 4 bits.
+          $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
         ecn_ns:
           description: >-
             Explicit congestion notification, concealment protection.
@@ -40,12 +55,12 @@ components:
           $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
         ctl_urg:
           description: >-
-            The urgent pointer field is significant. 
+            A value of 1 indicates that the urgent pointer field is significant.
             Max length is 1 bit.
           $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
         ctl_ack:
           description: >-
-            The ackknowledgment field is significant. 
+            A value of 1 indicates that the ackknowledgment field is significant.
             Max length is 1 bit.
           $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
         ctl_psh:
@@ -67,5 +82,10 @@ components:
           description: >-
             Last packet from the sender. 
             Max length is 1 bit.
+          $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
+        window:
+          description: >-
+            Tcp connection window.
+            Max length is 2 bytes.
           $ref: './patterns.yaml#/components/schemas/Flow.Pattern'
 


### PR DESCRIPTION
 Added sequence number, acknowledgement number, data_offset, and window parameters to the TCP flow definition.  Closes #35.