### PR TITLE
Otf rate

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -97,9 +97,9 @@ paths:
   /control/flows:
     post:
       tags: ['Control']
-      operationId: update_flow_state
+      operationId: update_flows
       description: >-
-        Updates the state of configuration resources on the traffic generator.
+        Updates flow properties without disruption of transmit state.
       requestBody:
         required: true
         content:
@@ -109,7 +109,7 @@ paths:
       responses:
         '200':
           description: >-
-            Response with current Config from the traffic generator
+            Response with updated Config from the traffic generator
           content:
             application/json:
               schema:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -94,6 +94,31 @@ paths:
         '500':
           $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
+  /control/flows:
+    post:
+      tags: ['Control']
+      operationId: update_flow_state
+      description: >-
+        Updates the state of configuration resources on the traffic generator.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../control/control.yaml#/components/schemas/Flow.Update'
+      responses:
+        '200':
+          description: >-
+            Response with current Config from the traffic generator
+          content:
+            application/json:
+              schema:
+                $ref: '../config/config.yaml#/components/schemas/Config'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
+
   /control/routes:
     post:
       tags: ['Control']

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -105,7 +105,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '../control/control.yaml#/components/schemas/Flow.Update'
+              $ref: '../control/control.yaml#/components/schemas/Flows.Update'
       responses:
         '200':
           description: >-

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -18,24 +18,6 @@ paths:
           $ref: '../result/request.yaml#/components/responses/BadRequest'
         '500':
           $ref: '../result/request.yaml#/components/responses/InternalServerError'
-    patch:
-      tags: ['Configuration']
-      operationId: update_config
-      description: >-
-        Updates configuration resources on the traffic generator.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '../config/config.yaml#/components/schemas/Config'
-      responses:
-        '200':
-          $ref: '../result/request.yaml#/components/responses/Success'
-        '400':
-          $ref: '../result/request.yaml#/components/responses/BadRequest'
-        '500':
-          $ref: '../result/request.yaml#/components/responses/InternalServerError'
     get:
       tags: ['Configuration']
       operationId: get_config

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -37,25 +37,6 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalServerError'
-    patch:
-      tags:
-      - Configuration
-      operationId: update_config
-      description: |-
-        Updates configuration resources on the traffic generator.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Config'
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
     get:
       tags:
       - Configuration
@@ -128,6 +109,31 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /control/flows:
+    post:
+      tags:
+      - Control
+      operationId: update_flow_state
+      description: |-
+        Updates the state of configuration resources on the traffic generator.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Flows.Update'
+      responses:
+        '200':
+          description: |-
+            Response with current Config from the traffic generator
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Config'
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -3151,6 +3157,33 @@ components:
           enum:
           - start
           - stop
+    Flow.Update:
+      description: |-
+        A container for properties that define flow property changes
+      type: object
+      properties:
+        update:
+          description: |-
+            Indicates what child nodes of a flow are being updated on the fly.
+          type: array
+          items:
+            type: string
+            enum:
+            - rate
+            - size
+        flow:
+          $ref: '#/components/schemas/Flow'
+    Flows.Update:
+      description: |-
+        A container of flows for whom property change is intended
+      type: object
+      properties:
+        flows:
+          description: |-
+            Indicates list of flows which are being updated on the fly.
+          type: array
+          items:
+            $ref: '#/components/schemas/Flow.Update'
     Route.State:
       description: |-
         Sets the device route state

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3157,32 +3157,26 @@ components:
           enum:
           - start
           - stop
-    Flow.Update:
-      description: |-
-        A container for properties that define flow property changes
-      type: object
-      required:
-      - flow_name
-      properties:
-        flow_name:
-          description: |-
-            Name of the flow object to be updated
-          type: string
-        size:
-          $ref: '#/components/schemas/Flow.Size'
-        rate:
-          $ref: '#/components/schemas/Flow.Rate'
     Flows.Update:
       description: |-
-        A container of flows for whom property change is intended
+        A container of flows with associated property updates intended for on the fly change
       type: object
+      required:
+      - update
       properties:
+        update:
+          description: |-
+            Flow properties to be updated on the fly
+          type: string
+          enum:
+          - rate
+          - size
         flows:
           description: |-
-            Indicates list of flows which are being updated on the fly.
+            The list of configured flows on which update will be applied. An empty or null list will cause the update to be applied to all configured flows.
           type: array
           items:
-            $ref: '#/components/schemas/Flow.Update'
+            $ref: '#/components/schemas/Flow'
     Route.State:
       description: |-
         Sets the device route state

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -117,9 +117,9 @@ paths:
     post:
       tags:
       - Control
-      operationId: update_flow_state
+      operationId: update_flows
       description: |-
-        Updates the state of configuration resources on the traffic generator.
+        Updates flow properties without disruption of transmit state.
       requestBody:
         required: true
         content:
@@ -129,7 +129,7 @@ paths:
       responses:
         '200':
           description: |-
-            Response with current Config from the traffic generator
+            Response with updated Config from the traffic generator
           content:
             application/json:
               schema:
@@ -3159,21 +3159,21 @@ components:
           - stop
     Flows.Update:
       description: |-
-        A container of flows with associated property updates intended for on the fly change
+        A container of flows with associated properties to be updated without affecting the transmit state
       type: object
       required:
-      - update
+      - property_names
       properties:
-        update:
+        property_names:
           description: |-
-            Flow properties to be updated on the fly
+            Flow properties to be updated without affecting the transmit state
           type: string
           enum:
           - rate
           - size
         flows:
           description: |-
-            The list of configured flows on which update will be applied. An empty or null list will cause the update to be applied to all configured flows.
+            The list of configured flows for which given properties will be updated. An empty or null list will cause the update to be applied to all configured flows.
           type: array
           items:
             $ref: '#/components/schemas/Flow'

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -3109,6 +3109,33 @@ message CaptureState {
   ];
 }
 
+message FlowUpdate {
+  option (msg_meta).description = "A container for properties that define flow property changes";
+
+  message Update {
+    enum Enum {
+      unspecified = 0;
+      rate = 1;
+      size = 2;
+    }
+  }
+  repeated Update.Enum update = 1 [
+    (fld_meta).description = "Indicates what child nodes of a flow are being updated on the fly."
+  ];
+
+  optional Flow flow = 2 [
+    (fld_meta).description = "Description missing in models"
+  ];
+}
+
+message FlowsUpdate {
+  option (msg_meta).description = "A container of flows for whom property change is intended";
+
+  repeated FlowUpdate flows = 1 [
+    (fld_meta).description = "Indicates list of flows which are being updated on the fly."
+  ];
+}
+
 message RouteState {
   option (msg_meta).description = "Sets the device route state";
 
@@ -11736,28 +11763,7 @@ message SetConfigRequest {
   Config config = 1;
 }
 
-message UpdateConfigRequest {
-  Config config = 1;
-}
-
 message SetConfigResponse {
-  message StatusCode200 {
-    Success success = 1;
-  }
-  message StatusCode400 {
-    BadRequest bad_request = 1;
-  }
-  message StatusCode500 {
-    InternalServerError internal_server_error = 1;
-  }
-  oneof statuscode {
-    StatusCode200 status_code_200 = 1;
-    StatusCode400 status_code_400 = 2;
-    StatusCode500 status_code_500 = 3;
-  }
-}
-
-message UpdateConfigResponse {
   message StatusCode200 {
     Success success = 1;
   }
@@ -11840,6 +11846,27 @@ message SetCaptureStateRequest {
 message SetCaptureStateResponse {
   message StatusCode200 {
     Success success = 1;
+  }
+  message StatusCode400 {
+    BadRequest bad_request = 1;
+  }
+  message StatusCode500 {
+    InternalServerError internal_server_error = 1;
+  }
+  oneof statuscode {
+    StatusCode200 status_code_200 = 1;
+    StatusCode400 status_code_400 = 2;
+    StatusCode500 status_code_500 = 3;
+  }
+}
+
+message UpdateFlowStateRequest {
+  FlowsUpdate flows_update = 1;
+}
+
+message UpdateFlowStateResponse {
+  message StatusCode200 {
+    Config config = 1;
   }
   message StatusCode400 {
     BadRequest bad_request = 1;
@@ -11940,9 +11967,6 @@ service Openapi {
   rpc SetConfig(SetConfigRequest) returns (SetConfigResponse) {
     option (rpc_meta).description = "Sets configuration resources on the traffic generator.";
   }
-  rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse) {
-    option (rpc_meta).description = "Updates configuration resources on the traffic generator.";
-  }
   rpc GetConfig(google.protobuf.Empty) returns (GetConfigResponse) {
     option (rpc_meta).description = "Description missing in models";
   }
@@ -11953,6 +11977,9 @@ service Openapi {
     option (rpc_meta).description = "Updates the state of configuration resources on the traffic generator.";
   }
   rpc SetCaptureState(SetCaptureStateRequest) returns (SetCaptureStateResponse) {
+    option (rpc_meta).description = "Updates the state of configuration resources on the traffic generator.";
+  }
+  rpc UpdateFlowState(UpdateFlowStateRequest) returns (UpdateFlowStateResponse) {
     option (rpc_meta).description = "Updates the state of configuration resources on the traffic generator.";
   }
   rpc SetRouteState(SetRouteStateRequest) returns (SetRouteStateResponse) {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -3109,27 +3109,22 @@ message CaptureState {
   ];
 }
 
-message FlowUpdate {
-  option (msg_meta).description = "A container for properties that define flow property changes";
-
-  string flow_name = 1 [
-    (fld_meta).description = "Name of the flow object to be updated"
-  ];
-
-  optional FlowSize size = 2 [
-    (fld_meta).description = "Description missing in models"
-  ];
-
-  optional FlowRate rate = 3 [
-    (fld_meta).description = "Description missing in models"
-  ];
-}
-
 message FlowsUpdate {
-  option (msg_meta).description = "A container of flows for whom property change is intended";
+  option (msg_meta).description = "A container of flows with associated property updates intended for on the fly change";
 
-  repeated FlowUpdate flows = 1 [
-    (fld_meta).description = "Indicates list of flows which are being updated on the fly."
+  message Update {
+    enum Enum {
+      unspecified = 0;
+      rate = 1;
+      size = 2;
+    }
+  }
+  Update.Enum update = 1 [
+    (fld_meta).description = "Flow properties to be updated on the fly"
+  ];
+
+  repeated Flow flows = 2 [
+    (fld_meta).description = "The list of configured flows on which update will be applied. An empty or null list will cause the update to be applied to all configured flows."
   ];
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -3110,21 +3110,21 @@ message CaptureState {
 }
 
 message FlowsUpdate {
-  option (msg_meta).description = "A container of flows with associated property updates intended for on the fly change";
+  option (msg_meta).description = "A container of flows with associated properties to be updated without affecting the transmit state";
 
-  message Update {
+  message PropertyNames {
     enum Enum {
       unspecified = 0;
       rate = 1;
       size = 2;
     }
   }
-  Update.Enum update = 1 [
-    (fld_meta).description = "Flow properties to be updated on the fly"
+  PropertyNames.Enum property_names = 1 [
+    (fld_meta).description = "Flow properties to be updated without affecting the transmit state"
   ];
 
   repeated Flow flows = 2 [
-    (fld_meta).description = "The list of configured flows on which update will be applied. An empty or null list will cause the update to be applied to all configured flows."
+    (fld_meta).description = "The list of configured flows for which given properties will be updated. An empty or null list will cause the update to be applied to all configured flows."
   ];
 }
 
@@ -11852,11 +11852,11 @@ message SetCaptureStateResponse {
   }
 }
 
-message UpdateFlowStateRequest {
+message UpdateFlowsRequest {
   FlowsUpdate flows_update = 1;
 }
 
-message UpdateFlowStateResponse {
+message UpdateFlowsResponse {
   message StatusCode200 {
     Config config = 1;
   }
@@ -11971,8 +11971,8 @@ service Openapi {
   rpc SetCaptureState(SetCaptureStateRequest) returns (SetCaptureStateResponse) {
     option (rpc_meta).description = "Updates the state of configuration resources on the traffic generator.";
   }
-  rpc UpdateFlowState(UpdateFlowStateRequest) returns (UpdateFlowStateResponse) {
-    option (rpc_meta).description = "Updates the state of configuration resources on the traffic generator.";
+  rpc UpdateFlows(UpdateFlowsRequest) returns (UpdateFlowsResponse) {
+    option (rpc_meta).description = "Updates flow properties without disruption of transmit state.";
   }
   rpc SetRouteState(SetRouteStateRequest) returns (SetRouteStateResponse) {
     option (rpc_meta).description = "Updates the state of configuration resources on the traffic generator.";

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -73,28 +73,22 @@ components:
           type: string
           enum: [start, stop]
 
-    Flow.Update:
-      description: A container for properties that define flow property changes
-      type: object
-      required: [flow_name]
-      properties:
-        flow_name:
-          description: Name of the flow object to be updated
-          type: string
-        size:
-          $ref: '#/components/schemas/Flow.Size'
-        rate:
-          $ref: '#/components/schemas/Flow.Rate'
-
     Flows.Update:
-      description: A container of flows for whom property change is intended
+      description: A container of flows with associated property updates intended for on the fly change
       type: object
+      required: [update]
       properties:
+        update:
+          description: Flow properties to be updated on the fly 
+          type: string
+          enum: [rate, size]
         flows:
-          description: Indicates list of flows which are being updated on the fly. 
+          description: >-
+            The list of configured flows on which update will be applied.
+            An empty or null list will cause the update to be applied to all configured flows.
           type: array
           items:
-            $ref: '#/components/schemas/Flow.Update'
+            $ref: '#/components/schemas/Flow'
 
     Route.State:
       description: >-

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -73,6 +73,19 @@ components:
           type: string
           enum: [start, stop]
 
+    Flow.Update:
+      description: A container for properties that define flow property changes
+      type: object
+      properties:
+        update:
+          description: Indicates what child nodes of a flow are being updated on the fly. 
+          type: array
+          items:
+            type: string
+            enum: [rate, size]
+        flow:
+          $ref: '#/components/schemas/Flow'
+
     Route.State:
       description: >-
         Sets the device route state

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -74,17 +74,17 @@ components:
           enum: [start, stop]
 
     Flows.Update:
-      description: A container of flows with associated property updates intended for on the fly change
+      description: A container of flows with associated properties to be updated without affecting the transmit state
       type: object
-      required: [update]
+      required: [property_names]
       properties:
-        update:
-          description: Flow properties to be updated on the fly 
+        property_names:
+          description: Flow properties to be updated without affecting the transmit state 
           type: string
           enum: [rate, size]
         flows:
           description: >-
-            The list of configured flows on which update will be applied.
+            The list of configured flows for which given properties will be updated.
             An empty or null list will cause the update to be applied to all configured flows.
           type: array
           items:

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -86,6 +86,16 @@ components:
         flow:
           $ref: '#/components/schemas/Flow'
 
+    Flows.Update:
+      description: A container of flows for whom property change is intended
+      type: object
+      properties:
+        flows:
+          description: Indicates list of flows which are being updated on the fly. 
+          type: array
+          items:
+            $ref: '#/components/schemas/Flow.Update'
+
     Route.State:
       description: >-
         Sets the device route state

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -76,15 +76,15 @@ components:
     Flow.Update:
       description: A container for properties that define flow property changes
       type: object
+      required: [flow_name]
       properties:
-        update:
-          description: Indicates what child nodes of a flow are being updated on the fly. 
-          type: array
-          items:
-            type: string
-            enum: [rate, size]
-        flow:
-          $ref: '#/components/schemas/Flow'
+        flow_name:
+          description: Name of the flow object to be updated
+          type: string
+        size:
+          $ref: '#/components/schemas/Flow.Size'
+        rate:
+          $ref: '#/components/schemas/Flow.Rate'
 
     Flows.Update:
       description: A container of flows for whom property change is intended


### PR DESCRIPTION
This PR is intended to fix issue [142](https://github.com/open-traffic-generator/models/issues/142) based on the discussion and last proposed model by Andy.

[Please view the proposed changes using the redocly API viewer](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/otf_rate/artifacts/openapi.yaml#operation/update_flow_state)


A sample snippet should look like

```
import snappi
api = snappi.api(location='https://127.0.0.1:443')

# Create Config
config = api.config()
tx, rx = (
    config.ports
    .port(name='tx', location="localhost:5555")
    .port(name='rx', location="localhost:5556")
)

ly = config.layer1.layer1(name='l1')[0]
ly.speed = ly.SPEED_1_GBPS
ly.port_names = [tx.name, rx.name]

f1, f2, f3 = config.flows.flow(name='flow1').flow(
    name='flow2').flow(name='flow3')

for flow in [f1, f2, f3]:
    flow.packet.ethernet()
    flow.size.fixed = 128
    flow.rate.mbps = 10
    flow.tx_rx.port.tx_name = tx.name
    flow.tx_rx.port.rx_name = rx.name

# Set Config
api.set_config(config)

# Start transmit
ts = api.transmit_state()
ts.state = ts.START
api.set_transmit_state(ts)

# Update flows
fupd = api.flow_updates()

f1.size.fixed = 64
fupd.append(f1.name, f1.size)

f2.rate.pps = 100
fupd.append(f2.name, f2.rate)

f3.size.fixed = 100
f3.rate.percentage = 50
fupd.append(f3.name, f3.size, f3.rate)

api.update_flow_state(fupd)
```

