### PR TITLE
State retrieval support for IPv4 & IPv6 Neighbors (ARP & NDISC cache)

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -214,11 +214,11 @@ paths:
         '500':
           $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
-  /results/state:
+  /results/states:
     description: >-
-      State API
+      States API
     post:
-      tags: ['State']
+      tags: ['States']
       operationId: get_states
       requestBody:
         description: >-

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -215,16 +215,27 @@ paths:
           $ref: '../result/request.yaml#/components/responses/InternalServerError'
 
   /results/state:
+    description: >-
+      State API
     post:
-      tags: ['Metrics']
-      operationId: get_state_metrics
+      tags: ['State']
+      operationId: get_states
+      requestBody:
+        description: >-
+          Request to traffic generator for states of choice
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../result/states.yaml#/components/schemas/States.Request'
       responses:
         '200':
-          description: List of states
+          description: >-
+            Response from traffic generator for chosen states
           content:
             application/json:
               schema:
-                $ref: '../result/state.yaml#/components/schemas/State.Metrics'
+                $ref: '../result/states.yaml#/components/schemas/States.Response'
         '400':
           $ref: '../result/request.yaml#/components/responses/BadRequest'
         '500':
@@ -234,7 +245,7 @@ paths:
     description: >-
       Capture results API
     post:
-      tags: ['Metrics']
+      tags: ['Capture']
       operationId: get_capture
       requestBody:
         description: >-

--- a/api/info.yaml
+++ b/api/info.yaml
@@ -8,7 +8,7 @@ info:
     Contributions can be made in the following ways:
     - [open an issue](https://github.com/open-traffic-generator/models/issues) in the models repository
     - [fork the models repository](https://github.com/open-traffic-generator/models) and submit a PR
-  version: 0.6.6
+  version: 0.6.7
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -5644,12 +5644,12 @@ components:
             $ref: '#/components/schemas/Neighborsv6.State'
     Neighborsv4.States.Request:
       description: |-
-        The request to retrieve IPv4 Neighbors state (ARP cache entries) for device network interface(s).
+        The request to retrieve IPv4 Neighbor state (ARP cache entries) for device network interface(s).
       type: object
       properties:
-        interface_names:
+        ethernet_names:
           description: |
-            The names of device Ethernet interfaces for which Neighbors will be retrieved. If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.
+            The names of device Ethernet interfaces for which Neighbors will be retrieved. If no names are specified then the results will contain Neighbors for all Ethernet interfaces.
 
             x-constraint:
             - /components/schemas/Device.Ethernet/properties/name
@@ -5660,31 +5660,34 @@ components:
           - /components/schemas/Device.Ethernet/properties/name
     Neighborsv4.State:
       description: |-
-        IPv4 Neighbor states (ARP cache entry).
+        IPv4 Neighbor state (ARP cache entry).
       type: object
+      required:
+      - ethernet_name
+      - ipv4_address
       properties:
-        interface:
+        ethernet_name:
           description: |-
             The name of the device Ethernet interface associated with the neighbor.
           type: string
-        ip:
+        ipv4_address:
           description: |-
             The IPv4 address of the neighbor.
           type: string
           format: ipv4
         link_layer_address:
           description: |-
-            The link-layer address (MAC) of the neighbor. For an unresolved Neighbor entry value will be set to "00:00:00:00:00:00".
+            The link-layer address (MAC) of the neighbor.
           type: string
           format: mac
     Neighborsv6.States.Request:
       description: |-
-        The request to retrieve IPv6 Neighbors state (NDISC cache entries) for device network interface(s).
+        The request to retrieve IPv6 Neighbor state (NDISC cache entries) for device network interface(s).
       type: object
       properties:
-        interface_names:
+        ethernet_names:
           description: |
-            The names of device Ethernet interfaces for which Neighbors will be retrieved. If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.
+            The names of device Ethernet interfaces for which Neighbors will be retrieved. If no names are specified then the results will contain Neighbors for all Ethernet interfaces.
 
             x-constraint:
             - /components/schemas/Device.Ethernet/properties/name
@@ -5695,21 +5698,24 @@ components:
           - /components/schemas/Device.Ethernet/properties/name
     Neighborsv6.State:
       description: |-
-        IPv6 Neighbor states (NDISC cache entry).
+        IPv6 Neighbor state (NDISC cache entry).
       type: object
+      required:
+      - ethernet_name
+      - ipv6_address
       properties:
-        interface:
+        ethernet_name:
           description: |-
             The name of the device Ethernet interface associated with the neighbor.
           type: string
-        ip:
+        ipv6_address:
           description: |-
             The IPv6 address of the neighbor.
           type: string
           format: ipv6
         link_layer_address:
           description: |-
-            The link-layer address (MAC) of the neighbor. For an unresolved Neighbor entry value will be set to "00:00:00:00:00:00".
+            The link-layer address (MAC) of the neighbor.
           type: string
           format: mac
     Capture.Request:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -231,18 +231,28 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
   /results/state:
+    description: |-
+      State API
     post:
       tags:
-      - Metrics
-      operationId: get_state_metrics
+      - State
+      operationId: get_states
+      requestBody:
+        description: |-
+          Request to traffic generator for states of choice
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/States.Request'
       responses:
         '200':
           description: |-
-            List of states
+            Response from traffic generator for chosen states
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/State.Metrics'
+                $ref: '#/components/schemas/States.Response'
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -252,7 +262,7 @@ paths:
       Capture results API
     post:
       tags:
-      - Metrics
+      - Capture
       operationId: get_capture
       requestBody:
         description: |-
@@ -5598,45 +5608,110 @@ components:
           description: |-
             Number of Level 2 (L2) Link State Protocol Data Units (LSPs) received.
           type: integer
-    State.Metrics:
+    States.Request:
       description: |-
-        A container for the different types of states.
+        Request to traffic generator for states of choice
       type: object
       properties:
-        port_state:
+        choice:
+          type: string
+          enum:
+          - ipv4_neighbors
+          - ipv6_neighbors
+          default: ipv4_neighbors
+        ipv4_neighbors:
+          $ref: '#/components/schemas/Neighborsv4.States.Request'
+        ipv6_neighbors:
+          $ref: '#/components/schemas/Neighborsv6.States.Request'
+    States.Response:
+      description: |-
+        Response containing chosen traffic generator states
+      type: object
+      properties:
+        choice:
+          type: string
+          enum:
+          - ipv4_neighbors
+          - ipv6_neighbors
+          default: ipv4_neighbors
+        ipv4_neighbors:
           type: array
           items:
-            $ref: '#/components/schemas/Port.State'
-        flow_state:
+            $ref: '#/components/schemas/Neighborsv4.State'
+        ipv6_neighbors:
           type: array
           items:
-            $ref: '#/components/schemas/Flow.State'
-    Port.State:
+            $ref: '#/components/schemas/Neighborsv6.State'
+    Neighborsv4.States.Request:
+      description: |-
+        The request to retrieve IPv4 Neighbors state (ARP cache entries) for device network interface(s).
       type: object
       properties:
-        name:
-          type: string
-        link:
-          type: string
-          enum:
-          - up
-          - down
-        capture:
-          type: string
-          enum:
-          - started
-          - stopped
-    Flow.State:
+        interface_names:
+          description: |
+            The names of device Ethernet interfaces for which Neighbors will be retrieved. If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.
+
+            x-constraint:
+            - /components/schemas/Device.Ethernet/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Device.Ethernet/properties/name
+    Neighborsv4.State:
+      description: |-
+        IPv4 Neighbor states (ARP cache entry).
       type: object
       properties:
-        name:
+        interface:
+          description: |-
+            The name of the device Ethernet interface associated with the neighbor.
           type: string
-        transmit:
+        ip:
+          description: |-
+            The IPv4 address of the neighbor.
           type: string
-          enum:
-          - started
-          - stopped
-          - paused
+          format: ipv4
+        link_layer_address:
+          description: |-
+            The link-layer address (MAC) of the neighbor. For an unresolved Neighbor entry value will be set to "00:00:00:00:00:00".
+          type: string
+          format: mac
+    Neighborsv6.States.Request:
+      description: |-
+        The request to retrieve IPv6 Neighbors state (NDISC cache entries) for device network interface(s).
+      type: object
+      properties:
+        interface_names:
+          description: |
+            The names of device Ethernet interfaces for which Neighbors will be retrieved. If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.
+
+            x-constraint:
+            - /components/schemas/Device.Ethernet/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Device.Ethernet/properties/name
+    Neighborsv6.State:
+      description: |-
+        IPv6 Neighbor states (NDISC cache entry).
+      type: object
+      properties:
+        interface:
+          description: |-
+            The name of the device Ethernet interface associated with the neighbor.
+          type: string
+        ip:
+          description: |-
+            The IPv6 address of the neighbor.
+          type: string
+          format: ipv6
+        link_layer_address:
+          description: |-
+            The link-layer address (MAC) of the neighbor. For an unresolved Neighbor entry value will be set to "00:00:00:00:00:00".
+          type: string
+          format: mac
     Capture.Request:
       description: |-
         The capture result request to the traffic generator. Stops the port capture on the port_name and returns the capture.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5134,50 +5134,50 @@ message StatesResponse {
 }
 
 message Neighborsv4StatesRequest {
-  option (msg_meta).description = "The request to retrieve IPv4 Neighbors state (ARP cache entries) for device network interface(s).";
+  option (msg_meta).description = "The request to retrieve IPv4 Neighbor state (ARP cache entries) for device network interface(s).";
 
-  repeated string interface_names = 1 [
-    (fld_meta).description = "The names of device Ethernet interfaces for which Neighbors will be retrieved. If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
+  repeated string ethernet_names = 1 [
+    (fld_meta).description = "The names of device Ethernet interfaces for which Neighbors will be retrieved. If no names are specified then the results will contain Neighbors for all Ethernet interfaces.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
   ];
 }
 
 message Neighborsv4State {
-  option (msg_meta).description = "IPv4 Neighbor states (ARP cache entry).";
+  option (msg_meta).description = "IPv4 Neighbor state (ARP cache entry).";
 
-  optional string interface = 1 [
+  string ethernet_name = 1 [
     (fld_meta).description = "The name of the device Ethernet interface associated with the neighbor."
   ];
 
-  optional string ip = 2 [
+  string ipv4_address = 2 [
     (fld_meta).description = "The IPv4 address of the neighbor."
   ];
 
   optional string link_layer_address = 3 [
-    (fld_meta).description = "The link-layer address (MAC) of the neighbor. For an unresolved Neighbor entry value will be set to 00:00:00:00:00:00."
+    (fld_meta).description = "The link-layer address (MAC) of the neighbor."
   ];
 }
 
 message Neighborsv6StatesRequest {
-  option (msg_meta).description = "The request to retrieve IPv6 Neighbors state (NDISC cache entries) for device network interface(s).";
+  option (msg_meta).description = "The request to retrieve IPv6 Neighbor state (NDISC cache entries) for device network interface(s).";
 
-  repeated string interface_names = 1 [
-    (fld_meta).description = "The names of device Ethernet interfaces for which Neighbors will be retrieved. If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
+  repeated string ethernet_names = 1 [
+    (fld_meta).description = "The names of device Ethernet interfaces for which Neighbors will be retrieved. If no names are specified then the results will contain Neighbors for all Ethernet interfaces.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
   ];
 }
 
 message Neighborsv6State {
-  option (msg_meta).description = "IPv6 Neighbor states (NDISC cache entry).";
+  option (msg_meta).description = "IPv6 Neighbor state (NDISC cache entry).";
 
-  optional string interface = 1 [
+  string ethernet_name = 1 [
     (fld_meta).description = "The name of the device Ethernet interface associated with the neighbor."
   ];
 
-  optional string ip = 2 [
+  string ipv6_address = 2 [
     (fld_meta).description = "The IPv6 address of the neighbor."
   ];
 
   optional string link_layer_address = 3 [
-    (fld_meta).description = "The link-layer address (MAC) of the neighbor. For an unresolved Neighbor entry value will be set to 00:00:00:00:00:00."
+    (fld_meta).description = "The link-layer address (MAC) of the neighbor."
   ];
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5085,65 +5085,99 @@ message IsisMetric {
   ];
 }
 
-message StateMetrics {
-  option (msg_meta).description = "A container for the different types of states.";
+message StatesRequest {
+  option (msg_meta).description = "Request to traffic generator for states of choice";
 
-  repeated PortState port_state = 1 [
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      ipv4_neighbors = 1;
+      ipv6_neighbors = 2;
+    }
+  }
+  optional Choice.Enum choice = 1 [
+    (fld_meta).default = "Choice.Enum.ipv4_neighbors",
     (fld_meta).description = "Description missing in models"
   ];
 
-  repeated FlowState flow_state = 2 [
+  optional Neighborsv4StatesRequest ipv4_neighbors = 2 [
+    (fld_meta).description = "Description missing in models"
+  ];
+
+  optional Neighborsv6StatesRequest ipv6_neighbors = 3 [
     (fld_meta).description = "Description missing in models"
   ];
 }
 
-message PortState {
-  option (msg_meta).description = "Description missing in models";
+message StatesResponse {
+  option (msg_meta).description = "Response containing chosen traffic generator states";
 
-  optional string name = 1 [
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      ipv4_neighbors = 1;
+      ipv6_neighbors = 2;
+    }
+  }
+  optional Choice.Enum choice = 1 [
+    (fld_meta).default = "Choice.Enum.ipv4_neighbors",
     (fld_meta).description = "Description missing in models"
   ];
 
-  message Link {
-    enum Enum {
-      unspecified = 0;
-      up = 1;
-      down = 2;
-    }
-  }
-  optional Link.Enum link = 2 [
+  repeated Neighborsv4State ipv4_neighbors = 2 [
     (fld_meta).description = "Description missing in models"
   ];
 
-  message Capture {
-    enum Enum {
-      unspecified = 0;
-      started = 1;
-      stopped = 2;
-    }
-  }
-  optional Capture.Enum capture = 3 [
+  repeated Neighborsv6State ipv6_neighbors = 3 [
     (fld_meta).description = "Description missing in models"
   ];
 }
 
-message FlowState {
-  option (msg_meta).description = "Description missing in models";
+message Neighborsv4StatesRequest {
+  option (msg_meta).description = "The request to retrieve IPv4 Neighbors state (ARP cache entries) for device network interface(s).";
 
-  optional string name = 1 [
-    (fld_meta).description = "Description missing in models"
+  repeated string interface_names = 1 [
+    (fld_meta).description = "The names of device Ethernet interfaces for which Neighbors will be retrieved. If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
+  ];
+}
+
+message Neighborsv4State {
+  option (msg_meta).description = "IPv4 Neighbor states (ARP cache entry).";
+
+  optional string interface = 1 [
+    (fld_meta).description = "The name of the device Ethernet interface associated with the neighbor."
   ];
 
-  message Transmit {
-    enum Enum {
-      unspecified = 0;
-      started = 1;
-      stopped = 2;
-      paused = 3;
-    }
-  }
-  optional Transmit.Enum transmit = 2 [
-    (fld_meta).description = "Description missing in models"
+  optional string ip = 2 [
+    (fld_meta).description = "The IPv4 address of the neighbor."
+  ];
+
+  optional string link_layer_address = 3 [
+    (fld_meta).description = "The link-layer address (MAC) of the neighbor. For an unresolved Neighbor entry value will be set to 00:00:00:00:00:00."
+  ];
+}
+
+message Neighborsv6StatesRequest {
+  option (msg_meta).description = "The request to retrieve IPv6 Neighbors state (NDISC cache entries) for device network interface(s).";
+
+  repeated string interface_names = 1 [
+    (fld_meta).description = "The names of device Ethernet interfaces for which Neighbors will be retrieved. If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.\n\nx-constraint:\n- /components/schemas/Device.Ethernet/properties/name\n"
+  ];
+}
+
+message Neighborsv6State {
+  option (msg_meta).description = "IPv6 Neighbor states (NDISC cache entry).";
+
+  optional string interface = 1 [
+    (fld_meta).description = "The name of the device Ethernet interface associated with the neighbor."
+  ];
+
+  optional string ip = 2 [
+    (fld_meta).description = "The IPv6 address of the neighbor."
+  ];
+
+  optional string link_layer_address = 3 [
+    (fld_meta).description = "The link-layer address (MAC) of the neighbor. For an unresolved Neighbor entry value will be set to 00:00:00:00:00:00."
   ];
 }
 
@@ -13377,8 +13411,12 @@ message GetMetricsResponse {
   optional ResponseError status_code_500 = 3;
 }
 
-message GetStateMetricsResponse {
-  optional StateMetrics status_code_200 = 1;
+
+message GetStatesRequest {
+  StatesRequest states_request = 1;
+}
+message GetStatesResponse {
+  optional StatesResponse status_code_200 = 1;
   optional ResponseError status_code_400 = 2;
   optional ResponseError status_code_500 = 3;
 }
@@ -13427,7 +13465,7 @@ service Openapi {
   rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse) {
     option (rpc_meta).description = "Description missing in models";
   }
-  rpc GetStateMetrics(google.protobuf.Empty) returns (GetStateMetricsResponse) {
+  rpc GetStates(GetStatesRequest) returns (GetStatesResponse) {
     option (rpc_meta).description = "Description missing in models";
   }
   rpc GetCapture(GetCaptureRequest) returns (GetCaptureResponse) {

--- a/result/neighborsv4.yaml
+++ b/result/neighborsv4.yaml
@@ -1,0 +1,43 @@
+openapi: 3.1.0
+
+info:
+  title: IPv4 Neighbors models
+  version: ^0.0.0
+
+components:
+  schemas:
+    Neighborsv4.States.Request:
+      description: >-
+        The request to retrieve IPv4 Neighbors state (ARP cache entries) for device network interface(s).
+      type: object
+      properties:
+        interface_names:
+          description: >-
+            The names of device Ethernet interfaces for which Neighbors will be retrieved.
+            If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.
+          type: array
+          items:
+            type: string
+          x-constraint:
+            - "/components/schemas/Device.Ethernet/properties/name"
+
+    Neighborsv4.State:
+      description: >-
+        IPv4 Neighbor states (ARP cache entry).
+      type: object
+      properties:
+        interface:
+          description: >-
+            The name of the device Ethernet interface associated with the neighbor.
+          type: string
+        ip:
+          description: >-
+            The IPv4 address of the neighbor.
+          type: string
+          format: ipv4
+        link_layer_address:
+          description: >-
+            The link-layer address (MAC) of the neighbor.
+            For an unresolved Neighbor entry value will be set to "00:00:00:00:00:00".
+          type: string
+          format: mac

--- a/result/neighborsv4.yaml
+++ b/result/neighborsv4.yaml
@@ -8,13 +8,13 @@ components:
   schemas:
     Neighborsv4.States.Request:
       description: >-
-        The request to retrieve IPv4 Neighbors state (ARP cache entries) for device network interface(s).
+        The request to retrieve IPv4 Neighbor state (ARP cache entries) for device network interface(s).
       type: object
       properties:
-        interface_names:
+        ethernet_names:
           description: >-
             The names of device Ethernet interfaces for which Neighbors will be retrieved.
-            If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.
+            If no names are specified then the results will contain Neighbors for all Ethernet interfaces.
           type: array
           items:
             type: string
@@ -23,14 +23,15 @@ components:
 
     Neighborsv4.State:
       description: >-
-        IPv4 Neighbor states (ARP cache entry).
+        IPv4 Neighbor state (ARP cache entry).
       type: object
+      required: [ethernet_name, ipv4_address]
       properties:
-        interface:
+        ethernet_name:
           description: >-
             The name of the device Ethernet interface associated with the neighbor.
           type: string
-        ip:
+        ipv4_address:
           description: >-
             The IPv4 address of the neighbor.
           type: string
@@ -38,6 +39,5 @@ components:
         link_layer_address:
           description: >-
             The link-layer address (MAC) of the neighbor.
-            For an unresolved Neighbor entry value will be set to "00:00:00:00:00:00".
           type: string
           format: mac

--- a/result/neighborsv4.yaml
+++ b/result/neighborsv4.yaml
@@ -8,13 +8,13 @@ components:
   schemas:
     Neighborsv4.States.Request:
       description: >-
-        The request to retrieve IPv4 Neighbor state (ARP cache entries) for device network interface(s).
+        The request to retrieve IPv4 Neighbor state (ARP cache entries) of a network interface(s).
       type: object
       properties:
         ethernet_names:
           description: >-
-            The names of device Ethernet interfaces for which Neighbors will be retrieved.
-            If no names are specified then the results will contain Neighbors for all Ethernet interfaces.
+            The names of Ethernet interfaces for which Neighbor state (ARP cache entries) will be retrieved.
+            If no names are specified then the results will contain Neighbor state (ARP cache entries) for all available Ethernet interfaces.
           type: array
           items:
             type: string
@@ -29,7 +29,7 @@ components:
       properties:
         ethernet_name:
           description: >-
-            The name of the device Ethernet interface associated with the neighbor.
+            The name of the Ethernet interface associated with the Neighbor state (ARP cache entry).
           type: string
         ipv4_address:
           description: >-

--- a/result/neighborsv6.yaml
+++ b/result/neighborsv6.yaml
@@ -1,0 +1,43 @@
+openapi: 3.1.0
+
+info:
+  title: IPv6 Neighbors models
+  version: ^0.0.0
+
+components:
+  schemas:
+    Neighborsv6.States.Request:
+      description: >-
+        The request to retrieve IPv6 Neighbors state (NDISC cache entries) for device network interface(s).
+      type: object
+      properties:
+        interface_names:
+          description: >-
+            The names of device Ethernet interfaces for which Neighbors will be retrieved.
+            If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.
+          type: array
+          items:
+            type: string
+          x-constraint:
+            - "/components/schemas/Device.Ethernet/properties/name"
+
+    Neighborsv6.State:
+      description: >-
+        IPv6 Neighbor states (NDISC cache entry).
+      type: object
+      properties:
+        interface:
+          description: >-
+            The name of the device Ethernet interface associated with the neighbor.
+          type: string
+        ip:
+          description: >-
+            The IPv6 address of the neighbor.
+          type: string
+          format: ipv6
+        link_layer_address:
+          description: >-
+            The link-layer address (MAC) of the neighbor.
+            For an unresolved Neighbor entry value will be set to "00:00:00:00:00:00".
+          type: string
+          format: mac

--- a/result/neighborsv6.yaml
+++ b/result/neighborsv6.yaml
@@ -8,13 +8,13 @@ components:
   schemas:
     Neighborsv6.States.Request:
       description: >-
-        The request to retrieve IPv6 Neighbors state (NDISC cache entries) for device network interface(s).
+        The request to retrieve IPv6 Neighbor state (NDISC cache entries) for device network interface(s).
       type: object
       properties:
-        interface_names:
+        ethernet_names:
           description: >-
             The names of device Ethernet interfaces for which Neighbors will be retrieved.
-            If no interface names are specified then the results will contain Neighbors for all Ethernet interfaces.
+            If no names are specified then the results will contain Neighbors for all Ethernet interfaces.
           type: array
           items:
             type: string
@@ -23,14 +23,15 @@ components:
 
     Neighborsv6.State:
       description: >-
-        IPv6 Neighbor states (NDISC cache entry).
+        IPv6 Neighbor state (NDISC cache entry).
       type: object
+      required: [ethernet_name, ipv6_address]
       properties:
-        interface:
+        ethernet_name:
           description: >-
             The name of the device Ethernet interface associated with the neighbor.
           type: string
-        ip:
+        ipv6_address:
           description: >-
             The IPv6 address of the neighbor.
           type: string
@@ -38,6 +39,5 @@ components:
         link_layer_address:
           description: >-
             The link-layer address (MAC) of the neighbor.
-            For an unresolved Neighbor entry value will be set to "00:00:00:00:00:00".
           type: string
           format: mac

--- a/result/neighborsv6.yaml
+++ b/result/neighborsv6.yaml
@@ -8,13 +8,13 @@ components:
   schemas:
     Neighborsv6.States.Request:
       description: >-
-        The request to retrieve IPv6 Neighbor state (NDISC cache entries) for device network interface(s).
+        The request to retrieve IPv6 Neighbor state (NDISC cache entries) of a network interface(s).
       type: object
       properties:
         ethernet_names:
           description: >-
-            The names of device Ethernet interfaces for which Neighbors will be retrieved.
-            If no names are specified then the results will contain Neighbors for all Ethernet interfaces.
+            The names of Ethernet interfaces for which Neighbor state (NDISC cache entries) will be retrieved.
+            If no names are specified then the results will contain Neighbor state (NDISC cache entries) for all available Ethernet interfaces.
           type: array
           items:
             type: string
@@ -29,7 +29,7 @@ components:
       properties:
         ethernet_name:
           description: >-
-            The name of the device Ethernet interface associated with the neighbor.
+            The name of the Ethernet interface associated with the Neighbor state (NDISC cache entry).
           type: string
         ipv6_address:
           description: >-

--- a/result/states.yaml
+++ b/result/states.yaml
@@ -1,0 +1,37 @@
+components:
+  schemas:
+    States.Request:
+      description: >-
+        Request to traffic generator for states of choice
+      type: object
+      properties:
+        choice:
+          type: string
+          enum:
+          - ipv4_neighbors
+          - ipv6_neighbors
+          default: ipv4_neighbors
+        ipv4_neighbors:
+          $ref: './neighborsv4.yaml#/components/schemas/Neighborsv4.States.Request'
+        ipv6_neighbors:
+          $ref: './neighborsv6.yaml#/components/schemas/Neighborsv6.States.Request'
+
+    States.Response:
+      description: >-
+        Response containing chosen traffic generator states
+      type: object
+      properties:
+        choice:
+          type: string
+          enum:
+          - ipv4_neighbors
+          - ipv6_neighbors
+          default: ipv4_neighbors
+        ipv4_neighbors:
+          type: array
+          items:
+            $ref: './neighborsv4.yaml#/components/schemas/Neighborsv4.State'
+        ipv6_neighbors:
+          type: array
+          items:
+            $ref: './neighborsv6.yaml#/components/schemas/Neighborsv6.State'


### PR DESCRIPTION
[Please view the proposed changes using the redocly API viewer](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/neighbors_state_support/artifacts/openapi.yaml#operation/get_metrics)

The proposed change has the support of retrieving IPv4 & IPv6 Neighbors (ARP & NDISC cache) to make the same information available through gNMI interface (through the gNMI server) as a flat table to the user.

"get_state_metrics" function has been renamed to "get_state" and modified to return neighbors state.  Existing state_metrics (for port & flow states) are removed for now as it requires a new request option to group it with new choices. Since port/flow states are not implemented/used anywhere, we can re-introduce these states later which will give us scope to refine the requirement further, without breaking compatibility.

Group names (category tags) are also modified.

Following are example query path to retrieve the state informaiton through gNMI server:
		"/ipv4_neighbors“
		"/ipv4_neighbors[interface=p1_d1_eth1]"
		"/ipv6_neighbors“
		"/ipv6_neighbors[interface=p1_d1_eth1]“