### PR TITLE
add doc url to release body

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -83,6 +83,7 @@ jobs:
               repo,
               tag_name: tag,
               name: `Release ${tag}`,
+              body: `View openapi.yaml spec at https://redocly.github.io/redoc/?url=https://github.com/open-traffic-generator/models/releases/download/${tag}/openapi.yaml`,
               draft: false,
               prerelease: false,
               target_commitish: sha


### PR DESCRIPTION
What: release body content will have a url to redocly so that users can view the spec