### PR TITLE
Fix update_flows api

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3159,19 +3159,21 @@ components:
           - stop
     Flows.Update:
       description: |-
-        A container of flows with associated property to be updated without affecting the transmit state
+        A container of flows with associated properties to be updated without affecting the transmit state
       type: object
       required:
-      - property_name
+      - property_names
       - flows
       properties:
-        property_name:
+        property_names:
           description: |-
-            Flow property to be updated without affecting the transmit state
-          type: string
-          enum:
-          - rate
-          - size
+            Flow properties to be updated without affecting the transmit state
+          type: array
+          items:
+            type: string
+            enum:
+            - rate
+            - size
         flows:
           description: |-
             The list of configured flows for which given property will be updated.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -3110,17 +3110,17 @@ message CaptureState {
 }
 
 message FlowsUpdate {
-  option (msg_meta).description = "A container of flows with associated property to be updated without affecting the transmit state";
+  option (msg_meta).description = "A container of flows with associated properties to be updated without affecting the transmit state";
 
-  message PropertyName {
+  message PropertyNames {
     enum Enum {
       unspecified = 0;
       rate = 1;
       size = 2;
     }
   }
-  PropertyName.Enum property_name = 1 [
-    (fld_meta).description = "Flow property to be updated without affecting the transmit state"
+  repeated PropertyNames.Enum property_names = 1 [
+    (fld_meta).description = "Flow properties to be updated without affecting the transmit state"
   ];
 
   repeated Flow flows = 2 [

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -74,18 +74,17 @@ components:
           enum: [start, stop]
 
     Flows.Update:
-      description: A container of flows with associated properties to be updated without affecting the transmit state
+      description: A container of flows with associated property to be updated without affecting the transmit state
       type: object
-      required: [property_names]
+      required: [property_name, flows]
       properties:
-        property_names:
-          description: Flow properties to be updated without affecting the transmit state 
+        property_name:
+          description: Flow property to be updated without affecting the transmit state 
           type: string
           enum: [rate, size]
         flows:
           description: >-
-            The list of configured flows for which given properties will be updated.
-            An empty or null list will cause the update to be applied to all configured flows.
+            The list of configured flows for which given property will be updated.
           type: array
           items:
             $ref: '#/components/schemas/Flow'

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -74,14 +74,16 @@ components:
           enum: [start, stop]
 
     Flows.Update:
-      description: A container of flows with associated property to be updated without affecting the transmit state
+      description: A container of flows with associated properties to be updated without affecting the transmit state
       type: object
-      required: [property_name, flows]
+      required: [property_names, flows]
       properties:
-        property_name:
-          description: Flow property to be updated without affecting the transmit state 
-          type: string
-          enum: [rate, size]
+        property_names:
+          description: Flow properties to be updated without affecting the transmit state
+          type: array
+          items: 
+            type: string
+            enum: [rate, size]
         flows:
           description: >-
             The list of configured flows for which given property will be updated.


### PR DESCRIPTION
Proposed changes:
1. Change _property_names_ to _property_name_ as a single property is updated at a time.
2. Make the argument _flows_ mandatory because with only _property_name_ enum value and nil/empty _flows_ the operation becomes NO-OP for any implementation, because the updated property value(s) are supposed to be contained in one or more of the flows in _flows_ array. 

[Please view the proposed changes using the redocly API viewer](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/otf_rate_fix/artifacts/openapi.yaml#operation/update_flows)