### PR TITLE
Add burst_count in burst in duration

### DIFF
--- a/flow/duration.yaml
+++ b/flow/duration.yaml
@@ -101,13 +101,15 @@ components:
 
     Flow.Burst:
       description: >-
-        A continuous burst of packets that will not automatically stop.
+        Transmits continuous or fixed burst of packets. 
+        For continuous burst of packets, it will not automatically stop.
+        For fixed burst of packets, it will stop after transmitting fixed number of bursts.      
       type: object      
       properties:
-        burst_count:
+        bursts:
           description: >-
-            The number of burst transmitted per stream.
-            A value 0 means it is continuous burst.
+            The number of packet bursts transmitted per flow.
+            A value of 0 implies continuous burst of packets.
           type: integer
           default: 0
         packets:

--- a/flow/duration.yaml
+++ b/flow/duration.yaml
@@ -104,6 +104,12 @@ components:
         A continuous burst of packets that will not automatically stop.
       type: object      
       properties:
+        burst_count:
+          description: >-
+            The number of burst transmitted per stream.
+            A value 0 means it is continuous burst.
+          type: integer
+          default: 0
         packets:
           description: >-
             The number of packets transmitted per burst.


### PR DESCRIPTION
burst_count provides number of burst per stream. Default is 0 which means continuous burst.