### PR TITLE
add custom and packet captures

### DIFF
--- a/capture/capture.yaml
+++ b/capture/capture.yaml
@@ -12,7 +12,7 @@ components:
       description: >-
         Container for capture settings.
       type: object
-      required: [name, choice]
+      required: [name]
       properties:
         port_names:
           description: >-
@@ -22,24 +22,22 @@ components:
             type: string
             x-constraint:
             - '/components/schemas/Port/properties/name'
-        choice: 
+        custom_filters:
           description: >-
-            The type of filter.
-          type: string
-          enum: [basic, pcap]
-        basic:
-          description: >-
-            An array of basic filters.
-            The filters supported are source address, destination address and
-            custom.  
+            A list of custom filters
           type: array
           items:
-            $ref: '#/components/schemas/Capture.BasicFilter'
-        pcap:
+            $ref: '#/components/schemas/Capture.Custom'
+        packet_filter:
           description: >-
-            The content of this property must be of pcap filter syntax.
-            https://www.tcpdump.org/manpages/pcap-filter.7.html
-          type: string
+            A list of packet filters to apply to the capturing ports.
+            If no packet filters are specified then all packets will be captured.
+            A capture can have multiple filters. The number of filters supported
+            is determined by the implementation which can be retrieved using
+            the capabilities API.
+          type: array
+          items:
+            $ref: '#/components/schemas/Capture.Filter'
         enable:
           description: >-
             Enable capture on the port.
@@ -57,64 +55,72 @@ components:
           enum: [pcap, pcapng]
           default: pcap
 
-    Capture.BasicFilter:
+    Capture.Filter:
       description: >-
-        A container for different types of basic capture filters.
+        Container for capture filters
       type: object
       required: [choice]
       properties:
         choice:
           type: string
-          enum: [mac_address, custom]
-        mac_address:
-          $ref: '#/components/schemas/Capture.MacAddressFilter'
-        custom:
-          $ref: '#/components/schemas/Capture.CustomFilter'
-        and_operator:
-          type: boolean
-          default: true
-        not_operator:
-          type: boolean
-          default: false
+          enum: [ethernet, vlan, ipv4]
+        ethernet:
+          $ref: '#/components/schemas/Capture.Ethernet'
+        vlan:
+          $ref: '#/components/schemas/Capture.Vlan'
+        ipv4:
+          $ref: '#/components/schemas/Capture.Ipv4'
 
-    Capture.MacAddressFilter:
-      description: >-
-        A container for a mac address capture filter.
+    Capture.Custom:
       type: object
-      required: [mac, filter]
       properties:
-        mac:
-          description: >-
-            The type of mac address filters.
-            This can be either source or destination.
-          type: string
-          enum: [source, destination]
-        filter:
-          description: >-
-            The value of the mac address.
-          type: string
-        mask:
-          description: >-
-            The value of the mask to be applied to the mac address.
-          type: string
-
-    Capture.CustomFilter:
-      description: >-
-        A container for a custom capture filter.
-      type: object
-      required: [filter, offset]
-      properties:
-        filter:
-          description: >-
-            The value to filter on.
-          type: string
-        mask:
-          description: >-
-            The mask to be applied to the filter.
-          type: string
         offset:
           description: >-
-            The offset in the packet to filter at.
+            The byte offset to filter on
           type: integer
+        value:
+          type: string
+          format: hex
+        mask:
+          type: string
+          format: hex
+    
+    Capture.Field:
+      type: object
+      properties:
+        value:
+          type: string
+          format: hex
+        mask:
+          type: string
+          format: hex
 
- 
+    Capture.Ethernet:
+      type: object
+      properties:
+        src:
+          $ref: '#/components/schemas/Capture.Field'
+        dst:
+          $ref: '#/components/schemas/Capture.Field'
+        ether_type:
+          $ref: '#/components/schemas/Capture.Field'
+        pfc_queue:
+          $ref: '#/components/schemas/Capture.Field'
+
+    Capture.Vlan:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/Capture.Field'
+        priority:
+          $ref: '#/components/schemas/Capture.Field'
+
+    Capture.Ipv4:
+      type: object
+      properties:
+        src:
+          $ref: '#/components/schemas/Capture.Field'
+        dst:
+          $ref: '#/components/schemas/Capture.Field'
+        priority:
+          $ref: '#/components/schemas/Capture.Field'

--- a/capture/capture.yaml
+++ b/capture/capture.yaml
@@ -17,6 +17,7 @@ components:
         port_names:
           description: >-
             The unique names of ports that the capture settings will apply to.
+            Port_names cannot be duplicated between capture objects.
           type: array
           items:
             type: string
@@ -40,6 +41,12 @@ components:
             Overwrite the capture buffer.
           type: boolean
           default: false
+        packet_size:
+          description: >-
+            The maximum size of each captured packet.
+            If no value is specified or it is null then the entire packet will
+            be captured.
+          type: integer
         format:
           description: >-
             The format of the capture file.

--- a/capture/capture.yaml
+++ b/capture/capture.yaml
@@ -29,6 +29,9 @@ components:
             A capture can have multiple filters. The number of filters supported
             is determined by the implementation which can be retrieved using
             the capabilities API.
+
+            When multiple filters are specified the capture implementation 
+            must && (and) all the filters.
           type: array
           items:
             $ref: '#/components/schemas/Capture.Filter'

--- a/capture/capture.yaml
+++ b/capture/capture.yaml
@@ -22,27 +22,16 @@ components:
             type: string
             x-constraint:
             - '/components/schemas/Port/properties/name'
-        custom_filters:
+        filters:
           description: >-
-            A list of custom filters
-          type: array
-          items:
-            $ref: '#/components/schemas/Capture.Custom'
-        packet_filter:
-          description: >-
-            A list of packet filters to apply to the capturing ports.
-            If no packet filters are specified then all packets will be captured.
+            A list of filters to apply to the capturing ports.
+            If no filters are specified then all packets will be captured.
             A capture can have multiple filters. The number of filters supported
             is determined by the implementation which can be retrieved using
             the capabilities API.
           type: array
           items:
             $ref: '#/components/schemas/Capture.Filter'
-        enable:
-          description: >-
-            Enable capture on the port.
-          type: boolean
-          default: True
         overwrite:
           description: >-
             Overwrite the capture buffer.
@@ -63,7 +52,14 @@ components:
       properties:
         choice:
           type: string
-          enum: [ethernet, vlan, ipv4]
+          enum: [custom, ethernet, vlan, ipv4]
+        custom:
+          description: >-
+            Offset from last filter in the list.
+            If no filters are present it is offset from position 0.
+            Multiple custom filters can be present, the length of each custom
+            filter is the length of the value being filtered.
+          $ref: '#/components/schemas/Capture.Custom'
         ethernet:
           $ref: '#/components/schemas/Capture.Ethernet'
         vlan:
@@ -72,18 +68,12 @@ components:
           $ref: '#/components/schemas/Capture.Ipv4'
 
     Capture.Custom:
-      type: object
+      x-include: '#/components/schemas/Capture.Field'
       properties:
         offset:
           description: >-
             The byte offset to filter on
           type: integer
-        value:
-          type: string
-          format: hex
-        mask:
-          type: string
-          format: hex
     
     Capture.Field:
       type: object
@@ -94,6 +84,9 @@ components:
         mask:
           type: string
           format: hex
+        negate:
+          type: boolean
+          default: false
 
     Capture.Ethernet:
       type: object
@@ -110,17 +103,43 @@ components:
     Capture.Vlan:
       type: object
       properties:
+        priority:
+          $ref: '#/components/schemas/Capture.Field'
+        cfi:
+          $ref: '#/components/schemas/Capture.Field'
         id:
           $ref: '#/components/schemas/Capture.Field'
-        priority:
+        protocol:
           $ref: '#/components/schemas/Capture.Field'
 
     Capture.Ipv4:
       type: object
       properties:
+        version:
+          $ref: '#/components/schemas/Capture.Field'
+        headeer_length:
+          $ref: '#/components/schemas/Capture.Field'
+        priority:
+          $ref: '#/components/schemas/Capture.Field'
+        total_length:
+          $ref: '#/components/schemas/Capture.Field'
+        identification:
+          $ref: '#/components/schemas/Capture.Field'
+        reserved:
+          $ref: '#/components/schemas/Capture.Field'
+        dont_fragment:
+          $ref: '#/components/schemas/Capture.Field'
+        more_fragments:
+          $ref: '#/components/schemas/Capture.Field'
+        fragment_offset:
+          $ref: '#/components/schemas/Capture.Field'
+        time_to_live:
+          $ref: '#/components/schemas/Capture.Field'
+        protocol:
+          $ref: '#/components/schemas/Capture.Field'
+        header_checksum:
+          $ref: '#/components/schemas/Capture.Field'
         src:
           $ref: '#/components/schemas/Capture.Field'
         dst:
-          $ref: '#/components/schemas/Capture.Field'
-        priority:
           $ref: '#/components/schemas/Capture.Field'


### PR DESCRIPTION
Refactor for a more agnostic capture specification.
The following is what it would be like to specify a capture configuration using the current proposal.

```python
def test_capture(api):
    """Test capture functionality

    Capture should allow for multiple filters.
    The capture.filters is a list of CaptureFilter objects which can be 
    CaptureCustom, CaptureEthernet, CaptureVlan and CaptureIpv4.
    A CaptureCustom object is used when packet header is not available.
    """
    config = api.config()

    # create a capture
    config.ports.port(name='port1').port(name='port2')
    capture = config.captures.capture()[0]
    capture.name = 'capture1'
    capture.port_names = [port.name for port in config.ports]

    # add 2 custom filters
    capture.filters.custom().custom()
    src_mac = capture.filters[0]  # type: snappi.CustomFilter
    src_mac.offset = 0
    src_mac.value = '000100000001'
    src_mac.mask = 'FFFFFFFFFFFF'
    dst_mac = capture.filters[1]  # type: snappi.CustomFilter
    dst_mac.offset = 0
    dst_mac.value = '000200000001'
    dst_mac.mask = 'FFFFFFFFFFFF'
    print(config)

    # add packet filters for inner and outer vlan
    capture.filters.clear()
    _, i_vlan, o_vlan = capture.filters.ethernet().vlan().vlan()
    i_vlan.id.value = '01'
    i_vlan.id.mask = 'FF'
    o_vlan.id.value = '03'
    o_vlan.id.mask = 'FF'
    print(config)

    # add packet filters for a custom packet after eth, ip
    capture.filters.clear()
    eth, _, custom = capture.filters.ethernet().ipv4().custom()
    eth.src.value = '000001000001'
    eth.src.mask = 'FFFFFFFFFFFF'
    custom.offset = 16
    custom.value = '010101'
    custom.mask = 'FFFFFF'
    print(config)
```