### PR TITLE
Dev metric datatype

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -5026,18 +5026,26 @@ components:
           description: |-
             The current total number of frames transmitted
           type: integer
+          format: int64
+          minimum: 0
         frames_rx:
           description: |-
             The current total number of valid frames received
           type: integer
+          format: int64
+          minimum: 0
         bytes_tx:
           description: |-
             The current total number of bytes transmitted
           type: integer
+          format: int64
+          minimum: 0
         bytes_rx:
           description: |-
             The current total number of valid bytes received
           type: integer
+          format: int64
+          minimum: 0
         frames_tx_rate:
           description: |-
             The current rate of frames transmitted
@@ -5158,18 +5166,26 @@ components:
           description: |-
             The current total number of frames transmitted
           type: integer
+          format: int64
+          minimum: 0
         frames_rx:
           description: |-
             The current total number of valid frames received
           type: integer
+          format: int64
+          minimum: 0
         bytes_tx:
           description: |-
             The current total number of bytes transmitted
           type: integer
+          format: int64
+          minimum: 0
         bytes_rx:
           description: |-
             The current total number of bytes received
           type: integer
+          format: int64
+          minimum: 0
         frames_tx_rate:
           description: |-
             The current rate of frames transmitted

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -4531,19 +4531,19 @@ message PortMetric {
     (fld_meta).description = "The state of the test port capture infrastructure. The string can be started, stopped or a custom error message."
   ];
 
-  optional int32 frames_tx = 5 [
+  optional int64 frames_tx = 5 [
     (fld_meta).description = "The current total number of frames transmitted"
   ];
 
-  optional int32 frames_rx = 6 [
+  optional int64 frames_rx = 6 [
     (fld_meta).description = "The current total number of valid frames received"
   ];
 
-  optional int32 bytes_tx = 7 [
+  optional int64 bytes_tx = 7 [
     (fld_meta).description = "The current total number of bytes transmitted"
   ];
 
-  optional int32 bytes_rx = 8 [
+  optional int64 bytes_rx = 8 [
     (fld_meta).description = "The current total number of valid bytes received"
   ];
 
@@ -4649,19 +4649,19 @@ message FlowMetric {
     (fld_meta).description = "The transmit state of the flow."
   ];
 
-  optional int32 frames_tx = 6 [
+  optional int64 frames_tx = 6 [
     (fld_meta).description = "The current total number of frames transmitted"
   ];
 
-  optional int32 frames_rx = 7 [
+  optional int64 frames_rx = 7 [
     (fld_meta).description = "The current total number of valid frames received"
   ];
 
-  optional int32 bytes_tx = 8 [
+  optional int64 bytes_tx = 8 [
     (fld_meta).description = "The current total number of bytes transmitted"
   ];
 
-  optional int32 bytes_rx = 9 [
+  optional int64 bytes_rx = 9 [
     (fld_meta).description = "The current total number of bytes received"
   ];
 

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -101,10 +101,14 @@ components:
           description: >-
             The current total number of frames transmitted
           type: integer
+          format: int64
+          minimum: 0
         frames_rx:
           description: >-
             The current total number of valid frames received
           type: integer
+          format: int64
+          minimum: 0
         bytes_tx:
           description: >-
             The current total number of bytes transmitted

--- a/result/port.yaml
+++ b/result/port.yaml
@@ -67,10 +67,14 @@ components:
           description: >-
             The current total number of frames transmitted
           type: integer
+          format: int64
+          minimum: 0
         frames_rx:
           description: >-
             The current total number of valid frames received
           type: integer
+          format: int64
+          minimum: 0
         bytes_tx:
           description: >-
             The current total number of bytes transmitted


### PR DESCRIPTION
Change datatype to int64 for frames_tx/rx.. Thses values could be higher than range of int32. 