### PR TITLE
plugins sample

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2929,7 +2929,7 @@ components:
         port:
           $ref: '#/components/schemas/Port.Metrics.Request'
         flow:
-          $ref: '#/components/schemas/Flow.Metrics.Request'
+          $ref: '#/components/schemas/Plugin.Flow.Metrics.Request'
         bgpv4:
           $ref: '#/components/schemas/Bgpv4.Metrics.Request'
         bgpv6:
@@ -2954,7 +2954,7 @@ components:
         flow_metrics:
           type: array
           items:
-            $ref: '#/components/schemas/Flow.Metric'
+            $ref: '#/components/schemas/Plugin.Flow.Metric'
         bgpv4_metrics:
           type: array
           items:
@@ -3052,7 +3052,7 @@ components:
           description: |-
             The current rate of bytes received
           type: number
-    Flow.Metrics.Request:
+    Plugin.Flow.Metrics.Request:
       description: |-
         The request to the traffic generator for flow results.
       type: object
@@ -3093,7 +3093,7 @@ components:
             type: string
             x-constraint:
             - /components/schemas/Flow.Pattern/properties/metric_group
-    Flow.MetricGroup:
+    Plugin.Flow.MetricGroup:
       description: |-
         A metric group
       type: object
@@ -3109,7 +3109,7 @@ components:
           description: |-
             The value of the flow packet header field
           type: number
-    Flow.Metric:
+    Plugin.Flow.Metric:
       type: object
       properties:
         name:
@@ -3181,7 +3181,7 @@ components:
             Any configured flow packet header field metric_group names will  appear as additional name/value pairs.
           type: array
           items:
-            $ref: '#/components/schemas/Flow.MetricGroup'
+            $ref: '#/components/schemas/Plugin.Flow.MetricGroup'
           x-constraint:
           - /components/schemas/Flow.Pattern/properties/result_group
     Bgpv4.Metrics.Request:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1578,7 +1578,7 @@ message MetricsRequest {
 
   PortMetricsRequest port = 2;
 
-  FlowMetricsRequest flow = 3;
+  PluginFlowMetricsRequest flow = 3;
 
   Bgpv4MetricsRequest bgpv4 = 4;
 
@@ -1600,7 +1600,7 @@ message MetricsResponse {
 
   repeated PortMetric port_metrics = 2;
 
-  repeated FlowMetric flow_metrics = 3;
+  repeated PluginFlowMetric flow_metrics = 3;
 
   repeated Bgpv4Metric bgpv4_metrics = 4;
 
@@ -1685,7 +1685,7 @@ message PortMetric {
   } }
 }
 
-message FlowMetricsRequest {
+message PluginFlowMetricsRequest {
   repeated string flow_names = 1;
 
   repeated Column_names column_names = 2;
@@ -1721,13 +1721,13 @@ message FlowMetricsRequest {
   } }
 }
 
-message FlowMetricGroup {
+message PluginFlowMetricGroup {
   string name = 1;
 
   float value = 2;
 }
 
-message FlowMetric {
+message PluginFlowMetric {
   string name = 1;
 
   Transmit.Enum transmit = 2;
@@ -1756,7 +1756,7 @@ message FlowMetric {
 
   float loss = 14;
 
-  repeated FlowMetricGroup metric_groups = 15;
+  repeated PluginFlowMetricGroup metric_groups = 15;
 
   message Transmit { enum Enum {
     started = 0;

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -6,7 +6,7 @@ info:
 
 components:
   schemas:
-    Flow.Metrics.Request:
+    Plugin.Flow.Metrics.Request:
       description: >-
         The request to the traffic generator for flow results.
       type: object
@@ -53,7 +53,7 @@ components:
             x-constraint:
               - "/components/schemas/Flow.Pattern/properties/metric_group"
     
-    Flow.MetricGroup:
+    Plugin.Flow.MetricGroup:
       description: >-
         A metric group
       type: object
@@ -68,7 +68,7 @@ components:
             The value of the flow packet header field
           type: number
 
-    Flow.Metric:
+    Plugin.Flow.Metric:
       type: object
       properties:
         name:
@@ -138,6 +138,6 @@ components:
             appear as additional name/value pairs.
           type: array
           items:
-            $ref: '#/components/schemas/Flow.MetricGroup'
+            $ref: '#/components/schemas/Plugin.Flow.MetricGroup'
           x-constraint:
             - "/components/schemas/Flow.Pattern/properties/result_group"

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -18,7 +18,7 @@ components:
         port:
           $ref: './port.yaml#/components/schemas/Port.Metrics.Request'
         flow:
-          $ref: './flow.yaml#/components/schemas/Flow.Metrics.Request'
+          $ref: './flow.yaml#/components/schemas/Plugin.Flow.Metrics.Request'
         bgpv4:
           $ref: './bgpv4.yaml#/components/schemas/Bgpv4.Metrics.Request'
         bgpv6:
@@ -40,7 +40,7 @@ components:
         flow_metrics:
           type: array
           items:
-            $ref: '#/components/schemas/Flow.Metric'
+            $ref: '#/components/schemas/Plugin.Flow.Metric'
         bgpv4_metrics:
           type: array
           items:


### PR DESCRIPTION
@ajbalogh
This PR is just to get the gist of plugins way of implementation.
moved flow metrics from the base package and made it as plugin.
currently to identify plugin prepended flow metrics objects with string 'Plugin.'
ex: 'Plugin.Flow.Metrics.Request'
once if this approach is approved all the plugins can be moved to separate node instead of prepending the string.
Also modified snappigenerator.py to support plugin installations. Info will be available in snappi PR.
