### PR TITLE
Reverting back LAG ethernet config

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -404,11 +404,12 @@ components:
       - name
     Lag.Port:
       description: |-
-        The container for a port and LAG protocol settings.
+        The container for a port's ethernet interface and LAG protocol settings
       type: object
       required:
       - port_name
       - protocol
+      - ethernet
       properties:
         port_name:
           description: "The name of a port object that will be part of the LAG. \n\
@@ -418,6 +419,8 @@ components:
           - /components/schemas/Port/properties/name
         protocol:
           $ref: '#/components/schemas/Lag.Protocol'
+        ethernet:
+          $ref: '#/components/schemas/Device.EthernetBase'
     Lag.Protocol:
       type: object
       properties:
@@ -516,6 +519,250 @@ components:
           - passive
           - active
           default: active
+    Device.EthernetBase:
+      description: |-
+        Base Ethernet interface.
+      type: object
+      required:
+      - mac
+      - name
+      properties:
+        mac:
+          description: |-
+            Media Access Control address.
+          type: string
+          format: mac
+        mtu:
+          description: |-
+            Maximum Transmission Unit.
+          type: integer
+          minimum: 0
+          maximum: 65535
+          default: 1500
+        vlans:
+          description: |-
+            List of VLANs
+          type: array
+          items:
+            $ref: '#/components/schemas/Device.Vlan'
+        name:
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+    Device.Ethernet:
+      description: |-
+        An Ethernet interface with IPv4 and IPv6 addresses.
+        Base Ethernet interface.
+      type: object
+      required:
+      - port_name
+      - mac
+      - name
+      properties:
+        port_name:
+          description: |
+            The unique name of a Port or a LAG that will emulate this interface.
+
+            x-constraint:
+            - /components/schemas/Port/properties/name
+            - /components/schemas/Lag/properties/name
+          type: string
+          x-constraint:
+          - /components/schemas/Port/properties/name
+          - /components/schemas/Lag/properties/name
+        ipv4_addresses:
+          description: "List of IPv4 addresses and their gateways. "
+          type: array
+          items:
+            $ref: '#/components/schemas/Device.Ipv4'
+        ipv6_addresses:
+          description: |-
+            List of global IPv6 addresses and their gateways.
+            The Link Local IPv6 address will be automatically generated.
+          type: array
+          items:
+            $ref: '#/components/schemas/Device.Ipv6'
+        mac:
+          description: |-
+            Media Access Control address.
+          type: string
+          format: mac
+        mtu:
+          description: |-
+            Maximum Transmission Unit.
+          type: integer
+          minimum: 0
+          maximum: 65535
+          default: 1500
+        vlans:
+          description: |-
+            List of VLANs
+          type: array
+          items:
+            $ref: '#/components/schemas/Device.Vlan'
+        name:
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+    Device.Vlan:
+      description: |-
+        Emulated VLAN protocol.
+      type: object
+      properties:
+        tpid:
+          description: |-
+            Tag protocol identifier
+          type: string
+          enum:
+          - x8100
+          - x88A8
+          - x9100
+          - x9200
+          - x9300
+          default: x8100
+        priority:
+          description: |-
+            Priority code point
+          type: integer
+          minimum: 0
+          maximum: 3
+          default: 0
+        id:
+          description: |-
+            VLAN identifier
+          type: integer
+          minimum: 0
+          maximum: 4095
+          default: 1
+        name:
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+      required:
+      - name
+    Device.Ipv4:
+      description: |-
+        An IPv4 interface with gateway
+        A base IPv4 interface.
+      type: object
+      required:
+      - gateway
+      - address
+      - name
+      properties:
+        gateway:
+          description: |-
+            The IPv4 address of the gateway
+          type: string
+          format: ipv4
+        address:
+          description: |-
+            The IPv4 address
+          type: string
+          format: ipv4
+        prefix:
+          description: |-
+            The prefix of the IPv4 address.
+          type: integer
+          minimum: 1
+          maximum: 32
+          default: 24
+        name:
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+    Device.Ipv4Loopback:
+      description: |-
+        An IPv4 Loopback interface.
+      type: object
+      required:
+      - eth_name
+      - name
+      properties:
+        eth_name:
+          description: |
+            The unique name of the Ethernet interface behind which this Loopback  interface will be created.
+
+            x-constraint:
+            - /components/schemas/Device.Ethernet/properties/name
+          type: string
+          x-constraint:
+          - /components/schemas/Device.Ethernet/properties/name
+        address:
+          description: |-
+            The IPv4 Loopback address with prefix length of 32.
+          type: string
+          format: ipv4
+          default: 0.0.0.0
+        name:
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+    Device.Ipv6:
+      description: |-
+        Status: under-review
+        An IPv6 interface with gateway.
+        A base IPv6 interface.
+      type: object
+      required:
+      - gateway
+      - address
+      - name
+      properties:
+        gateway:
+          description: |-
+            The IPv6 gateway address.
+          type: string
+          format: ipv6
+          default: ::0
+        address:
+          description: |-
+            The IPv6 address.
+          type: string
+          format: ipv6
+        prefix:
+          description: |-
+            The network prefix.
+          type: integer
+          minimum: 1
+          maximum: 128
+          default: 64
+        name:
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+      x-status: under-review
+    Device.Ipv6Loopback:
+      description: |-
+        An IPv6 Loopback interface
+      type: object
+      required:
+      - eth_name
+      - name
+      properties:
+        eth_name:
+          description: "The unique name of the Ethernet interface behind which this\
+            \ Loopback \n interface will be created.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
+          type: string
+          x-constraint:
+          - /components/schemas/Device.Ethernet/properties/name
+        address:
+          description: |-
+            The IPv6 Loopback address with prefix length of 128.
+          type: string
+          format: ipv6
+          default: ::0
+        name:
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
     Layer1:
       description: |-
         A container for layer1 settings.
@@ -947,219 +1194,6 @@ components:
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
       required:
       - name
-    Device.Ethernet:
-      description: |-
-        An Ethernet interface with IPv4 and IPv6 addresses.
-        Base Ethernet interface.
-      type: object
-      required:
-      - port_name
-      - mac
-      - name
-      properties:
-        port_name:
-          description: |
-            The unique name of a Port or a LAG that will emulate this interface.
-
-            x-constraint:
-            - /components/schemas/Port/properties/name
-            - /components/schemas/Lag/properties/name
-          type: string
-          x-constraint:
-          - /components/schemas/Port/properties/name
-          - /components/schemas/Lag/properties/name
-        ipv4_addresses:
-          description: "List of IPv4 addresses and their gateways. "
-          type: array
-          items:
-            $ref: '#/components/schemas/Device.Ipv4'
-        ipv6_addresses:
-          description: |-
-            List of global IPv6 addresses and their gateways.
-            The Link Local IPv6 address will be automatically generated.
-          type: array
-          items:
-            $ref: '#/components/schemas/Device.Ipv6'
-        mac:
-          description: |-
-            Media Access Control address.
-          type: string
-          format: mac
-        mtu:
-          description: |-
-            Maximum Transmission Unit.
-          type: integer
-          minimum: 0
-          maximum: 65535
-          default: 1500
-        vlans:
-          description: |-
-            List of VLANs
-          type: array
-          items:
-            $ref: '#/components/schemas/Device.Vlan'
-        name:
-          description: |-
-            Globally unique name of an object. It also serves as the primary key for arrays of objects.
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-    Device.Vlan:
-      description: |-
-        Emulated VLAN protocol.
-      type: object
-      properties:
-        tpid:
-          description: |-
-            Tag protocol identifier
-          type: string
-          enum:
-          - x8100
-          - x88A8
-          - x9100
-          - x9200
-          - x9300
-          default: x8100
-        priority:
-          description: |-
-            Priority code point
-          type: integer
-          minimum: 0
-          maximum: 3
-          default: 0
-        id:
-          description: |-
-            VLAN identifier
-          type: integer
-          minimum: 0
-          maximum: 4095
-          default: 1
-        name:
-          description: |-
-            Globally unique name of an object. It also serves as the primary key for arrays of objects.
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-      required:
-      - name
-    Device.Ipv4:
-      description: |-
-        An IPv4 interface with gateway
-        A base IPv4 interface.
-      type: object
-      required:
-      - gateway
-      - address
-      - name
-      properties:
-        gateway:
-          description: |-
-            The IPv4 address of the gateway
-          type: string
-          format: ipv4
-        address:
-          description: |-
-            The IPv4 address
-          type: string
-          format: ipv4
-        prefix:
-          description: |-
-            The prefix of the IPv4 address.
-          type: integer
-          minimum: 1
-          maximum: 32
-          default: 24
-        name:
-          description: |-
-            Globally unique name of an object. It also serves as the primary key for arrays of objects.
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-    Device.Ipv4Loopback:
-      description: |-
-        An IPv4 Loopback interface.
-      type: object
-      required:
-      - eth_name
-      - name
-      properties:
-        eth_name:
-          description: |
-            The unique name of the Ethernet interface behind which this Loopback  interface will be created.
-
-            x-constraint:
-            - /components/schemas/Device.Ethernet/properties/name
-          type: string
-          x-constraint:
-          - /components/schemas/Device.Ethernet/properties/name
-        address:
-          description: |-
-            The IPv4 Loopback address with prefix length of 32.
-          type: string
-          format: ipv4
-          default: 0.0.0.0
-        name:
-          description: |-
-            Globally unique name of an object. It also serves as the primary key for arrays of objects.
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-    Device.Ipv6:
-      description: |-
-        Status: under-review
-        An IPv6 interface with gateway.
-        A base IPv6 interface.
-      type: object
-      required:
-      - gateway
-      - address
-      - name
-      properties:
-        gateway:
-          description: |-
-            The IPv6 gateway address.
-          type: string
-          format: ipv6
-          default: ::0
-        address:
-          description: |-
-            The IPv6 address.
-          type: string
-          format: ipv6
-        prefix:
-          description: |-
-            The network prefix.
-          type: integer
-          minimum: 1
-          maximum: 128
-          default: 64
-        name:
-          description: |-
-            Globally unique name of an object. It also serves as the primary key for arrays of objects.
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-      x-status: under-review
-    Device.Ipv6Loopback:
-      description: |-
-        An IPv6 Loopback interface
-      type: object
-      required:
-      - eth_name
-      - name
-      properties:
-        eth_name:
-          description: "The unique name of the Ethernet interface behind which this\
-            \ Loopback \n interface will be created.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
-          type: string
-          x-constraint:
-          - /components/schemas/Device.Ethernet/properties/name
-        address:
-          description: |-
-            The IPv6 Loopback address with prefix length of 128.
-          type: string
-          format: ipv6
-          default: ::0
-        name:
-          description: |-
-            Globally unique name of an object. It also serves as the primary key for arrays of objects.
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
     Device.IsisRouter:
       x-status: under-review
       description: |-

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -115,13 +115,17 @@ message Lag {
 }
 
 message LagPort {
-  option (msg_meta).description = "The container for a port and LAG protocol settings.";
+  option (msg_meta).description = "The container for a port's ethernet interface and LAG protocol settings";
 
   string port_name = 1 [
     (fld_meta).description = "The name of a port object that will be part of the LAG. \n\nx-constraint:\n- /components/schemas/Port/properties/name\n"
   ];
 
   LagProtocol protocol = 2 [
+    (fld_meta).description = "Description missing in models"
+  ];
+
+  DeviceEthernetBase ethernet = 3 [
     (fld_meta).description = "Description missing in models"
   ];
 }
@@ -207,6 +211,170 @@ message LagLacp {
   optional ActorActivity.Enum actor_activity = 8 [
     (fld_meta).default = "ActorActivity.Enum.active",
     (fld_meta).description = "Sets the value of LACP actor activity as either passive or active\nPassive indicates the port's preference for not transmitting  LACPDUs unless its partner's control is Active\nActive indicates the port's preference to participate in the  protocol regardless of the partner's control value"
+  ];
+}
+
+message DeviceEthernetBase {
+  option (msg_meta).description = "Base Ethernet interface.";
+
+  string mac = 1 [
+    (fld_meta).description = "Media Access Control address."
+  ];
+
+  optional int32 mtu = 2 [
+    (fld_meta).default = "1500",
+    (fld_meta).description = "Maximum Transmission Unit."
+  ];
+
+  repeated DeviceVlan vlans = 3 [
+    (fld_meta).description = "List of VLANs"
+  ];
+
+  string name = 4 [
+    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
+  ];
+}
+
+message DeviceEthernet {
+  option (msg_meta).description = "An Ethernet interface with IPv4 and IPv6 addresses.\nBase Ethernet interface.";
+
+  string port_name = 1 [
+    (fld_meta).description = "The unique name of a Port or a LAG that will emulate this interface.\n\nx-constraint:\n- /components/schemas/Port/properties/name\n- /components/schemas/Lag/properties/name\n"
+  ];
+
+  repeated DeviceIpv4 ipv4_addresses = 2 [
+    (fld_meta).description = "List of IPv4 addresses and their gateways. "
+  ];
+
+  repeated DeviceIpv6 ipv6_addresses = 3 [
+    (fld_meta).description = "List of global IPv6 addresses and their gateways.\nThe Link Local IPv6 address will be automatically generated."
+  ];
+
+  string mac = 4 [
+    (fld_meta).description = "Media Access Control address."
+  ];
+
+  optional int32 mtu = 5 [
+    (fld_meta).default = "1500",
+    (fld_meta).description = "Maximum Transmission Unit."
+  ];
+
+  repeated DeviceVlan vlans = 6 [
+    (fld_meta).description = "List of VLANs"
+  ];
+
+  string name = 7 [
+    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
+  ];
+}
+
+message DeviceVlan {
+  option (msg_meta).description = "Emulated VLAN protocol.";
+
+  message Tpid {
+    enum Enum {
+      unspecified = 0;
+      x8100 = 1;
+      x88a8 = 2;
+      x9100 = 3;
+      x9200 = 4;
+      x9300 = 5;
+    }
+  }
+  optional Tpid.Enum tpid = 1 [
+    (fld_meta).default = "Tpid.Enum.x8100",
+    (fld_meta).description = "Tag protocol identifier"
+  ];
+
+  optional int32 priority = 2 [
+    (fld_meta).default = "0",
+    (fld_meta).description = "Priority code point"
+  ];
+
+  optional int32 id = 3 [
+    (fld_meta).default = "1",
+    (fld_meta).description = "VLAN identifier"
+  ];
+
+  string name = 4 [
+    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
+  ];
+}
+
+message DeviceIpv4 {
+  option (msg_meta).description = "An IPv4 interface with gateway\nA base IPv4 interface.";
+
+  string gateway = 1 [
+    (fld_meta).description = "The IPv4 address of the gateway"
+  ];
+
+  string address = 2 [
+    (fld_meta).description = "The IPv4 address"
+  ];
+
+  optional int32 prefix = 3 [
+    (fld_meta).default = "24",
+    (fld_meta).description = "The prefix of the IPv4 address."
+  ];
+
+  string name = 4 [
+    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
+  ];
+}
+
+message DeviceIpv4Loopback {
+  option (msg_meta).description = "An IPv4 Loopback interface.";
+
+  string eth_name = 1 [
+    (fld_meta).description = "The unique name of the Ethernet interface behind which this Loopback  interface will be created.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
+  ];
+
+  optional string address = 2 [
+    (fld_meta).default = "0.0.0.0",
+    (fld_meta).description = "The IPv4 Loopback address with prefix length of 32."
+  ];
+
+  string name = 3 [
+    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
+  ];
+}
+
+message DeviceIpv6 {
+  option (msg_meta).description = "Status: under-review\nAn IPv6 interface with gateway.\nA base IPv6 interface.";
+
+  string gateway = 1 [
+    (fld_meta).default = "::0",
+    (fld_meta).description = "The IPv6 gateway address."
+  ];
+
+  string address = 2 [
+    (fld_meta).description = "The IPv6 address."
+  ];
+
+  optional int32 prefix = 3 [
+    (fld_meta).default = "64",
+    (fld_meta).description = "The network prefix."
+  ];
+
+  string name = 4 [
+    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
+  ];
+}
+
+message DeviceIpv6Loopback {
+  option (msg_meta).description = "An IPv6 Loopback interface";
+
+  string eth_name = 1 [
+    (fld_meta).description = "The unique name of the Ethernet interface behind which this Loopback \n interface will be created.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
+  ];
+
+  optional string address = 2 [
+    (fld_meta).default = "::0",
+    (fld_meta).description = "The IPv6 Loopback address with prefix length of 128."
+  ];
+
+  string name = 3 [
+    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
   ];
 }
 
@@ -688,149 +856,6 @@ message Device {
   ];
 
   string name = 6 [
-    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
-  ];
-}
-
-message DeviceEthernet {
-  option (msg_meta).description = "An Ethernet interface with IPv4 and IPv6 addresses.\nBase Ethernet interface.";
-
-  string port_name = 1 [
-    (fld_meta).description = "The unique name of a Port or a LAG that will emulate this interface.\n\nx-constraint:\n- /components/schemas/Port/properties/name\n- /components/schemas/Lag/properties/name\n"
-  ];
-
-  repeated DeviceIpv4 ipv4_addresses = 2 [
-    (fld_meta).description = "List of IPv4 addresses and their gateways. "
-  ];
-
-  repeated DeviceIpv6 ipv6_addresses = 3 [
-    (fld_meta).description = "List of global IPv6 addresses and their gateways.\nThe Link Local IPv6 address will be automatically generated."
-  ];
-
-  string mac = 4 [
-    (fld_meta).description = "Media Access Control address."
-  ];
-
-  optional int32 mtu = 5 [
-    (fld_meta).default = "1500",
-    (fld_meta).description = "Maximum Transmission Unit."
-  ];
-
-  repeated DeviceVlan vlans = 6 [
-    (fld_meta).description = "List of VLANs"
-  ];
-
-  string name = 7 [
-    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
-  ];
-}
-
-message DeviceVlan {
-  option (msg_meta).description = "Emulated VLAN protocol.";
-
-  message Tpid {
-    enum Enum {
-      unspecified = 0;
-      x8100 = 1;
-      x88a8 = 2;
-      x9100 = 3;
-      x9200 = 4;
-      x9300 = 5;
-    }
-  }
-  optional Tpid.Enum tpid = 1 [
-    (fld_meta).default = "Tpid.Enum.x8100",
-    (fld_meta).description = "Tag protocol identifier"
-  ];
-
-  optional int32 priority = 2 [
-    (fld_meta).default = "0",
-    (fld_meta).description = "Priority code point"
-  ];
-
-  optional int32 id = 3 [
-    (fld_meta).default = "1",
-    (fld_meta).description = "VLAN identifier"
-  ];
-
-  string name = 4 [
-    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
-  ];
-}
-
-message DeviceIpv4 {
-  option (msg_meta).description = "An IPv4 interface with gateway\nA base IPv4 interface.";
-
-  string gateway = 1 [
-    (fld_meta).description = "The IPv4 address of the gateway"
-  ];
-
-  string address = 2 [
-    (fld_meta).description = "The IPv4 address"
-  ];
-
-  optional int32 prefix = 3 [
-    (fld_meta).default = "24",
-    (fld_meta).description = "The prefix of the IPv4 address."
-  ];
-
-  string name = 4 [
-    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
-  ];
-}
-
-message DeviceIpv4Loopback {
-  option (msg_meta).description = "An IPv4 Loopback interface.";
-
-  string eth_name = 1 [
-    (fld_meta).description = "The unique name of the Ethernet interface behind which this Loopback  interface will be created.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
-  ];
-
-  optional string address = 2 [
-    (fld_meta).default = "0.0.0.0",
-    (fld_meta).description = "The IPv4 Loopback address with prefix length of 32."
-  ];
-
-  string name = 3 [
-    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
-  ];
-}
-
-message DeviceIpv6 {
-  option (msg_meta).description = "Status: under-review\nAn IPv6 interface with gateway.\nA base IPv6 interface.";
-
-  string gateway = 1 [
-    (fld_meta).default = "::0",
-    (fld_meta).description = "The IPv6 gateway address."
-  ];
-
-  string address = 2 [
-    (fld_meta).description = "The IPv6 address."
-  ];
-
-  optional int32 prefix = 3 [
-    (fld_meta).default = "64",
-    (fld_meta).description = "The network prefix."
-  ];
-
-  string name = 4 [
-    (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
-  ];
-}
-
-message DeviceIpv6Loopback {
-  option (msg_meta).description = "An IPv6 Loopback interface";
-
-  string eth_name = 1 [
-    (fld_meta).description = "The unique name of the Ethernet interface behind which this Loopback \n interface will be created.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
-  ];
-
-  optional string address = 2 [
-    (fld_meta).default = "::0",
-    (fld_meta).description = "The IPv6 Loopback address with prefix length of 128."
-  ];
-
-  string name = 3 [
     (fld_meta).description = "Globally unique name of an object. It also serves as the primary key for arrays of objects."
   ];
 }

--- a/lag/lag.yaml
+++ b/lag/lag.yaml
@@ -14,9 +14,9 @@ components:
     
     Lag.Port:
       description: >-
-        The container for a port and LAG protocol settings.
+        The container for a port's ethernet interface and LAG protocol settings
       type: object
-      required: [port_name, protocol]
+      required: [port_name, protocol, ethernet]
       properties:
         port_name:
           description: >- 
@@ -26,6 +26,8 @@ components:
           - '/components/schemas/Port/properties/name'
         protocol:
           $ref: '#/components/schemas/Lag.Protocol'
+        ethernet:
+          $ref: '../device/ethernet.yaml#/components/schemas/Device.EthernetBase'
 
     Lag.Protocol:
       type: object


### PR DESCRIPTION
@SuryyaKrJana / @apratimmukherjee,
The use case referring to is if Ethernet mac and vlan needs to configured on a LAG interface.
recently in sonic we noticed a use case with vlan being configured on a port-channel

please advice if this is a valid scenario?