### PR TITLE
Allow requesting traffic generator metrics using same API endpoint (`api.get_metrics()`)

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -125,6 +125,29 @@ paths:
         '590':
           $ref: '../result/request.yaml#/components/responses/Fail'
 
+  /results/metrics:
+    description: >-
+      Traffic metrics API
+    post:
+      tags: [Results]
+      operationId: get_metrics
+      requestBody:
+        description: >-
+          Request to traffic generator for metrics of choice
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../result/metrics.yaml#/components/schemas/Metrics.Request'
+      responses:
+        '200':
+          description: >-
+            Response from traffic generator for chosen metrics
+          content:
+            application/json:
+              schema:
+                $ref: '../result/metrics.yaml#/components/schemas/Metrics.Response'
+
   /results/state:
     post:
       tags: [Results]
@@ -152,29 +175,6 @@ paths:
               schema:
                 $ref: '../result/capability.yaml#/components/schemas/Capabilities'
 
-  /results/port:
-    description: >-
-      Port results API
-    post:
-      tags: [Results]
-      operationId: get_port_metrics
-      requestBody:
-        description: >-
-          Port results request to the traffic generator.
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '../result/port.yaml#/components/schemas/Port.Metrics.Request'
-      responses:
-        '200':
-          description: >-
-            Port results response from the traffic generator
-          content:
-            application/json:
-              schema:
-                $ref: '../result/port.yaml#/components/schemas/Port.Metrics'
-
   /results/capture:
     description: >-
       Capture results API
@@ -198,49 +198,3 @@ paths:
               schema:
                 type: string
                 format: binary
-
-  /results/flow:
-    description: >-
-      Flow results API
-    post:
-      tags: [Results]
-      operationId: get_flow_metrics
-      requestBody:
-        description: >-
-          Flow results request to the traffic generator.
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '../result/flow.yaml#/components/schemas/Flow.Metrics.Request'
-      responses:
-        '200':
-          description: >-
-            Flow results response from the traffic generator
-          content:
-            application/json:
-              schema:
-                $ref: '../result/flow.yaml#/components/schemas/Flow.Metrics'
-
-  /results/bgpv4:
-    description: >-
-      BGP results API
-    post:
-      tags: [Results]
-      operationId: get_bgpv4_metrics
-      requestBody:
-        description: >-
-          The request to retrieve BGP Router statistics and learned routing information.
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '../result/bgpv4.yaml#/components/schemas/Bgpv4.Metrics.Request'
-      responses:
-        '200':
-          description: >-
-            BGP Router statistics and learned routing information
-          content:
-            application/json:
-              schema:
-                $ref: '../result/bgpv4.yaml#/components/schemas/Bgpv4.Metrics'

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -1,0 +1,42 @@
+openapi: 3.1.0
+
+info:
+  title: Metrics models
+  version: ^0.0.0
+
+components:
+  schemas:
+    Metrics.Request:
+      description: >-
+        Request to traffic generator for metrics of choice
+      type: object
+      required: [choice]
+      properties:
+        choice:
+          type: string
+          enum:
+            - port_metrics_request
+            - flow_metrics_request
+            - bgpv4_metrics_request
+        port_metrics_request:
+          $ref: './port.yaml#/components/schemas/Port.Metrics.Request'
+        flow_metrics_request:
+          $ref: './flow.yaml#/components/schemas/Flow.Metrics.Request'
+        bgpv4_metrics_request:
+          $ref: './bgpv4.yaml#/components/schemas/Bgpv4.Metrics.Request'
+
+    Metrics.Response:
+      description: >-
+        Response containing chosen traffic generator metrics
+      type: object
+      required: [choice]
+      properties:
+        choice:
+          type: string
+          enum: [port_metrics, flow_metrics, bgpv4_metrics]
+        port_metrics:
+          $ref: './port.yaml#/components/schemas/Port.Metrics'
+        flow_metrics:
+          $ref: './flow.yaml#/components/schemas/Flow.Metrics'
+        bgpv4_metrics:
+          $ref: './bgpv4.yaml#/components/schemas/Bgpv4.Metrics'

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -14,15 +14,12 @@ components:
       properties:
         choice:
           type: string
-          enum:
-            - port_metrics_request
-            - flow_metrics_request
-            - bgpv4_metrics_request
-        port_metrics_request:
+          enum: [port, flow, bgpv4]
+        port:
           $ref: './port.yaml#/components/schemas/Port.Metrics.Request'
-        flow_metrics_request:
+        flow:
           $ref: './flow.yaml#/components/schemas/Flow.Metrics.Request'
-        bgpv4_metrics_request:
+        bgpv4:
           $ref: './bgpv4.yaml#/components/schemas/Bgpv4.Metrics.Request'
 
     Metrics.Response:


### PR DESCRIPTION
This is how it would look after the changes are incorporated:

```python
import snappi

api = snappi.api()

# flow metrics request with no filters
req = api.metrics_request()
req.choice = req.FLOW

# flow metrics request with filters
req = api.metrics_request()
req.flow.flow_names = ['f1', 'f2']
req.flow.column_names = ['frames_tx', 'transmit']

# check from response if flow transmit is stopped
res = api.get_metrics(req)
transmit_stopped = all([m.transmit == m.STOPPED for m in res.flow_metrics])

# port metrics request with filters
req = api.metrics_request()
req.port.port_names = ['p1']

# calculate total tx on given ports from response
res = api.get_metrics(req)
total_tx = sum([m.frames_tx for m in res.port_metrics])
```

This is how it looks right now:

```python
import snappi

api = snappi.api()

# flow metrics request with no filters
req = api.flow_metrics_request()

# flow metrics request with filters
req = api.flow_metrics_request()
req.flow_names = ['f1', 'f2']
req.column_names = ['frames_tx', 'transmit']

# check from response if flow transmit is stopped
flow_metrics = api.get_flow_metrics(req)
transmit_stopped = all([m.transmit == m.STOPPED for m in flow_metrics])

# port metrics request with filters
req = api.port_metrics_request()
req.port_names = ['p1']

# calculate total tx on given ports from response
port_metrics = api.get_port_metrics(req)
total_tx = sum([m.frames_tx for m in port_metrics])
```