### PR TITLE
set correct defaults for step and values

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+artifacts/openapi.yaml linguist-generated=true
+artifacts/otg.proto linguist-generated=true

--- a/bundler.py
+++ b/bundler.py
@@ -6,6 +6,7 @@ import subprocess
 import re
 import copy
 import json
+from typing import Dict, Union, Literal
 
 
 class Bundler(object):
@@ -295,16 +296,20 @@ class Bundler(object):
                     'type': 'integer',
                     'default': 1
                 }
-            self._apply_common_x_field_pattern_properties(counter_schema['properties']['start'], xpattern, format, type='start')
-            self._apply_common_x_field_pattern_properties(counter_schema['properties']['step'], xpattern, format, type='step')
+            self._apply_common_x_field_pattern_properties(counter_schema['properties']['start'], xpattern, format, property_name='start')
+            self._apply_common_x_field_pattern_properties(counter_schema['properties']['step'], xpattern, format, property_name='step')
             if xconstants is not None:
                 counter_schema['x-constants'] = copy.deepcopy(xconstants)
             self._content['components']['schemas'][counter_pattern_name] = counter_schema
-        self._apply_common_x_field_pattern_properties(schema['properties']['value'], xpattern, format, type='value')
-        self._apply_common_x_field_pattern_properties(schema['properties']['values'], xpattern, format, type='values')
+        self._apply_common_x_field_pattern_properties(schema['properties']['value'], xpattern, format, property_name='value')
+        self._apply_common_x_field_pattern_properties(schema['properties']['values'], xpattern, format, property_name='values')
         self._content['components']['schemas'][schema_name] = schema
 
-    def _apply_common_x_field_pattern_properties(self, schema, xpattern, format, type):
+    def _apply_common_x_field_pattern_properties(self, 
+        schema: Dict, 
+        xpattern: Dict, 
+        format: str, 
+        property_name: Union[Literal["start"], Literal["step"], Literal["value"], Literal["values"]]):
         step_defaults = {
             'mac': '00:00:00:00:00:01',
             'ipv4': '0.0.0.1',
@@ -312,12 +317,12 @@ class Bundler(object):
         }
         if 'default' in xpattern:
             schema['default'] = xpattern['default']
-            if type == 'step':
+            if property_name == 'step':
                 if format in step_defaults:
                     schema['default'] = step_defaults[format]
                 else:
                     schema['default'] = 1
-            elif type == 'values':
+            elif property_name == 'values':
                 schema['default'] = [schema['default']]
         if format is not None:
             schema['format'] = format

--- a/bundler.py
+++ b/bundler.py
@@ -295,18 +295,30 @@ class Bundler(object):
                     'type': 'integer',
                     'default': 1
                 }
-            self._apply_common_x_field_pattern_properties(counter_schema['properties']['start'], xpattern, format)
-            self._apply_common_x_field_pattern_properties(counter_schema['properties']['step'], xpattern, format)
+            self._apply_common_x_field_pattern_properties(counter_schema['properties']['start'], xpattern, format, type='start')
+            self._apply_common_x_field_pattern_properties(counter_schema['properties']['step'], xpattern, format, type='step')
             if xconstants is not None:
                 counter_schema['x-constants'] = copy.deepcopy(xconstants)
             self._content['components']['schemas'][counter_pattern_name] = counter_schema
-        self._apply_common_x_field_pattern_properties(schema['properties']['value'], xpattern, format)
-        self._apply_common_x_field_pattern_properties(schema['properties']['values']['items'], xpattern, format)
+        self._apply_common_x_field_pattern_properties(schema['properties']['value'], xpattern, format, type='value')
+        self._apply_common_x_field_pattern_properties(schema['properties']['values'], xpattern, format, type='values')
         self._content['components']['schemas'][schema_name] = schema
 
-    def _apply_common_x_field_pattern_properties(self, schema, xpattern, format):
+    def _apply_common_x_field_pattern_properties(self, schema, xpattern, format, type):
+        step_defaults = {
+            'mac': '00:00:00:00:00:01',
+            'ipv4': '0.0.0.1',
+            'ipv6': '::1'
+        }
         if 'default' in xpattern:
             schema['default'] = xpattern['default']
+            if type == 'step':
+                if format in step_defaults:
+                    schema['default'] = step_defaults[format]
+                else:
+                    schema['default'] = 1
+            elif type == 'values':
+                schema['default'] = [schema['default']]
         if format is not None:
             schema['format'] = format
         if 'length' in xpattern:


### PR DESCRIPTION
# Issue #114 
Auto generated schema objects from an x-field-pattern do not have the correct defaults for step and values properties.

# Change
An x-field-pattern will produce generated schema object default keyword/values as follows:
```
if there is a default value
  if format is mac, step default is '00:00:00:00:00:01', values default is ['00:00:00:00:00:01']
  if format is ipv4, step default is '0.0.0.1', values default is ['0.0.0.1']
  if format is ipv6, step default is '::1', values default is ['::1']
  else step default is 1, values defaults is [1]
```
 