### PR TITLE
Arp cache support

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -4878,11 +4878,11 @@ components:
             $ref: '#/components/schemas/Bgpv6.Metric'
         arp_entries:
           description: |-
-            Arp entries - for resolved & unresolved.
+            ARP entries - for resolved & unresolved ARP(s).
           $ref: '#/components/schemas/Arp.Entries.Response'
         nd_entries:
           description: |-
-            ND entries - for resolved & unresolved.
+            ND entries - for resolved & unresolved ND(s).
           $ref: '#/components/schemas/Nd.Entries.Response'
     Port.Metrics.Request:
       description: |-
@@ -5375,12 +5375,12 @@ components:
           type: integer
     Arp.Entries.Request:
       description: |-
-        The request to retrieve ARP entries per IPv4 interface.
+        The request to retrieve ARP entries for IPv4 interface(s).
       type: object
       properties:
         ipv4_names:
           description: |
-            The names of IPv4 interfaces for which ARP entries will be retrieved. If no interface names are specified then the result set will contain all ARP entries.
+            The names of IPv4 interfaces for which ARP entries will be retrieved. If no interface names are specified then the result set will contain all ARP entries for all available IPv4 interfaces.
 
             x-constraint:
             - /components/schemas/Device.Ipv4/properties/name
@@ -5391,7 +5391,7 @@ components:
           - /components/schemas/Device.Ipv4/properties/name
         column_names:
           description: |-
-            The list of column names that the returned result set will contain. If the list is empty then all columns will be returned. The column ipv4_name will always be present in the returned result set.
+            Name of the columns (as list), that will present in the returned result set. If the column names is empty then all columns will be returned. The column ipv4_name (the name of the IPv4 interface) will always be present in the returned result set.
           type: array
           items:
             type: string
@@ -5406,19 +5406,19 @@ components:
       properties:
         resolved:
           description: |-
-            Contains the ARP entries where link-layer address of the neighbor is already known.
+            Contains the ARP entries for which link-layer address (MAC) of the neighbor is already known.
           type: array
           items:
             $ref: '#/components/schemas/Arp.Entry'
         unresolved:
           description: |-
-            Contains the ARP entries where link-layer address learning of the neighbor is still pending.
+            Contains the ARP entries for which link-layer address (MAC) learning of the neighbor is still pending.
           type: array
           items:
             $ref: '#/components/schemas/Arp.Entry'
     Arp.Entry:
       description: |-
-        ARP entry. A per neighbor information for IPv4 interfaces, learned through ARP.
+        ARP entry. For an IPv4 interface, a neighbor MAC information as learned through ARP.
       type: object
       properties:
         ipv4_name:
@@ -5432,17 +5432,17 @@ components:
           format: ipv4
         link_layer_address:
           description: |-
-            The link-layer address of the neighbor node. For an unresolved ARP entry, value will be either empty or set to default MAC address.
+            The link-layer address (MAC) of the neighbor node. For an unresolved ARP entry, value will be either empty or set to default MAC address.
           type: string
           format: mac
     Nd.Entries.Request:
       description: |-
-        The request to retrieve Neighbor Discovery entries per IPv6 interface.
+        The request to retrieve Neighbor Discovery entries for IPv6 interface(s).
       type: object
       properties:
         ipv6_names:
           description: |
-            The names of IPv6 interfaces for which ND entries will be retrieved. If no interface names are specified then the result set will contain all ND entries.
+            The names of IPv6 interfaces for which ND entries will be retrieved. If no interface names are specified then the result set will contain all ND entries for all available IPv6 interfaces.
 
             x-constraint:
             - /components/schemas/Device.Ipv6/properties/name
@@ -5453,7 +5453,7 @@ components:
           - /components/schemas/Device.Ipv6/properties/name
         column_names:
           description: |-
-            The list of column names that the returned result set will contain. If the list is empty then all columns will be returned. The column ipv6_name will always be present in the returned result set.
+            Name of the columns (as list), that will present in the returned result set. If the column names is empty then all columns will be returned. The column ipv6_name (the name of the IPv6 interface) will always be present in the returned result set.
           type: array
           items:
             type: string
@@ -5468,19 +5468,19 @@ components:
       properties:
         resolved:
           description: |-
-            Contains the Neighbor Discovery entries where link-layer address of the neighbor is already known.
+            Contains the Neighbor Discovery entries for which link-layer address (MAC) of the neighbor is already known.
           type: array
           items:
             $ref: '#/components/schemas/Nd.Entry'
         unresolved:
           description: |-
-            Contains the Neighbor Discovery entries where link-layer address learning of the neighbor is still pending.
+            Contains the Neighbor Discovery entries for which link-layer address (MAC) learning of the neighbor is still pending.
           type: array
           items:
             $ref: '#/components/schemas/Nd.Entry'
     Nd.Entry:
       description: |-
-        Neighbor Discovery entry. A per neighbor information for IPv6 interfaces, learned through NDP.
+        Neighbor Discovery entry. For an IPv6 interface, a neighbor MAC information as learned through NDP.
       type: object
       properties:
         ipv6_name:
@@ -5494,7 +5494,7 @@ components:
           format: ipv6
         link_layer_address:
           description: |-
-            The link-layer address of the neighbor node. For an unresolved ND entry, value will be either empty or set to default MAC address.
+            The link-layer address (MAC) of the neighbor node. For an unresolved ND entry, value will be either empty or set to default MAC address.
           type: string
           format: mac
     State.Metrics:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -4434,11 +4434,11 @@ message MetricsResponse {
   ];
 
   optional ArpEntriesResponse arp_entries = 6 [
-    (fld_meta).description = "Arp entries - for resolved & unresolved."
+    (fld_meta).description = "ARP entries - for resolved & unresolved ARP(s)."
   ];
 
   optional NdEntriesResponse nd_entries = 7 [
-    (fld_meta).description = "ND entries - for resolved & unresolved."
+    (fld_meta).description = "ND entries - for resolved & unresolved ND(s)."
   ];
 }
 
@@ -4904,10 +4904,10 @@ message Bgpv6Metric {
 }
 
 message ArpEntriesRequest {
-  option (msg_meta).description = "The request to retrieve ARP entries per IPv4 interface.";
+  option (msg_meta).description = "The request to retrieve ARP entries for IPv4 interface(s).";
 
   repeated string ipv4_names = 1 [
-    (fld_meta).description = "The names of IPv4 interfaces for which ARP entries will be retrieved. If no interface names are specified then the result set will contain all ARP entries.\n\nx-constraint:\n- /components/schemas/Device.Ipv4/properties/name\n"
+    (fld_meta).description = "The names of IPv4 interfaces for which ARP entries will be retrieved. If no interface names are specified then the result set will contain all ARP entries for all available IPv4 interfaces.\n\nx-constraint:\n- /components/schemas/Device.Ipv4/properties/name\n"
   ];
 
   message ColumnNames {
@@ -4919,7 +4919,7 @@ message ArpEntriesRequest {
     }
   }
   repeated ColumnNames.Enum column_names = 2 [
-    (fld_meta).description = "The list of column names that the returned result set will contain. If the list is empty then all columns will be returned. The column ipv4_name will always be present in the returned result set."
+    (fld_meta).description = "Name of the columns (as list), that will present in the returned result set. If the column names is empty then all columns will be returned. The column ipv4_name (the name of the IPv4 interface) will always be present in the returned result set."
   ];
 }
 
@@ -4927,16 +4927,16 @@ message ArpEntriesResponse {
   option (msg_meta).description = "A container for ARP entries.";
 
   repeated ArpEntry resolved = 1 [
-    (fld_meta).description = "Contains the ARP entries where link-layer address of the neighbor is already known."
+    (fld_meta).description = "Contains the ARP entries for which link-layer address (MAC) of the neighbor is already known."
   ];
 
   repeated ArpEntry unresolved = 2 [
-    (fld_meta).description = "Contains the ARP entries where link-layer address learning of the neighbor is still pending."
+    (fld_meta).description = "Contains the ARP entries for which link-layer address (MAC) learning of the neighbor is still pending."
   ];
 }
 
 message ArpEntry {
-  option (msg_meta).description = "ARP entry. A per neighbor information for IPv4 interfaces, learned through ARP.";
+  option (msg_meta).description = "ARP entry. For an IPv4 interface, a neighbor MAC information as learned through ARP.";
 
   optional string ipv4_name = 1 [
     (fld_meta).description = "The name of the IPv4 interface."
@@ -4947,15 +4947,15 @@ message ArpEntry {
   ];
 
   optional string link_layer_address = 3 [
-    (fld_meta).description = "The link-layer address of the neighbor node. For an unresolved ARP entry, value will be either empty or set to default MAC address."
+    (fld_meta).description = "The link-layer address (MAC) of the neighbor node. For an unresolved ARP entry, value will be either empty or set to default MAC address."
   ];
 }
 
 message NdEntriesRequest {
-  option (msg_meta).description = "The request to retrieve Neighbor Discovery entries per IPv6 interface.";
+  option (msg_meta).description = "The request to retrieve Neighbor Discovery entries for IPv6 interface(s).";
 
   repeated string ipv6_names = 1 [
-    (fld_meta).description = "The names of IPv6 interfaces for which ND entries will be retrieved. If no interface names are specified then the result set will contain all ND entries.\n\nx-constraint:\n- /components/schemas/Device.Ipv6/properties/name\n"
+    (fld_meta).description = "The names of IPv6 interfaces for which ND entries will be retrieved. If no interface names are specified then the result set will contain all ND entries for all available IPv6 interfaces.\n\nx-constraint:\n- /components/schemas/Device.Ipv6/properties/name\n"
   ];
 
   message ColumnNames {
@@ -4967,7 +4967,7 @@ message NdEntriesRequest {
     }
   }
   repeated ColumnNames.Enum column_names = 2 [
-    (fld_meta).description = "The list of column names that the returned result set will contain. If the list is empty then all columns will be returned. The column ipv6_name will always be present in the returned result set."
+    (fld_meta).description = "Name of the columns (as list), that will present in the returned result set. If the column names is empty then all columns will be returned. The column ipv6_name (the name of the IPv6 interface) will always be present in the returned result set."
   ];
 }
 
@@ -4975,16 +4975,16 @@ message NdEntriesResponse {
   option (msg_meta).description = "A container for Neighbor Discovery entries.";
 
   repeated NdEntry resolved = 1 [
-    (fld_meta).description = "Contains the Neighbor Discovery entries where link-layer address of the neighbor is already known."
+    (fld_meta).description = "Contains the Neighbor Discovery entries for which link-layer address (MAC) of the neighbor is already known."
   ];
 
   repeated NdEntry unresolved = 2 [
-    (fld_meta).description = "Contains the Neighbor Discovery entries where link-layer address learning of the neighbor is still pending."
+    (fld_meta).description = "Contains the Neighbor Discovery entries for which link-layer address (MAC) learning of the neighbor is still pending."
   ];
 }
 
 message NdEntry {
-  option (msg_meta).description = "Neighbor Discovery entry. A per neighbor information for IPv6 interfaces, learned through NDP.";
+  option (msg_meta).description = "Neighbor Discovery entry. For an IPv6 interface, a neighbor MAC information as learned through NDP.";
 
   optional string ipv6_name = 1 [
     (fld_meta).description = "The name of the IPv6 interface."
@@ -4995,7 +4995,7 @@ message NdEntry {
   ];
 
   optional string link_layer_address = 3 [
-    (fld_meta).description = "The link-layer address of the neighbor node. For an unresolved ND entry, value will be either empty or set to default MAC address."
+    (fld_meta).description = "The link-layer address (MAC) of the neighbor node. For an unresolved ND entry, value will be either empty or set to default MAC address."
   ];
 }
 

--- a/result/arp.yaml
+++ b/result/arp.yaml
@@ -24,31 +24,50 @@ components:
           description: >-
             The list of column names that the returned result set will contain.
             If the list is empty then all columns will be returned.
-            The column interface_name will always be present in the returned result set.
+            The column ipv4_name will always be present in the returned result set.
           type: array
           items:
             type: string
             enum:
-              - interface_name
-              - ip_address
+              - ipv4_name
+              - neighbor_ip
               - link_layer_address
+
+    Arp.Entries.Response:
+      description: >-
+        A container for ARP entries.
+      type: object
+      properties:
+        resolved:
+          description: >-
+            Contains the ARP entries where link-layer address of the neighbor is already known.
+          type: array
+          items:
+            $ref: './arp.yaml#/components/schemas/Arp.Entry'
+        unresolved:
+          description: >-
+            Contains the ARP entries where link-layer address learning of the neighbor is still pending.
+          type: array
+          items:
+            $ref: './arp.yaml#/components/schemas/Arp.Entry'
 
     Arp.Entry:
       description: >-
         ARP entry. A per neighbor information for IPv4 interfaces, learned through ARP.
       type: object
       properties:
-        interface_name:
+        ipv4_name:
           description: >-
-            The name of the interface.
+            The name of the IPv4 interface.
           type: string
-        ip_address:
+        neighbor_ip:
           description: >-
-            The IPv4 address of the neighbour node.
+            The IPv4 address of the neighbor node.
           type: string
           format: ipv4
         link_layer_address:
           description: >-
             The link-layer address of the neighbor node.
+            For an unresolved ARP entry, value will be either empty or set to default MAC address.
           type: string
           format: mac

--- a/result/arp.yaml
+++ b/result/arp.yaml
@@ -8,13 +8,13 @@ components:
   schemas:
     Arp.Entries.Request:
       description: >-
-        The request to retrieve ARP entries per IPv4 interface.
+        The request to retrieve ARP entries for IPv4 interface(s).
       type: object
       properties:
         ipv4_names:
           description: >-
             The names of IPv4 interfaces for which ARP entries will be retrieved.
-            If no interface names are specified then the result set will contain all ARP entries.
+            If no interface names are specified then the result set will contain all ARP entries for all available IPv4 interfaces.
           type: array
           items:
             type: string
@@ -22,9 +22,9 @@ components:
             - "/components/schemas/Device.Ipv4/properties/name"
         column_names:
           description: >-
-            The list of column names that the returned result set will contain.
-            If the list is empty then all columns will be returned.
-            The column ipv4_name will always be present in the returned result set.
+            Name of the columns (as list), that will present in the returned result set.
+            If the column names is empty then all columns will be returned.
+            The column ipv4_name (the name of the IPv4 interface) will always be present in the returned result set.
           type: array
           items:
             type: string
@@ -40,20 +40,20 @@ components:
       properties:
         resolved:
           description: >-
-            Contains the ARP entries where link-layer address of the neighbor is already known.
+            Contains the ARP entries for which link-layer address (MAC) of the neighbor is already known.
           type: array
           items:
             $ref: './arp.yaml#/components/schemas/Arp.Entry'
         unresolved:
           description: >-
-            Contains the ARP entries where link-layer address learning of the neighbor is still pending.
+            Contains the ARP entries for which link-layer address (MAC) learning of the neighbor is still pending.
           type: array
           items:
             $ref: './arp.yaml#/components/schemas/Arp.Entry'
 
     Arp.Entry:
       description: >-
-        ARP entry. A per neighbor information for IPv4 interfaces, learned through ARP.
+        ARP entry. For an IPv4 interface, a neighbor MAC information as learned through ARP.
       type: object
       properties:
         ipv4_name:
@@ -67,7 +67,7 @@ components:
           format: ipv4
         link_layer_address:
           description: >-
-            The link-layer address of the neighbor node.
+            The link-layer address (MAC) of the neighbor node.
             For an unresolved ARP entry, value will be either empty or set to default MAC address.
           type: string
           format: mac

--- a/result/arp.yaml
+++ b/result/arp.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+
+info:
+  title: ARP table models
+  version: ^0.0.0
+
+components:
+  schemas:
+    Arp.Entries.Request:
+      description: >-
+        The request to retrieve ARP entries per IPv4 interface.
+      type: object
+      properties:
+        ipv4_names:
+          description: >-
+            The names of IPv4 interfaces for which ARP entries will be retrieved.
+            If no interface names are specified then the result set will contain all ARP entries.
+          type: array
+          items:
+            type: string
+          x-constraint:
+            - "/components/schemas/Device.Ipv4/properties/name"
+        column_names:
+          description: >-
+            The list of column names that the returned result set will contain.
+            If the list is empty then all columns will be returned.
+            The column interface_name will always be present in the returned result set.
+          type: array
+          items:
+            type: string
+            enum:
+              - interface_name
+              - ip_address
+              - link_layer_address
+
+    Arp.Entry:
+      description: >-
+        ARP entry. A per neighbor information for IPv4 interfaces, learned through ARP.
+      type: object
+      properties:
+        interface_name:
+          description: >-
+            The name of the interface.
+          type: string
+        ip_address:
+          description: >-
+            The IPv4 address of the neighbour node.
+          type: string
+          format: ipv4
+        link_layer_address:
+          description: >-
+            The link-layer address of the neighbor node.
+          type: string
+          format: mac

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -12,6 +12,8 @@ components:
           - flow
           - bgpv4
           - bgpv6
+          - arp
+          - nd
           default: port
         port:
           $ref: './port.yaml#/components/schemas/Port.Metrics.Request'
@@ -21,6 +23,10 @@ components:
           $ref: './bgpv4.yaml#/components/schemas/Bgpv4.Metrics.Request'
         bgpv6:
           $ref: './bgpv6.yaml#/components/schemas/Bgpv6.Metrics.Request'
+        arp:
+          $ref: './arp.yaml#/components/schemas/Arp.Entries.Request'
+        nd:
+          $ref: './nd.yaml#/components/schemas/Nd.Entries.Request'
 
     Metrics.Response:
       description: >-
@@ -34,6 +40,8 @@ components:
           - port_metrics
           - bgpv4_metrics
           - bgpv6_metrics
+          - arp_entries
+          - nd_entries
           default: port_metrics
         port_metrics:
           type: array
@@ -51,3 +59,11 @@ components:
           type: array
           items:
             $ref: './bgpv6.yaml#/components/schemas/Bgpv6.Metric'
+        arp_entries:
+          type: array
+          items:
+            $ref: './arp.yaml#/components/schemas/Arp.Entry'
+        nd_entries:
+          type: array
+          items:
+            $ref: './nd.yaml#/components/schemas/Nd.Entry'

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -61,9 +61,9 @@ components:
             $ref: './bgpv6.yaml#/components/schemas/Bgpv6.Metric'
         arp_entries:
           description: >-
-            Arp entries - for resolved & unresolved.
+            ARP entries - for resolved & unresolved ARP(s).
           $ref: './arp.yaml#/components/schemas/Arp.Entries.Response'
         nd_entries:
           description: >-
-            ND entries - for resolved & unresolved.
+            ND entries - for resolved & unresolved ND(s).
           $ref: './nd.yaml#/components/schemas/Nd.Entries.Response'

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -60,10 +60,10 @@ components:
           items:
             $ref: './bgpv6.yaml#/components/schemas/Bgpv6.Metric'
         arp_entries:
-          type: array
-          items:
-            $ref: './arp.yaml#/components/schemas/Arp.Entry'
+          description: >-
+            Arp entries - for resolved & unresolved.
+          $ref: './arp.yaml#/components/schemas/Arp.Entries.Response'
         nd_entries:
-          type: array
-          items:
-            $ref: './nd.yaml#/components/schemas/Nd.Entry'
+          description: >-
+            ND entries - for resolved & unresolved.
+          $ref: './nd.yaml#/components/schemas/Nd.Entries.Response'

--- a/result/nd.yaml
+++ b/result/nd.yaml
@@ -8,13 +8,13 @@ components:
   schemas:
     Nd.Entries.Request:
       description: >-
-        The request to retrieve Neighbor Discovery entries per IPv6 interface.
+        The request to retrieve Neighbor Discovery entries for IPv6 interface(s).
       type: object
       properties:
         ipv6_names:
           description: >-
             The names of IPv6 interfaces for which ND entries will be retrieved.
-            If no interface names are specified then the result set will contain all ND entries.
+            If no interface names are specified then the result set will contain all ND entries for all available IPv6 interfaces.
           type: array
           items:
             type: string
@@ -22,9 +22,9 @@ components:
             - "/components/schemas/Device.Ipv6/properties/name"
         column_names:
           description: >-
-            The list of column names that the returned result set will contain.
-            If the list is empty then all columns will be returned.
-            The column ipv6_name will always be present in the returned result set.
+            Name of the columns (as list), that will present in the returned result set.
+            If the column names is empty then all columns will be returned.
+            The column ipv6_name (the name of the IPv6 interface) will always be present in the returned result set.
           type: array
           items:
             type: string
@@ -40,20 +40,20 @@ components:
       properties:
         resolved:
           description: >-
-            Contains the Neighbor Discovery entries where link-layer address of the neighbor is already known.
+            Contains the Neighbor Discovery entries for which link-layer address (MAC) of the neighbor is already known.
           type: array
           items:
             $ref: './nd.yaml#/components/schemas/Nd.Entry'
         unresolved:
           description: >-
-            Contains the Neighbor Discovery entries where link-layer address learning of the neighbor is still pending.
+            Contains the Neighbor Discovery entries for which link-layer address (MAC) learning of the neighbor is still pending.
           type: array
           items:
             $ref: './nd.yaml#/components/schemas/Nd.Entry'
 
     Nd.Entry:
       description: >-
-        Neighbor Discovery entry. A per neighbor information for IPv6 interfaces, learned through NDP.
+        Neighbor Discovery entry. For an IPv6 interface, a neighbor MAC information as learned through NDP.
       type: object
       properties:
         ipv6_name:
@@ -67,7 +67,7 @@ components:
           format: ipv6
         link_layer_address:
           description: >-
-            The link-layer address of the neighbor node.
+            The link-layer address (MAC) of the neighbor node.
             For an unresolved ND entry, value will be either empty or set to default MAC address.
           type: string
           format: mac

--- a/result/nd.yaml
+++ b/result/nd.yaml
@@ -24,31 +24,50 @@ components:
           description: >-
             The list of column names that the returned result set will contain.
             If the list is empty then all columns will be returned.
-            The column interface_name will always be present in the returned result set.
+            The column ipv6_name will always be present in the returned result set.
           type: array
           items:
             type: string
             enum:
-              - interface_name
-              - ip_address
+              - ipv6_name
+              - neighbor_ip
               - link_layer_address
+
+    Nd.Entries.Response:
+      description: >-
+        A container for Neighbor Discovery entries.
+      type: object
+      properties:
+        resolved:
+          description: >-
+            Contains the Neighbor Discovery entries where link-layer address of the neighbor is already known.
+          type: array
+          items:
+            $ref: './nd.yaml#/components/schemas/Nd.Entry'
+        unresolved:
+          description: >-
+            Contains the Neighbor Discovery entries where link-layer address learning of the neighbor is still pending.
+          type: array
+          items:
+            $ref: './nd.yaml#/components/schemas/Nd.Entry'
 
     Nd.Entry:
       description: >-
         Neighbor Discovery entry. A per neighbor information for IPv6 interfaces, learned through NDP.
       type: object
       properties:
-        interface_name:
+        ipv6_name:
           description: >-
-            The name of the interface.
+            The name of the IPv6 interface.
           type: string
-        ip_address:
+        neighbor_ip:
           description: >-
-            The IPv6  address of the neighbour node.
+            The IPv6 address of the neighbor node.
           type: string
           format: ipv6
         link_layer_address:
           description: >-
             The link-layer address of the neighbor node.
+            For an unresolved ND entry, value will be either empty or set to default MAC address.
           type: string
           format: mac

--- a/result/nd.yaml
+++ b/result/nd.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+
+info:
+  title: Neighbor Discovery table models
+  version: ^0.0.0
+
+components:
+  schemas:
+    Nd.Entries.Request:
+      description: >-
+        The request to retrieve Neighbor Discovery entries per IPv6 interface.
+      type: object
+      properties:
+        ipv6_names:
+          description: >-
+            The names of IPv6 interfaces for which ND entries will be retrieved.
+            If no interface names are specified then the result set will contain all ND entries.
+          type: array
+          items:
+            type: string
+          x-constraint:
+            - "/components/schemas/Device.Ipv6/properties/name"
+        column_names:
+          description: >-
+            The list of column names that the returned result set will contain.
+            If the list is empty then all columns will be returned.
+            The column interface_name will always be present in the returned result set.
+          type: array
+          items:
+            type: string
+            enum:
+              - interface_name
+              - ip_address
+              - link_layer_address
+
+    Nd.Entry:
+      description: >-
+        Neighbor Discovery entry. A per neighbor information for IPv6 interfaces, learned through NDP.
+      type: object
+      properties:
+        interface_name:
+          description: >-
+            The name of the interface.
+          type: string
+        ip_address:
+          description: >-
+            The IPv6  address of the neighbour node.
+          type: string
+          format: ipv6
+        link_layer_address:
+          description: >-
+            The link-layer address of the neighbor node.
+          type: string
+          format: mac


### PR DESCRIPTION
[Please view the proposed changes using the redocly API viewer](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/arp_cache_support/artifacts/openapi.yaml)

The proposed change has the support of retrieving ARP cache and Neighbor Discovery entries to make the same information available through gNMI interface (through the gNMI server) to a user.

The result set has been intentionally subdivided into two sub-groups, for resolved and unresolved entries, instead of adding one more column with resolved / unresolved status.  This approach has the benefit of not processing the entire result to know if there is any un-resolved entry and need a re-query before moving to the next step of the test. Instead, it is less overhead to look or zero entry in the unresolved group.

The column set for resolved / unresolved items is intentionally made identical, for easier processing, though the link-layer address column is always un-used for the unresolved group and can be removed.

Assuming the number of columns is limited (3 or 2 for the unresolved group), the column filter can also be removed from the request configuration (and also remove the link-layer address column from unresolved entries).