### PR TITLE
Exposed MVP API for toggling protocol state

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -172,7 +172,7 @@ paths:
       tags: ['Control']
       operationId: set_protocol_state
       description: >-
-        Sets all configured protocols to intended state
+        Sets all configured protocols to `start` or `stop` state.
       requestBody:
         required: true
         content:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -167,6 +167,25 @@ paths:
         '500':
           $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
+  /control/protocols:
+    post:
+      tags: ['Control']
+      operationId: set_protocol_state
+      description: >-
+        Sets all configured protocols to intended state
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../control/control.yaml#/components/schemas/Protocol.State'
+      responses:
+        '200':
+          $ref: '../result/request.yaml#/components/responses/Success'
+        '400':
+          $ref: '../result/request.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /results/metrics:
     description: >-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -189,7 +189,7 @@ paths:
       - Control
       operationId: set_protocol_state
       description: |-
-        Sets all configured protocols to intended state
+        Sets all configured protocols to `start` or `stop` state.
       requestBody:
         required: true
         content:
@@ -3270,7 +3270,7 @@ components:
             $ref: '#/components/schemas/Ping'
     Protocol.State:
       description: |-
-        Sets all configured protocols to intended state
+        Sets all configured protocols to `start` or `stop` state.
       type: object
       required:
       - state

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -3156,7 +3156,7 @@ message PingRequest {
 }
 
 message ProtocolState {
-  option (msg_meta).description = "Sets all configured protocols to intended state";
+  option (msg_meta).description = "Sets all configured protocols to `start` or `stop` state.";
 
   message State {
     enum Enum {
@@ -12104,7 +12104,7 @@ service Openapi {
     option (rpc_meta).description = "API to send an IPv4 and/or IPv6 ICMP Echo Request(s) between endpoints. For each endpoint 1 ping packet will be sent and API shall wait for ping response to either be successful or timeout. The API wait timeout for each request is 300ms.";
   }
   rpc SetProtocolState(SetProtocolStateRequest) returns (SetProtocolStateResponse) {
-    option (rpc_meta).description = "Sets all configured protocols to intended state";
+    option (rpc_meta).description = "Sets all configured protocols to `start` or `stop` state.";
   }
   rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse) {
     option (rpc_meta).description = "Description missing in models";

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -125,3 +125,15 @@ components:
           type: array
           items:
             $ref: './ping.yaml#/components/schemas/Ping'
+
+    Protocol.State:
+      description: >-
+        Sets all configured protocols to intended state
+      type: object
+      required: [state]
+      properties:
+        state:
+          description: >-
+            Protocol specific states
+          type: string
+          enum: [start, stop]

--- a/control/control.yaml
+++ b/control/control.yaml
@@ -128,7 +128,7 @@ components:
 
     Protocol.State:
       description: >-
-        Sets all configured protocols to intended state
+        Sets all configured protocols to `start` or `stop` state.
       type: object
       required: [state]
       properties:


### PR DESCRIPTION
This should partially address https://github.com/open-traffic-generator/models/issues/151

[View the proposed changes using the redocly API viewer](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/protocol-state/artifacts/openapi.yaml)

Limitations:
- Currently protocol state toggling is not supported for subset of devices
- Currently the response only returns warning and error strings (the existing response will be extended to include `names` for which operation succeeded and failed)

Code should looks like

```python
import snappi
api = snappi.api(location='http://127.0.0.1:80')
config = api.config()
p1, p2 = config.ports.port(name='p1').port(name='p2')
d = config.devices.device(name='device', container_name=p1.name)[-1]
e = d.ethernet
e.name = 'ether'
e.mac = '00:01:00:00:00:01'
i4 = e.ipv4
i4.name = 'IPv4'
i4.address = '1.1.1.1'
i4.gateway = '1.1.1.2'
b4 = i4.bgpv4
b4.name = 'Bgpv4'
api.set_config(config)

# start protocol sessions
proto_state = api.protocol_state()
proto_state.state = proto_state.START
api.set_protocol_state(proto_state)

transmit_state = api.transmit_state()
transmit_state.state = transmit_state.START
api.set_transmit_state(transmit_state)
```

Closed https://github.com/open-traffic-generator/models/pull/152 as it was way behind HEAD.