### PR TITLE
Fix typo in IPv4 capture filter.  Fixes issue #129.

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -1957,7 +1957,7 @@ components:
       properties:
         version:
           $ref: '#/components/schemas/Capture.Field'
-        headeer_length:
+        header_length:
           $ref: '#/components/schemas/Capture.Field'
         priority:
           $ref: '#/components/schemas/Capture.Field'

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -860,7 +860,7 @@ message CaptureVlan {
 message CaptureIpv4 {
   CaptureField version = 1;
 
-  CaptureField headeer_length = 2;
+  CaptureField header_length = 2;
 
   CaptureField priority = 3;
 

--- a/capture/capture.yaml
+++ b/capture/capture.yaml
@@ -133,7 +133,7 @@ components:
       properties:
         version:
           $ref: '#/components/schemas/Capture.Field'
-        headeer_length:
+        header_length:
           $ref: '#/components/schemas/Capture.Field'
         priority:
           $ref: '#/components/schemas/Capture.Field'


### PR DESCRIPTION
Fixes typo.  "headeer_length" --> "header_length".
This change IS backwards incompatible.  I think it is ok since the spelling is wrong to begin with and it wasn't reported so far implying that it hasn't been used yet.
Fixes issue #129.