### PR TITLE
Dev min rate

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2722,29 +2722,34 @@ components:
             Packets per second.
           type: integer
           format: int64
+          minimum: 1
           default: 1000
         bps:
           description: |-
             Bits per second.
           type: integer
           format: int64
+          minimum: 672
           default: 1000000000
         kbps:
           description: |-
             Kilobits per second.
           type: integer
           format: int64
+          minimum: 1
           default: 1000000
         mbps:
           description: "Megabits per second. "
           type: integer
           format: int64
+          minimum: 1
           default: 1000
         gbps:
           description: |-
             Gigabits per second.
           type: integer
           format: int32
+          minimum: 1
           default: 1
         percentage:
           description: |-

--- a/flow/rate.yaml
+++ b/flow/rate.yaml
@@ -16,30 +16,35 @@ components:
             Packets per second.
           type: integer
           format: int64
+          minimum: 1
           default: 1000
         bps:
           description: >-
             Bits per second.
           type: integer
           format: int64
+          minimum: 672
           default: 1000000000
         kbps:
           description: >-
             Kilobits per second.
           type: integer
           format: int64
+          minimum: 1
           default: 1000000
         mbps:
           description: >-
             Megabits per second. 
           type: integer
           format: int64
+          minimum: 1
           default: 1000
         gbps:
           description: >-
             Gigabits per second.
           type: integer
           format: int32
+          minimum: 1
           default: 1
         percentage:
           description: >-


### PR DESCRIPTION
This PR is intended to set minimum values for Flow.Rate.

For,
a. pps, kbps, mbps, gbps: it should be 1 (as these are integer properties)
b. bps: it is set to bit equivalent of smallest supported packet size 64 
    [i.e. (64 [packet size] + 12 [signature] + 8 [pgid + sequence-id]) * 8 = 672]
c. percentage: no minimum (as it is of type number)

Changed model is available at [https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-min-rate/artifacts/openapi.yaml#operation/set_config](url)