### PR TITLE
Limit http responses to 200, 400 and 500 status codes

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -32,10 +32,10 @@ paths:
       responses:
         '200':
           $ref: '../result/request.yaml#/components/responses/Success'
-        '409':
-          $ref: '../result/request.yaml#/components/responses/Conflict'
-        '590':
-          $ref: '../result/request.yaml#/components/responses/Fail'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
     patch:
       tags: [Configuration]
       operationId: update_config
@@ -50,10 +50,10 @@ paths:
       responses:
         '200':
           $ref: '../result/request.yaml#/components/responses/Success'
-        '409':
-          $ref: '../result/request.yaml#/components/responses/Conflict'
-        '590':
-          $ref: '../result/request.yaml#/components/responses/Fail'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
     get:
       tags: [Configuration]
       operationId: get_config
@@ -65,6 +65,10 @@ paths:
             application/json:
               schema:
                 $ref: '../config/config.yaml#/components/schemas/Config'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /control/transmit:
     post:
@@ -81,10 +85,10 @@ paths:
       responses:
         '200':
           $ref: '../result/request.yaml#/components/responses/Success'
-        '409':
-          $ref: '../result/request.yaml#/components/responses/Conflict'
-        '590':
-          $ref: '../result/request.yaml#/components/responses/Fail'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /control/link:
     post:
@@ -101,10 +105,10 @@ paths:
       responses:
         '200':
           $ref: '../result/request.yaml#/components/responses/Success'
-        '409':
-          $ref: '../result/request.yaml#/components/responses/Conflict'
-        '590':
-          $ref: '../result/request.yaml#/components/responses/Fail'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /control/capture:
     post:
@@ -121,10 +125,10 @@ paths:
       responses:
         '200':
           $ref: '../result/request.yaml#/components/responses/Success'
-        '409':
-          $ref: '../result/request.yaml#/components/responses/Conflict'
-        '590':
-          $ref: '../result/request.yaml#/components/responses/Fail'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /results/metrics:
     description: >-
@@ -148,6 +152,10 @@ paths:
             application/json:
               schema:
                 $ref: '../result/metrics.yaml#/components/schemas/Metrics.Response'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /results/state:
     post:
@@ -160,6 +168,10 @@ paths:
             application/json:
               schema:
                 $ref: '../result/state.yaml#/components/schemas/State.Metrics'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /results/capabilities:
     description: >-
@@ -175,6 +187,10 @@ paths:
             application/json:
               schema:
                 $ref: '../result/capability.yaml#/components/schemas/Capabilities'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /results/capture:
     description: >-
@@ -199,3 +215,7 @@ paths:
               schema:
                 type: string
                 format: binary
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -30,10 +30,10 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '590':
-          $ref: '#/components/responses/Fail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     patch:
       tags:
       - Configuration
@@ -49,10 +49,10 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '590':
-          $ref: '#/components/responses/Fail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     get:
       tags:
       - Configuration
@@ -65,6 +65,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Config'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /control/transmit:
     post:
       tags:
@@ -81,10 +85,10 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '590':
-          $ref: '#/components/responses/Fail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /control/link:
     post:
       tags:
@@ -101,10 +105,10 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '590':
-          $ref: '#/components/responses/Fail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /control/capture:
     post:
       tags:
@@ -121,10 +125,10 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '590':
-          $ref: '#/components/responses/Fail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /results/metrics:
     description: |-
       Traffic metrics API
@@ -148,6 +152,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Metrics.Response'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /results/state:
     post:
       tags:
@@ -161,6 +169,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/State.Metrics'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /results/capabilities:
     description: |-
       Capability results API
@@ -176,6 +188,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Capabilities'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /results/capture:
     description: |-
       Capture results API
@@ -199,39 +215,35 @@ paths:
               schema:
                 type: string
                 format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   responses:
     Success:
-      description: |-
-        The request has succeeded. Detailed warnings if any will be returned as a list.
+      description: "The request has succeeded with no application content but the\
+        \ server \nmay return a list of detailed warnings."
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Details'
-    SuccessNoContent:
-      description: |-
-        The traffic generator has successfully completed the request and there is no content to return.
-    Pending:
-      description: |-
-        The traffic generator is currently processing the request which has  not yet completed. If a traffic generator implementation follows an asynchronous model it  should use this response to indicate that an operation has been  accepted but has not completed.
+            $ref: '#/components/schemas/Response.Warning'
+    BadRequest:
+      description: "This indicates that the server cannot or will not process the\
+        \ request \ndue to something that is perceived to be a client error.\nAdditional\
+        \ details are in the errors."
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Pending.Detail'
-    Conflict:
-      description: |-
-        The request is denied as the traffic generator is currently processing  another request.
+            $ref: '#/components/schemas/Response.Error'
+    InternalServerError:
+      description: "This indicates that the server encountered an unexpected condition\
+        \ that \nprevented it from fulfilling the request.\nAdditional details are\
+        \ in the errors."
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Details'
-    Fail:
-      description: |-
-        The request has failed. Detailed errors will be returned as a list.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Details'
+            $ref: '#/components/schemas/Response.Error'
   schemas:
     Config:
       description: |-
@@ -2870,32 +2882,25 @@ components:
           type: number
           format: double
           default: 0.096
-    Pending.Detail:
+    Response.Error:
       description: |-
-        The standard response to any request. This allows an implementation to be either async or sync.
-      type: object
-      properties:
-        state:
-          type: string
-          enum:
-          - pending
-          - success
-        url:
-          description: |-
-            The url to poll while the state is pending.
-          type: string
-    Details:
+        A list of errors that may have occurred while executing the request.
       type: object
       properties:
         errors:
-          description: |-
-            A list of any errors that may have occurred while executing the request.
+          description: "A list of any system specific errors that have occurred while\
+            \ \nexecuting the request."
           type: array
           items:
             type: string
+    Response.Warning:
+      description: |-
+        A list of warnings that have occurred while executing the request.
+      type: object
+      properties:
         warnings:
-          description: |-
-            A list of any warnings generated while executing the request.
+          description: "A list of any system specific warnings that have occurred\
+            \ while \nexecuting the request."
           type: array
           items:
             type: string

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1543,22 +1543,12 @@ message FlowDurationInterBurstGap {
   } }
 }
 
-message PendingDetail {
-  State.Enum state = 1;
-
-  string url = 2;
-
-  message State { enum Enum {
-    pending = 0;
-
-    success = 1;
-  } }
+message ResponseError {
+  repeated string errors = 1;
 }
 
-message Details {
-  repeated string errors = 1;
-
-  repeated string warnings = 2;
+message ResponseWarning {
+  repeated string warnings = 1;
 }
 
 message LinkState {
@@ -6363,13 +6353,6 @@ message PatternFlowIgmpv1GroupAddress {
   } }
 }
 
-message SuccessNoContent {
-}
-
-message Pending {
-  PendingDetail pending__detail = 1;
-}
-
 message SetConfigParameters {
   Config config = 1;
 }
@@ -6403,23 +6386,23 @@ service Openapi {
 //     option (google.api.http) = { get:"/config"  };
   }
 
-  rpc SetConfig ( SetConfigParameters ) returns ( Details ) {
+  rpc SetConfig ( SetConfigParameters ) returns ( ResponseWarning ) {
 //     option (google.api.http) = { post:"/config"  };
   }
 
-  rpc UpdateConfig ( UpdateConfigParameters ) returns ( Details ) {
+  rpc UpdateConfig ( UpdateConfigParameters ) returns ( ResponseWarning ) {
 //     option (google.api.http) = { patch:"/config"  };
   }
 
-  rpc SetTransmitState ( SetTransmitStateParameters ) returns ( Details ) {
+  rpc SetTransmitState ( SetTransmitStateParameters ) returns ( ResponseWarning ) {
 //     option (google.api.http) = { post:"/control/transmit"  };
   }
 
-  rpc SetLinkState ( SetLinkStateParameters ) returns ( Details ) {
+  rpc SetLinkState ( SetLinkStateParameters ) returns ( ResponseWarning ) {
 //     option (google.api.http) = { post:"/control/link"  };
   }
 
-  rpc SetCaptureState ( SetCaptureStateParameters ) returns ( Details ) {
+  rpc SetCaptureState ( SetCaptureStateParameters ) returns ( ResponseWarning ) {
 //     option (google.api.http) = { post:"/control/capture"  };
   }
 

--- a/result/request.yaml
+++ b/result/request.yaml
@@ -1,84 +1,57 @@
-openapi: 3.1.0
-
-info:
-  title: Request response models
-  description: >-
-    All standard request response schemas
-  version: ^0.0.0
-
 components:
   responses:
     Success:
-      description: >-
-        The request has succeeded.
-        Detailed warnings if any will be returned as a list.
+      description: |-
+        The request has succeeded with no application content but the server 
+        may return a list of detailed warnings.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Details'
+            $ref: '#/components/schemas/Response.Warning'
 
-    SuccessNoContent:
-      description: >-
-        The traffic generator has successfully completed the request
-        and there is no content to return.
-
-    Pending:
-      description: >-
-        The traffic generator is currently processing the request which has 
-        not yet completed.
-        If a traffic generator implementation follows an asynchronous model it 
-        should use this response to indicate that an operation has been 
-        accepted but has not completed.
+    BadRequest:
+      description: |-
+        This indicates that the server cannot or will not process the request 
+        due to something that is perceived to be a client error.
+        Additional details are in the errors.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Pending.Detail'
+            $ref: '#/components/schemas/Response.Error'
 
-    Conflict:
-      description: >-
-        The request is denied as the traffic generator is currently processing 
-        another request.
+    InternalServerError:
+      description: |-
+        This indicates that the server encountered an unexpected condition that 
+        prevented it from fulfilling the request.
+        Additional details are in the errors.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Details'
-
-    Fail:
-      description: >-
-        The request has failed.
-        Detailed errors will be returned as a list.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Details'
+            $ref: '#/components/schemas/Response.Error'
 
   schemas:
-    Pending.Detail:
-      description: >-
-        The standard response to any request.
-        This allows an implementation to be either async or sync.
-      type: object
-      properties:
-        state:
-          type: string
-          enum: [pending, success]
-        url:
-          description: >-
-            The url to poll while the state is pending.
-          type: string
-
-    Details:
+    Response.Error:
+      description: |-
+        A list of errors that may have occurred while executing the request.
       type: object
       properties:
         errors:
-          description: >-
-            A list of any errors that may have occurred while executing the request.
+          description: |-
+            A list of any system specific errors that have occurred while 
+            executing the request.
           type: array
           items:
             type: string
+
+    Response.Warning:
+      description: |-
+        A list of warnings that have occurred while executing the request.
+      type: object
+      properties:
         warnings:
-          description: >-
-            A list of any warnings generated while executing the request.
+          description: |-
+            A list of any system specific warnings that have occurred while 
+            executing the request.
           type: array
           items:
             type: string


### PR DESCRIPTION
Create a limited set of http responses that can be used by all API calls.

400/500 response will be used for all 4xx/5xx errors returned by a server implementation.  This means a server must wrap any 4xx error in the single 400 response and any 5xx response in the single 500 response. 

Please comment if an additional status code field is needed in the error, this will require breaking out the detail strings into a separate object and should be done now.

