### PR TITLE
refactor inter burst gap

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2744,18 +2744,38 @@ components:
           type: integer
           default: 12
         delay:
-          description: |-
-            The delay before starting transmission of packets.
-          type: integer
-          default: 0
-        delay_unit:
-          description: |-
-            The delay expressed as a number of this value.
+          $ref: '#/components/schemas/Flow.Delay'
+    Flow.Delay:
+      description: |-
+        The optional container to specify the delay before starting  transmission of packets.
+      type: object
+      required:
+      - choice
+      properties:
+        choice:
           type: string
           enum:
           - bytes
           - nanoseconds
-          default: bytes
+          - microseconds
+        bytes:
+          description: |-
+            The delay before starting transmission of packets. A value of 0 indicates no gap between bursts.
+          type: number
+          format: float
+          default: 0
+        nanoseconds:
+          description: |-
+            The delay before starting transmission of packets. A value of 0 indicates no gap between bursts.
+          type: number
+          format: float
+          default: 0
+        microseconds:
+          description: |-
+            The delay before starting transmission of packets. A value of 0 indicates no gap between bursts.
+          type: number
+          format: float
+          default: 0
     Flow.FixedPackets:
       description: |-
         Transmit a fixed number of packets after which the flow will stop.
@@ -2772,18 +2792,7 @@ components:
           type: integer
           default: 12
         delay:
-          description: |-
-            The delay before starting transmission of packets.
-          type: integer
-          default: 0
-        delay_unit:
-          description: |-
-            The delay expressed as a number of this value.
-          type: string
-          enum:
-          - bytes
-          - nanoseconds
-          default: bytes
+          $ref: '#/components/schemas/Flow.Delay'
     Flow.FixedSeconds:
       description: |-
         Transmit for a fixed number of seconds after which the flow will stop.
@@ -2800,18 +2809,7 @@ components:
           type: integer
           default: 12
         delay:
-          description: |-
-            The delay before starting transmission of packets.
-          type: integer
-          default: 0
-        delay_unit:
-          description: |-
-            The delay expressed as a number of this value.
-          type: string
-          enum:
-          - bytes
-          - nanoseconds
-          default: bytes
+          $ref: '#/components/schemas/Flow.Delay'
     Flow.Burst:
       description: "Transmits continuous or fixed burst of packets.  For continuous\
         \ burst of packets, it will not automatically stop. For fixed burst of packets,\

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2714,8 +2714,12 @@ components:
     Flow.Duration:
       description: "A container for different transmit durations. "
       type: object
+      required:
+      - choice
       properties:
         choice:
+          description: |-
+            A choice used to determine the type of duration.
           type: string
           enum:
           - fixed_packets

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2830,19 +2830,34 @@ components:
           type: integer
           default: 12
         inter_burst_gap:
-          description: |-
-            The gap between the transmission of each burst. A value of 0 means there is no gap between bursts.
-          type: integer
-          default: 12
-        inter_burst_gap_unit:
-          description: |-
-            The inter burst gap expressed as a number of this value.
+          $ref: '#/components/schemas/Flow.Duration.InterBurstGap'
+    Flow.Duration.InterBurstGap:
+      type: object
+      description: |-
+        The gap between the transmission of each burst.
+        A value of 0 means there is no gap between bursts.
+      required:
+      - choice
+      properties:
+        choice:
           type: string
           enum:
           - bytes
           - nanoseconds
           - microseconds
           default: bytes
+        bytes:
+          type: number
+          format: double
+          default: 12
+        nanoseconds:
+          type: number
+          format: double
+          default: 96
+        microseconds:
+          type: number
+          format: double
+          default: 0.096
     Pending.Detail:
       description: |-
         The standard response to any request. This allows an implementation to be either async or sync.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2834,12 +2834,13 @@ components:
     Flow.Duration.InterBurstGap:
       type: object
       description: |-
-        The gap between the transmission of each burst.
-        A value of 0 means there is no gap between bursts.
+        The optional container for specifying a gap between bursts.
       required:
       - choice
       properties:
         choice:
+          description: |-
+            The type of inter burst gap units.
           type: string
           enum:
           - bytes
@@ -2847,14 +2848,23 @@ components:
           - microseconds
           default: bytes
         bytes:
+          description: |-
+            The amount of time between bursts expressed in bytes.
+            A value of 0 indicates no gap between bursts.
           type: number
           format: double
           default: 12
         nanoseconds:
+          description: |-
+            The amount of time between bursts expressed in nanoseconds.
+            A value of 0 indicates no gap between bursts.
           type: number
           format: double
           default: 96
         microseconds:
+          description: |-
+            The amount of time between bursts expressed in microseconds.
+            A value of 0 indicates no gap between bursts.
           type: number
           format: double
           default: 0.096

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1478,14 +1478,24 @@ message FlowDuration {
 message FlowContinuous {
   int32 gap = 1;
 
-  int32 delay = 2;
+  FlowDelay delay = 2;
+}
 
-  Delay_unit.Enum delay_unit = 3;
+message FlowDelay {
+  Choice.Enum choice = 1;
 
-  message Delay_unit { enum Enum {
+  float bytes = 2;
+
+  float nanoseconds = 3;
+
+  float microseconds = 4;
+
+  message Choice { enum Enum {
     bytes = 0;
 
     nanoseconds = 1;
+
+    microseconds = 2;
   } }
 }
 
@@ -1494,15 +1504,7 @@ message FlowFixedPackets {
 
   int32 gap = 2;
 
-  int32 delay = 3;
-
-  Delay_unit.Enum delay_unit = 4;
-
-  message Delay_unit { enum Enum {
-    bytes = 0;
-
-    nanoseconds = 1;
-  } }
+  FlowDelay delay = 3;
 }
 
 message FlowFixedSeconds {
@@ -1510,15 +1512,7 @@ message FlowFixedSeconds {
 
   int32 gap = 2;
 
-  int32 delay = 3;
-
-  Delay_unit.Enum delay_unit = 4;
-
-  message Delay_unit { enum Enum {
-    bytes = 0;
-
-    nanoseconds = 1;
-  } }
+  FlowDelay delay = 3;
 }
 
 message FlowBurst {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1528,11 +1528,19 @@ message FlowBurst {
 
   int32 gap = 3;
 
-  int32 inter_burst_gap = 4;
+  FlowDurationInterBurstGap inter_burst_gap = 4;
+}
 
-  Inter_burst_gap_unit.Enum inter_burst_gap_unit = 5;
+message FlowDurationInterBurstGap {
+  Choice.Enum choice = 1;
 
-  message Inter_burst_gap_unit { enum Enum {
+  double bytes = 2;
+
+  double nanoseconds = 3;
+
+  double microseconds = 4;
+
+  message Choice { enum Enum {
     bytes = 0;
 
     nanoseconds = 1;

--- a/flow/duration.yaml
+++ b/flow/duration.yaml
@@ -37,16 +37,39 @@ components:
           type: integer
           default: 12
         delay:
+          $ref: '#/components/schemas/Flow.Delay'
+    
+    Flow.Delay:
+      description: >-
+        The optional container to specify the delay before starting 
+        transmission of packets.
+      type: object
+      required: [choice]
+      properties:
+        choice:
+          type: string
+          enum: [bytes, nanoseconds, microseconds]
+        bytes:
           description: >-
             The delay before starting transmission of packets.
-          type: integer
+            A value of 0 indicates no gap between bursts.
+          type: number
+          format: float
           default: 0
-        delay_unit:
+        nanoseconds:
           description: >-
-            The delay expressed as a number of this value.
-          type: string
-          enum: [bytes, nanoseconds]
-          default: bytes
+            The delay before starting transmission of packets.
+            A value of 0 indicates no gap between bursts.
+          type: number
+          format: float
+          default: 0
+        microseconds:
+          description: >-
+            The delay before starting transmission of packets.
+            A value of 0 indicates no gap between bursts.
+          type: number
+          format: float
+          default: 0
 
     Flow.FixedPackets:
       description: >-
@@ -64,16 +87,7 @@ components:
           type: integer
           default: 12
         delay:
-          description: >-
-            The delay before starting transmission of packets.
-          type: integer
-          default: 0
-        delay_unit:
-          description: >-
-            The delay expressed as a number of this value.
-          type: string
-          enum: [bytes, nanoseconds]
-          default: bytes
+          $ref: '#/components/schemas/Flow.Delay'
 
     Flow.FixedSeconds:
       description: >-
@@ -91,16 +105,7 @@ components:
           type: integer
           default: 12
         delay:
-          description: >-
-            The delay before starting transmission of packets.
-          type: integer
-          default: 0
-        delay_unit:
-          description: >-
-            The delay expressed as a number of this value.
-          type: string
-          enum: [bytes, nanoseconds]
-          default: bytes
+          $ref: '#/components/schemas/Flow.Delay'
 
     Flow.Burst:
       description: >-

--- a/flow/duration.yaml
+++ b/flow/duration.yaml
@@ -123,16 +123,30 @@ components:
           type: integer
           default: 12
         inter_burst_gap:
-          description: >-
-            The gap between the transmission of each burst.
-            A value of 0 means there is no gap between bursts.
-          type: integer
-          default: 12
-        inter_burst_gap_unit:
-          description: >-
-            The inter burst gap expressed as a number of this value.
+          $ref: '#/components/schemas/Flow.Duration.InterBurstGap'
+    
+    Flow.Duration.InterBurstGap:
+      type: object
+      description: |-
+        The gap between the transmission of each burst.
+        A value of 0 means there is no gap between bursts.
+      required: [choice]
+      properties:
+        choice:
           type: string
           enum: [bytes, nanoseconds, microseconds]
           default: bytes
+        bytes:
+          type: number
+          format: double
+          default: 12
+        nanoseconds:
+          type: number
+          format: double
+          default: 96
+        microseconds:
+          type: number
+          format: double
+          default: .096
 
 

--- a/flow/duration.yaml
+++ b/flow/duration.yaml
@@ -128,23 +128,33 @@ components:
     Flow.Duration.InterBurstGap:
       type: object
       description: |-
-        The gap between the transmission of each burst.
-        A value of 0 means there is no gap between bursts.
+        The optional container for specifying a gap between bursts.
       required: [choice]
       properties:
         choice:
+          description: |-
+            The type of inter burst gap units.
           type: string
           enum: [bytes, nanoseconds, microseconds]
           default: bytes
         bytes:
+          description: |-
+            The amount of time between bursts expressed in bytes.
+            A value of 0 indicates no gap between bursts.
           type: number
           format: double
           default: 12
         nanoseconds:
+          description: |-
+            The amount of time between bursts expressed in nanoseconds.
+            A value of 0 indicates no gap between bursts.
           type: number
           format: double
           default: 96
         microseconds:
+          description: |-
+            The amount of time between bursts expressed in microseconds.
+            A value of 0 indicates no gap between bursts.
           type: number
           format: double
           default: .096

--- a/flow/duration.yaml
+++ b/flow/duration.yaml
@@ -10,8 +10,11 @@ components:
       description: >-
         A container for different transmit durations. 
       type: object
+      required: [choice]
       properties:
         choice:
+          description: |-
+            A choice used to determine the type of duration.
           type: string
           enum: [fixed_packets, fixed_seconds, burst, continuous]
         fixed_packets:

--- a/flow/duration.yaml
+++ b/flow/duration.yaml
@@ -52,21 +52,21 @@ components:
         bytes:
           description: >-
             The delay before starting transmission of packets.
-            A value of 0 indicates no gap between bursts.
+            A value of 0 indicates no delay.
           type: number
           format: float
           default: 0
         nanoseconds:
           description: >-
             The delay before starting transmission of packets.
-            A value of 0 indicates no gap between bursts.
+            A value of 0 indicates no delay.
           type: number
           format: float
           default: 0
         microseconds:
           description: >-
             The delay before starting transmission of packets.
-            A value of 0 indicates no gap between bursts.
+            A value of 0 indicates no delay.
           type: number
           format: float
           default: 0


### PR DESCRIPTION
Why: The current structure of inter burst gap doesn't follow the choice model. The choice model allows for different defaults per choice while the original model does not. The choice model also removes the need to set units and a value.

[View the proposed changes using the redocly API viewer](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/inter_burst_gap_refactor/artifacts/openapi.yaml)

```
# the refactor allows for this snappi notation
flw.duration.burst.inter_burst_gap.microseconds = 1.5
```