### PR TITLE
One to one device endpoint for flows

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2039,10 +2039,12 @@ components:
       description: |-
         A container for declaring a map of 1..n transmit devices to 1..n receive devices. This allows for a single flow to have  different tx to rx device flows such as a single one to one map or a  many to many map.
       type: object
+      required:
+      - maps
       properties:
         maps:
           description: |-
-            A list of mapped devices
+            A list of tx to rx device mappings
           type: array
           items:
             $ref: '#/components/schemas/Flow.Device.Map'

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2010,10 +2010,6 @@ components:
           $ref: '#/components/schemas/Flow.Port'
         device:
           $ref: '#/components/schemas/Flow.Device'
-        device_one_to_one:
-          type: array
-          items:
-            $ref: '#/components/schemas/Flow.Device.OneToOne'
     Flow.Port:
       description: "A container for a transmit port and 0..n intended receive ports.\
         \ When assigning this container to a flow the flows's  packet headers will\
@@ -2041,47 +2037,20 @@ components:
           - /components/schemas/Lag/properties/name
     Flow.Device:
       description: |-
-        A container for declaring a many to many map of 1..n transmit devices to 1..n receive devices.
-        Implemementations may use learned information from the devices to  pre-populate Flow.properties.packet[Flow.Header fields].
-        For example an implementation may automatically start devices, get arp  table information and pre-populate the Flow.Ethernet dst mac address values.
-        To discover what the implementation supports use the  /results/capabilities API.
+        A container for declaring a map of 1..n transmit devices to 1..n receive devices. This allows for a single flow to have  different tx to rx device flows such as a single one to one map or a  many to many map.
       type: object
-      required:
-      - tx_names
-      - rx_names
       properties:
-        tx_names:
+        maps:
           description: |-
-            The unique names of devices that will be transmitting.
+            A list of mapped devices
           type: array
           items:
-            type: string
-            x-constraint:
-            - /components/schemas/Device/properties/name
-            - /components/schemas/Device.Ethernet/properties/name
-            - /components/schemas/Device.Ipv4/properties/name
-            - /components/schemas/Device.Ipv6/properties/name
-            - /components/schemas/Device.Bgpv4RouteRange/properties/name
-            - /components/schemas/Device.Bgpv6RouteRange/properties/name
-        rx_names:
-          description: |-
-            The unique names of emulated devices that will be receiving.
-          type: array
-          items:
-            type: string
-            x-constraint:
-            - /components/schemas/Device/properties/name
-            - /components/schemas/Device.Ethernet/properties/name
-            - /components/schemas/Device.Ipv4/properties/name
-            - /components/schemas/Device.Ipv6/properties/name
-            - /components/schemas/Device.Bgpv4RouteRange/properties/name
-            - /components/schemas/Device.Bgpv6RouteRange/properties/name
-    Flow.Device.OneToOne:
+            $ref: '#/components/schemas/Flow.Device.Map'
+    Flow.Device.Map:
       description: |-
         A container for declaring a one to one map of a transmit device to a receive device.
         Implemementations may use learned information from the devices to  pre-populate Flow.properties.packet[Flow.Header fields].
         For example an implementation may automatically start devices, get arp  table information and pre-populate the Flow.Ethernet dst mac address values.
-        To discover what the implementation supports use the  /results/capabilities API.
       type: object
       required:
       - tx_name
@@ -2090,29 +2059,23 @@ components:
         tx_name:
           description: |-
             The unique name of an emulated device that will be transmitting.
-          type: array
-          items:
-            type: string
-            x-constraint:
-            - /components/schemas/Device/properties/name
-            - /components/schemas/Device.Ethernet/properties/name
-            - /components/schemas/Device.Ipv4/properties/name
-            - /components/schemas/Device.Ipv6/properties/name
-            - /components/schemas/Device.Bgpv4RouteRange/properties/name
-            - /components/schemas/Device.Bgpv6RouteRange/properties/name
+          type: string
+          x-constraint:
+          - /components/schemas/Device.Ethernet/properties/name
+          - /components/schemas/Device.Ipv4/properties/name
+          - /components/schemas/Device.Ipv6/properties/name
+          - /components/schemas/Device.Bgpv4RouteRange/properties/name
+          - /components/schemas/Device.Bgpv6RouteRange/properties/name
         rx_name:
           description: |-
             The unique name of an emulated device that will be receiving.
-          type: array
-          items:
-            type: string
-            x-constraint:
-            - /components/schemas/Device/properties/name
-            - /components/schemas/Device.Ethernet/properties/name
-            - /components/schemas/Device.Ipv4/properties/name
-            - /components/schemas/Device.Ipv6/properties/name
-            - /components/schemas/Device.Bgpv4RouteRange/properties/name
-            - /components/schemas/Device.Bgpv6RouteRange/properties/name
+          type: string
+          x-constraint:
+          - /components/schemas/Device.Ethernet/properties/name
+          - /components/schemas/Device.Ipv4/properties/name
+          - /components/schemas/Device.Ipv6/properties/name
+          - /components/schemas/Device.Bgpv4RouteRange/properties/name
+          - /components/schemas/Device.Bgpv6RouteRange/properties/name
     Flow.Header:
       description: |-
         Container for all traffic packet headers

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -916,8 +916,6 @@ message FlowTxRx {
 
   FlowDevice device = 3;
 
-  repeated FlowDeviceOneToOne device_one_to_one = 4;
-
   message Choice { enum Enum {
     port = 0;
 
@@ -932,15 +930,13 @@ message FlowPort {
 }
 
 message FlowDevice {
-  repeated string tx_names = 1;
-
-  repeated string rx_names = 2;
+  repeated FlowDeviceMap maps = 1;
 }
 
-message FlowDeviceOneToOne {
-  repeated string tx_name = 1;
+message FlowDeviceMap {
+  string tx_name = 1;
 
-  repeated string rx_name = 2;
+  string rx_name = 2;
 }
 
 message FlowHeader {

--- a/flow/endpoint.yaml
+++ b/flow/endpoint.yaml
@@ -1,10 +1,3 @@
-openapi: 3.1.0
-
-info:
-  title: Flow endpoint models
-  version: ^0.0.0
-
-
 components:
   schemas:
     Flow.TxRx:
@@ -23,10 +16,6 @@ components:
           $ref: '#/components/schemas/Flow.Port'
         device:
           $ref: '#/components/schemas/Flow.Device'
-        device_one_to_one:
-          type: array
-          items:
-            $ref: '#/components/schemas/Flow.Device.OneToOne'
 
     Flow.Port:
       description: >-
@@ -57,48 +46,20 @@ components:
 
     Flow.Device:
       description: >-
-        A container for declaring a many to many map of 1..n transmit devices
-        to 1..n receive devices.
-
-        Implemementations may use learned information from the devices to 
-        pre-populate Flow.properties.packet[Flow.Header fields].
-        
-        For example an implementation may automatically start devices, get arp 
-        table information and pre-populate the Flow.Ethernet dst mac address values.
-
-        To discover what the implementation supports use the 
-        /results/capabilities API.
+        A container for declaring a map of 1..n transmit devices
+        to 1..n receive devices. This allows for a single flow to have 
+        different tx to rx device flows such as a single one to one map or a 
+        many to many map.
       type: object
-      required: [tx_names, rx_names]
       properties:
-        tx_names:
+        maps:
           description: >-
-            The unique names of devices that will be transmitting.
+            A list of mapped devices
           type: array
           items:
-            type: string
-            x-constraint:
-            - '/components/schemas/Device/properties/name'
-            - '/components/schemas/Device.Ethernet/properties/name'
-            - '/components/schemas/Device.Ipv4/properties/name'
-            - '/components/schemas/Device.Ipv6/properties/name'
-            - '/components/schemas/Device.Bgpv4RouteRange/properties/name'
-            - '/components/schemas/Device.Bgpv6RouteRange/properties/name'
-        rx_names:
-          description: >-
-            The unique names of emulated devices that will be receiving.
-          type: array
-          items:
-            type: string
-            x-constraint:
-            - '/components/schemas/Device/properties/name'
-            - '/components/schemas/Device.Ethernet/properties/name'
-            - '/components/schemas/Device.Ipv4/properties/name'
-            - '/components/schemas/Device.Ipv6/properties/name'
-            - '/components/schemas/Device.Bgpv4RouteRange/properties/name'
-            - '/components/schemas/Device.Bgpv6RouteRange/properties/name'
+            $ref: '#/components/schemas/Flow.Device.Map'
 
-    Flow.Device.OneToOne:
+    Flow.Device.Map:
       description: >-
         A container for declaring a one to one map of a transmit device
         to a receive device.
@@ -108,35 +69,26 @@ components:
         
         For example an implementation may automatically start devices, get arp 
         table information and pre-populate the Flow.Ethernet dst mac address values.
-
-        To discover what the implementation supports use the 
-        /results/capabilities API.
       type: object
       required: [tx_name, rx_name]
       properties:
         tx_name:
           description: >-
             The unique name of an emulated device that will be transmitting.
-          type: array
-          items:
-            type: string
-            x-constraint:
-            - '/components/schemas/Device/properties/name'
-            - '/components/schemas/Device.Ethernet/properties/name'
-            - '/components/schemas/Device.Ipv4/properties/name'
-            - '/components/schemas/Device.Ipv6/properties/name'
-            - '/components/schemas/Device.Bgpv4RouteRange/properties/name'
-            - '/components/schemas/Device.Bgpv6RouteRange/properties/name'
+          type: string
+          x-constraint:
+          - '/components/schemas/Device.Ethernet/properties/name'
+          - '/components/schemas/Device.Ipv4/properties/name'
+          - '/components/schemas/Device.Ipv6/properties/name'
+          - '/components/schemas/Device.Bgpv4RouteRange/properties/name'
+          - '/components/schemas/Device.Bgpv6RouteRange/properties/name'
         rx_name:
           description: >-
             The unique name of an emulated device that will be receiving.
-          type: array
-          items:
-            type: string
-            x-constraint:
-            - '/components/schemas/Device/properties/name'
-            - '/components/schemas/Device.Ethernet/properties/name'
-            - '/components/schemas/Device.Ipv4/properties/name'
-            - '/components/schemas/Device.Ipv6/properties/name'
-            - '/components/schemas/Device.Bgpv4RouteRange/properties/name'
-            - '/components/schemas/Device.Bgpv6RouteRange/properties/name'
+          type: string
+          x-constraint:
+          - '/components/schemas/Device.Ethernet/properties/name'
+          - '/components/schemas/Device.Ipv4/properties/name'
+          - '/components/schemas/Device.Ipv6/properties/name'
+          - '/components/schemas/Device.Bgpv4RouteRange/properties/name'
+          - '/components/schemas/Device.Bgpv6RouteRange/properties/name'

--- a/flow/endpoint.yaml
+++ b/flow/endpoint.yaml
@@ -51,10 +51,11 @@ components:
         different tx to rx device flows such as a single one to one map or a 
         many to many map.
       type: object
+      required: [maps]
       properties:
         maps:
           description: >-
-            A list of mapped devices
+            A list of tx to rx device mappings
           type: array
           items:
             $ref: '#/components/schemas/Flow.Device.Map'

--- a/flow/endpoint.yaml
+++ b/flow/endpoint.yaml
@@ -23,6 +23,10 @@ components:
           $ref: '#/components/schemas/Flow.Port'
         device:
           $ref: '#/components/schemas/Flow.Device'
+        device_one_to_one:
+          type: array
+          items:
+            $ref: '#/components/schemas/Flow.Device.OneToOne'
 
     Flow.Port:
       description: >-
@@ -53,7 +57,9 @@ components:
 
     Flow.Device:
       description: >-
-        A container for 1..n transmit devices and 1..n receive devices.
+        A container for declaring a many to many map of 1..n transmit devices
+        to 1..n receive devices.
+
         Implemementations may use learned information from the devices to 
         pre-populate Flow.properties.packet[Flow.Header fields].
         
@@ -81,6 +87,49 @@ components:
         rx_names:
           description: >-
             The unique names of emulated devices that will be receiving.
+          type: array
+          items:
+            type: string
+            x-constraint:
+            - '/components/schemas/Device/properties/name'
+            - '/components/schemas/Device.Ethernet/properties/name'
+            - '/components/schemas/Device.Ipv4/properties/name'
+            - '/components/schemas/Device.Ipv6/properties/name'
+            - '/components/schemas/Device.Bgpv4RouteRange/properties/name'
+            - '/components/schemas/Device.Bgpv6RouteRange/properties/name'
+
+    Flow.Device.OneToOne:
+      description: >-
+        A container for declaring a one to one map of a transmit device
+        to a receive device.
+
+        Implemementations may use learned information from the devices to 
+        pre-populate Flow.properties.packet[Flow.Header fields].
+        
+        For example an implementation may automatically start devices, get arp 
+        table information and pre-populate the Flow.Ethernet dst mac address values.
+
+        To discover what the implementation supports use the 
+        /results/capabilities API.
+      type: object
+      required: [tx_name, rx_name]
+      properties:
+        tx_name:
+          description: >-
+            The unique name of an emulated device that will be transmitting.
+          type: array
+          items:
+            type: string
+            x-constraint:
+            - '/components/schemas/Device/properties/name'
+            - '/components/schemas/Device.Ethernet/properties/name'
+            - '/components/schemas/Device.Ipv4/properties/name'
+            - '/components/schemas/Device.Ipv6/properties/name'
+            - '/components/schemas/Device.Bgpv4RouteRange/properties/name'
+            - '/components/schemas/Device.Bgpv6RouteRange/properties/name'
+        rx_name:
+          description: >-
+            The unique name of an emulated device that will be receiving.
           type: array
           items:
             type: string


### PR DESCRIPTION
The Flow.Device schema is intended to allow for the creation of one to one or many to many maps of tx names to rx names.

```
    config = api.config()

    for i in range(1, 5):
        config.ports.port(name='Port %s' % i, location='localhost/%s' % i)
        device = config.devices.device(name='Device %s' % i)[-1]
        device.ethernet.name = 'Eth %s' % i
        device.ethernet.ipv4.name = 'Ipv4 %s' % i

    flw1 = config.flows.flow(name='One To One Flow')[-1]
    flw1.tx_rx.device.maps.map(tx_name=config.devices[0].ethernet.name,
                               rx_name=config.devices[1].ethernet.name)

    flw2 = config.flows.flow(name='Many To Many Flow')[-1]
    flw2.tx_rx.device.maps.map(tx_name=config.devices[0].ethernet.name,
                               rx_name=config.devices[1].ethernet.name)
    flw2.tx_rx.device.maps.map(tx_name=config.devices[1].ethernet.name,
                               rx_name=config.devices[0].ethernet.name)
    flw2.tx_rx.device.maps.map(tx_name=config.devices[2].ethernet.name,
                               rx_name=config.devices[3].ethernet.name)
    flw2.tx_rx.device.maps.map(tx_name=config.devices[3].ethernet.name,
                               rx_name=config.devices[2].ethernet.name)
```
