### PR TITLE
Exposing wide metric, attached bit, and 3 way handshake

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -1570,6 +1570,11 @@ components:
             \ router \nare changed to match exactly."
           type: boolean
           default: false
+        enable_3way_handshake:
+          description: |-
+            If it is true, the Point-to-Point circuit will include 3-way TLV in its Point-to-Point IIH  and attempt to establish the adjacency as specified in RFC 5303. This field is not available if Network type is specified as Broadcast.
+          type: boolean
+          default: true
     IsisInterface.LinkProtection:
       description: |-
         Optional container for the link protection sub TLV (type 20).
@@ -1632,6 +1637,13 @@ components:
           description: |-
             Host name for the router. The host name is transmitted in all the packets sent from the router.
           type: string
+        enable_wide_metric:
+          description: |-
+            This turns the use of Extended Reachability (wide) metrics to support:
+              32-bits wide for IP reachability (routes).
+              24-bits wide for IS reachability (IS neighbors).
+          type: boolean
+          default: true
     Isis.Advanced:
       description: |-
         Contains ISIS router advanced properties.
@@ -1698,6 +1710,11 @@ components:
           minimum: 1
           maximum: 60000
           default: 5000
+        enable_attached_bit:
+          description: |-
+            Attach bit indicates that the node is attached to another area  or the Level 2 backbone. The purpose of an Attached-Bit is to accomplish Inter-Area Routing.  When an L1/L2 router is connected to more than one area, it sets the Attached-bit on its L1 LSP.
+          type: boolean
+          default: true
     Isis.Authentication:
       description: |-
         This contains ISIS Area/Domain authentication properties.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -1572,7 +1572,7 @@ components:
           default: false
         enable_3way_handshake:
           description: |-
-            If it is true, the Point-to-Point circuit will include 3-way TLV in its Point-to-Point IIH  and attempt to establish the adjacency as specified in RFC 5303. This field is not available if Network type is specified as Broadcast.
+            If it is true, the Point-to-Point circuit will include 3-way TLV in its Point-to-Point IIH  and attempt to establish the adjacency as specified in RFC 5303. This field is not applicable if network_type is set to 'broadcast' type in ISIS interface.
           type: boolean
           default: true
     IsisInterface.LinkProtection:
@@ -1639,9 +1639,7 @@ components:
           type: string
         enable_wide_metric:
           description: |-
-            This turns the use of Extended Reachability (wide) metrics to support:
-              32-bits wide for IP reachability (routes).
-              24-bits wide for IS reachability (IS neighbors).
+            When set to true, it allows sending of more detailed metric information  for the routes using 32-bit wide values using TLV 135 IP reachability and  more detailed reachability information for IS reachability by using TLV 22.  The detailed usage is described in RFC3784.
           type: boolean
           default: true
     Isis.Advanced:
@@ -1712,7 +1710,7 @@ components:
           default: 5000
         enable_attached_bit:
           description: |-
-            Attach bit indicates that the node is attached to another area  or the Level 2 backbone. The purpose of an Attached-Bit is to accomplish Inter-Area Routing.  When an L1/L2 router is connected to more than one area, it sets the Attached-bit on its L1 LSP.
+            If the Attached bit is enabled, it indicates that the ISIS router is attached to another area  or the Level 2 backbone. The purpose of an Attached-Bit is to accomplish Inter-Area Routing.  When an L1/L2 router is connected to more than one area, it sets the Attached-bit on its L1 LSP. This can cause a default route ( 0.0.0.0/0 ) to be installed by the receiving router.
           type: boolean
           default: true
     Isis.Authentication:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1130,6 +1130,11 @@ message IsisInterfaceAdvanced {
     (fld_meta).default = "False",
     (fld_meta).description = "If a Hello message listing supported protocols is received on this \nemulated router, the supported protocols advertised by this router \nare changed to match exactly."
   ];
+
+  optional bool enable_3way_handshake = 4 [
+    (fld_meta).default = "True",
+    (fld_meta).description = "If it is true, the Point-to-Point circuit will include 3-way TLV in its Point-to-Point IIH  and attempt to establish the adjacency as specified in RFC 5303. This field is not available if Network type is specified as Broadcast."
+  ];
 }
 
 message IsisInterfaceLinkProtection {
@@ -1186,6 +1191,11 @@ message IsisBasic {
   optional string hostname = 2 [
     (fld_meta).description = "Host name for the router. The host name is transmitted in all the packets sent from the router."
   ];
+
+  optional bool enable_wide_metric = 3 [
+    (fld_meta).default = "True",
+    (fld_meta).description = "This turns the use of Extended Reachability (wide) metrics to support:\n  32-bits wide for IP reachability (routes).\n  24-bits wide for IS reachability (IS neighbors)."
+  ];
 }
 
 message IsisAdvanced {
@@ -1233,6 +1243,11 @@ message IsisAdvanced {
   optional int32 lsp_mgroup_min_trans_interval = 9 [
     (fld_meta).default = "5000",
     (fld_meta).description = "The number of seconds between transmissions of LSPs/MGROUP-PDUs."
+  ];
+
+  optional bool enable_attached_bit = 10 [
+    (fld_meta).default = "True",
+    (fld_meta).description = "Attach bit indicates that the node is attached to another area  or the Level 2 backbone. The purpose of an Attached-Bit is to accomplish Inter-Area Routing.  When an L1/L2 router is connected to more than one area, it sets the Attached-bit on its L1 LSP."
   ];
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1133,7 +1133,7 @@ message IsisInterfaceAdvanced {
 
   optional bool enable_3way_handshake = 4 [
     (fld_meta).default = "True",
-    (fld_meta).description = "If it is true, the Point-to-Point circuit will include 3-way TLV in its Point-to-Point IIH  and attempt to establish the adjacency as specified in RFC 5303. This field is not available if Network type is specified as Broadcast."
+    (fld_meta).description = "If it is true, the Point-to-Point circuit will include 3-way TLV in its Point-to-Point IIH  and attempt to establish the adjacency as specified in RFC 5303. This field is not applicable if network_type is set to 'broadcast' type in ISIS interface."
   ];
 }
 
@@ -1194,7 +1194,7 @@ message IsisBasic {
 
   optional bool enable_wide_metric = 3 [
     (fld_meta).default = "True",
-    (fld_meta).description = "This turns the use of Extended Reachability (wide) metrics to support:\n  32-bits wide for IP reachability (routes).\n  24-bits wide for IS reachability (IS neighbors)."
+    (fld_meta).description = "When set to true, it allows sending of more detailed metric information  for the routes using 32-bit wide values using TLV 135 IP reachability and  more detailed reachability information for IS reachability by using TLV 22.  The detailed usage is described in RFC3784."
   ];
 }
 
@@ -1247,7 +1247,7 @@ message IsisAdvanced {
 
   optional bool enable_attached_bit = 10 [
     (fld_meta).default = "True",
-    (fld_meta).description = "Attach bit indicates that the node is attached to another area  or the Level 2 backbone. The purpose of an Attached-Bit is to accomplish Inter-Area Routing.  When an L1/L2 router is connected to more than one area, it sets the Attached-bit on its L1 LSP."
+    (fld_meta).description = "If the Attached bit is enabled, it indicates that the ISIS router is attached to another area  or the Level 2 backbone. The purpose of an Attached-Bit is to accomplish Inter-Area Routing.  When an L1/L2 router is connected to more than one area, it sets the Attached-bit on its L1 LSP. This can cause a default route ( 0.0.0.0/0 ) to be installed by the receiving router."
   ];
 }
 

--- a/device/isis/interfaceadvanced.yaml
+++ b/device/isis/interfaceadvanced.yaml
@@ -26,3 +26,10 @@ components:
             are changed to match exactly.
           type: boolean
           default: false
+        enable_3way_handshake:
+          description: >-
+            If it is true, the Point-to-Point circuit will include 3-way TLV in its Point-to-Point IIH 
+            and attempt to establish the adjacency as specified in RFC 5303.
+            This field is not available if Network type is specified as Broadcast.
+          type: boolean
+          default: true

--- a/device/isis/interfaceadvanced.yaml
+++ b/device/isis/interfaceadvanced.yaml
@@ -30,6 +30,6 @@ components:
           description: >-
             If it is true, the Point-to-Point circuit will include 3-way TLV in its Point-to-Point IIH 
             and attempt to establish the adjacency as specified in RFC 5303.
-            This field is not available if Network type is specified as Broadcast.
+            This field is not applicable if network_type is set to 'broadcast' type in ISIS interface.
           type: boolean
           default: true

--- a/device/isis/routeradvanced.yaml
+++ b/device/isis/routeradvanced.yaml
@@ -69,4 +69,11 @@ components:
           type: integer
           minimum: 1
           maximum: 60000
-          default: 5000  
+          default: 5000
+        enable_attached_bit:
+          description: >-
+            Attach bit indicates that the node is attached to another area 
+            or the Level 2 backbone. The purpose of an Attached-Bit is to accomplish Inter-Area Routing. 
+            When an L1/L2 router is connected to more than one area, it sets the Attached-bit on its L1 LSP.
+          type: boolean
+          default: true  

--- a/device/isis/routeradvanced.yaml
+++ b/device/isis/routeradvanced.yaml
@@ -72,8 +72,9 @@ components:
           default: 5000
         enable_attached_bit:
           description: >-
-            Attach bit indicates that the node is attached to another area 
+            If the Attached bit is enabled, it indicates that the ISIS router is attached to another area 
             or the Level 2 backbone. The purpose of an Attached-Bit is to accomplish Inter-Area Routing. 
             When an L1/L2 router is connected to more than one area, it sets the Attached-bit on its L1 LSP.
+            This can cause a default route ( 0.0.0.0/0 ) to be installed by the receiving router.
           type: boolean
           default: true  

--- a/device/isis/routerbasic.yaml
+++ b/device/isis/routerbasic.yaml
@@ -18,9 +18,10 @@ components:
           type: string
         enable_wide_metric:
           description: >-
-            This turns the use of Extended Reachability (wide) metrics to support:
-              32-bits wide for IP reachability (routes).
-              24-bits wide for IS reachability (IS neighbors).
+            When set to true, it allows sending of more detailed metric information 
+            for the routes using 32-bit wide values using TLV 135 IP reachability and 
+            more detailed reachability information for IS reachability by using TLV 22. 
+            The detailed usage is described in RFC3784.
           type: boolean
           default: true
         

--- a/device/isis/routerbasic.yaml
+++ b/device/isis/routerbasic.yaml
@@ -16,3 +16,12 @@ components:
           description: >-
             Host name for the router. The host name is transmitted in all the packets sent from the router.
           type: string
+        enable_wide_metric:
+          description: >-
+            This turns the use of Extended Reachability (wide) metrics to support:
+              32-bits wide for IP reachability (routes).
+              24-bits wide for IS reachability (IS neighbors).
+          type: boolean
+          default: true
+        
+


### PR DESCRIPTION
We are exposing 3 Boolean parameters
wide metric, 3 way handshake and attached bit --  which are right now enabled in the protocol engine for the rustic. While working with Arista DUT, we have found Arista DUT does not support narrow metric. To debug the ISIS session negotiations,  3 way handshakes helps in P2P.  And exposing attached bit, to over come a bug in Arista, SSH connection to DUT gets broken when attached bit is enabled for ISIS L1 session.