### PR TITLE
Xstatus changes

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -1814,12 +1814,7 @@ components:
           default: true
           x-field-uid: 1
     Device.IsisRouter:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         A container of properties for an ISIS router and its interfaces.
       type: object
       required:
@@ -1881,11 +1876,8 @@ components:
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Device.IsisMultiInstance:
-      x-status:
-        status: under_review
-        information: Information TBD
-      description: "Under Review: Information TBD\n\nThis container properties of\
-        \ an Multi-Instance-capable router (MI-RTR). "
+      description: "This container properties of an Multi-Instance-capable router\
+        \ (MI-RTR). "
       type: object
       properties:
         iid:
@@ -1907,12 +1899,7 @@ components:
             maximum: 65535
           x-field-uid: 2
     Isis.Interface:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration for single ISIS interface.
       type: object
       required:
@@ -2041,12 +2028,7 @@ components:
           default: 30
           x-field-uid: 3
     Isis.MT:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration of properties per interface per topology when multiple topologies are configured in an ISIS router.
         in a ISIS router.
       type: object
@@ -2068,12 +2050,7 @@ components:
           maximum: 16777215
           x-field-uid: 2
     LinkState.TE:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         A container for Traffic Engineering properties on a interface.
       type: object
       properties:
@@ -3703,12 +3680,7 @@ components:
           type: string
           x-field-uid: 2
     Bgp.Advanced:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration for BGP advanced settings.
       type: object
       properties:
@@ -3742,12 +3714,7 @@ components:
           type: string
           x-field-uid: 5
     Bgp.Capability:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration for BGP capability settings.
       type: object
       properties:
@@ -3903,12 +3870,7 @@ components:
           default: false
           x-field-uid: 25
     Bgp.LearnedInformationFilter:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration for controlling storage of BGP learned information recieved from the peer.
       type: object
       properties:
@@ -4443,12 +4405,7 @@ components:
           - push_ipv4_ipv6_enlp
           - do_not_push_enlp
     BgpSrte.SegmentList:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Optional configuration for BGP SR TE Policy segment list. The Segment List sub-TLV encodes a single explicit path towards the Endpoint.
       type: object
       properties:
@@ -4482,12 +4439,7 @@ components:
       required:
       - name
     BgpSrte.Segment:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         A Segment sub-TLV describes a single segment in a segment list  i.e., a single element of the explicit path. The Segment sub-TLVs are optional.
       type: object
       required:
@@ -4722,12 +4674,7 @@ components:
           $ref: '#/components/schemas/BgpSrte.SRv6SIDEndpointBehaviorAndStructure'
           x-field-uid: 3
     BgpSrte.SegmentCTypeSubTlv:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Type C: IPv4 Node Address with optional SID.
       type: object
       required:
@@ -5371,12 +5318,7 @@ components:
             $ref: '#/components/schemas/Bgp.V6Peer'
           x-field-uid: 2
     Bgp.V6SegmentRouting:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration for BGPv6 segment routing settings.
       type: object
       properties:
@@ -5883,12 +5825,7 @@ components:
           format: ipv6
           x-field-uid: 1
     Device.Rsvp:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration for one or more RSVP interfaces, ingress and egress LSPs. In this model, currently IPv4 RSVP and point-to-point LSPs are supported as per RFC3209 and related specifications.
       type: object
       properties:
@@ -5914,12 +5851,7 @@ components:
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Rsvp.Ipv4Interface:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration for RSVP Interface.
       type: object
       required:
@@ -6009,12 +5941,7 @@ components:
           maximum: 10
           x-field-uid: 11
     Rsvp.LspIpv4Interface:
-      x-status:
-        status: under_review
-        information: Information TBD
       description: |-
-        Under Review: Information TBD
-
         Configuration for RSVP LSP IPv4 Interface.
       type: object
       required:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -955,8 +955,6 @@ message ProtocolOptions {
   optional bool auto_start_all = 1;
 }
 
-// Under Review: Information TBD
-// 
 // A container of properties for an ISIS router and its interfaces.
 message DeviceIsisRouter {
 
@@ -992,8 +990,6 @@ message DeviceIsisRouter {
   string name = 9;
 }
 
-// Under Review: Information TBD
-// 
 // This container properties of an Multi-Instance-capable router (MI-RTR).
 message DeviceIsisMultiInstance {
 
@@ -1007,8 +1003,6 @@ message DeviceIsisMultiInstance {
   repeated int32 itids = 2;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration for single ISIS interface.
 message IsisInterface {
 
@@ -1096,8 +1090,6 @@ message IsisInterfaceLevel {
   optional int32 dead_interval = 3;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration of properties per interface per topology when multiple topologies are
 // configured in an ISIS router.
 // in a ISIS router.
@@ -1112,8 +1104,6 @@ message IsisMT {
   optional int32 link_metric = 2;
 }
 
-// Under Review: Information TBD
-// 
 // A container for Traffic Engineering properties on a interface.
 message LinkStateTE {
 
@@ -2352,8 +2342,6 @@ message BgpRouteTarget {
   optional string rt_value = 2;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration for BGP advanced settings.
 message BgpAdvanced {
 
@@ -2382,8 +2370,6 @@ message BgpAdvanced {
   optional string md5_key = 5;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration for BGP capability settings.
 message BgpCapability {
 
@@ -2500,8 +2486,6 @@ message BgpCapability {
   optional bool ipv6_unicast_add_path = 25;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration for controlling storage of BGP learned information recieved from the
 // peer.
 message BgpLearnedInformationFilter {
@@ -2976,8 +2960,6 @@ message BgpSrteExplicitNullLabelPolicySubTlv {
   optional ExplicitNullLabelPolicy.Enum explicit_null_label_policy = 1;
 }
 
-// Under Review: Information TBD
-// 
 // Optional configuration for BGP SR TE Policy segment list. The Segment List sub-TLV
 // encodes a single explicit path towards the Endpoint.
 message BgpSrteSegmentList {
@@ -3002,8 +2984,6 @@ message BgpSrteSegmentList {
   optional bool active = 4;
 }
 
-// Under Review: Information TBD
-// 
 // A Segment sub-TLV describes a single segment in a segment list  i.e., a single element
 // of the explicit path. The Segment sub-TLVs are optional.
 message BgpSrteSegment {
@@ -3161,8 +3141,6 @@ message BgpSrteSegmentBTypeSubTlv {
   optional BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 3;
 }
 
-// Under Review: Information TBD
-// 
 // Type C: IPv4 Node Address with optional SID.
 message BgpSrteSegmentCTypeSubTlv {
 
@@ -3630,8 +3608,6 @@ message BgpV6Interface {
   repeated BgpV6Peer peers = 2;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration for BGPv6 segment routing settings.
 message BgpV6SegmentRouting {
 
@@ -4044,8 +4020,6 @@ message VxlanV6TunnelDestinationIPModeMulticast {
   optional string address = 1;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration for one or more RSVP interfaces, ingress and egress LSPs. In this model,
 // currently IPv4 RSVP and point-to-point LSPs are supported as per RFC3209 and related
 // specifications.
@@ -4064,8 +4038,6 @@ message DeviceRsvp {
   optional string name = 3;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration for RSVP Interface.
 message RsvpIpv4Interface {
 
@@ -4130,8 +4102,6 @@ message RsvpIpv4Interface {
   optional int32 timeout_multiplier = 11;
 }
 
-// Under Review: Information TBD
-// 
 // Configuration for RSVP LSP IPv4 Interface.
 message RsvpLspIpv4Interface {
 

--- a/device/bgp/bgpadvanced.yaml
+++ b/device/bgp/bgpadvanced.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Bgp.Advanced:
-      x-status:
-        status: under_review
       description: >-
         Configuration for BGP advanced settings.
       type: object

--- a/device/bgp/bgpcapability.yaml
+++ b/device/bgp/bgpcapability.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Bgp.Capability:
-      x-status:
-        status: under_review
       description: >-
         Configuration for BGP capability settings.
       type: object

--- a/device/bgp/bgplearnedinfofilter.yaml
+++ b/device/bgp/bgplearnedinfofilter.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Bgp.LearnedInformationFilter:
-      x-status:
-        status: under_review
       description: >-
         Configuration for controlling storage of BGP learned information recieved
         from the peer.

--- a/device/bgp/bgpsrtesegment.yaml
+++ b/device/bgp/bgpsrtesegment.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     BgpSrte.Segment:
-      x-status:
-        status: under_review
       description: >-
         A Segment sub-TLV describes a single segment in a segment list  i.e., a single
         element of the explicit path. The Segment sub-TLVs are optional.
@@ -211,8 +209,6 @@ components:
           $ref: '#/components/schemas/BgpSrte.SRv6SIDEndpointBehaviorAndStructure'
           x-field-uid: 3
     BgpSrte.SegmentCTypeSubTlv:
-      x-status:
-        status: under_review
       description: >-
         Type C: IPv4 Node Address with optional SID.
       type: object

--- a/device/bgp/bgpsrtesegmentlist.yaml
+++ b/device/bgp/bgpsrtesegmentlist.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     BgpSrte.SegmentList:
-      x-status:
-        status: under_review
       description: >-
         Optional configuration for BGP SR TE Policy segment list.
         The Segment List sub-TLV encodes a single explicit path towards the

--- a/device/bgp/bgpv6segmentrouting.yaml
+++ b/device/bgp/bgpv6segmentrouting.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Bgp.V6SegmentRouting:
-      x-status:
-        status: under_review
       description: >-
         Configuration for BGPv6 segment routing settings.
       type: object

--- a/device/isis/interface.yaml
+++ b/device/isis/interface.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Isis.Interface:
-      x-status:
-        status: under_review
       description: >-
         Configuration for single ISIS interface.
       type: object

--- a/device/isis/isis.yaml
+++ b/device/isis/isis.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Device.IsisRouter:
-      x-status:
-        status: under_review
       description: >-
         A container of properties for an ISIS router and its interfaces.
       type: object

--- a/device/isis/multipleinstances.yaml
+++ b/device/isis/multipleinstances.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Device.IsisMultiInstance:
-      x-status:
-        status: under_review
       description: >-
         This container properties of an Multi-Instance-capable router (MI-RTR). 
       type: object

--- a/device/isis/multitopology.yaml
+++ b/device/isis/multitopology.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Isis.MT:
-      x-status:
-        status: under_review
       description: |-
         Configuration of properties per interface per topology when multiple topologies are configured in an ISIS router.
         in a ISIS router.

--- a/device/linkstate/teprofile.yaml
+++ b/device/linkstate/teprofile.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     LinkState.TE:
-      x-status:
-        status: under_review
       description: >-
         A container for Traffic Engineering properties on a interface.
       type: object

--- a/device/rsvp/rsvp.yaml
+++ b/device/rsvp/rsvp.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Device.Rsvp:
-      x-status:
-        status: under_review
       description: >-
         Configuration for one or more RSVP interfaces, ingress and egress LSPs.
         In this model, currently IPv4 RSVP and point-to-point LSPs are supported as per RFC3209 and related specifications.

--- a/device/rsvp/rsvpInterface.yaml
+++ b/device/rsvp/rsvpInterface.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Rsvp.Ipv4Interface:
-      x-status:
-        status: under_review
       description: >-
         Configuration for RSVP Interface.
       type: object

--- a/device/rsvp/rsvpLspInterface.yaml
+++ b/device/rsvp/rsvpLspInterface.yaml
@@ -1,8 +1,6 @@
 components:
   schemas:
     Rsvp.LspIpv4Interface:
-      x-status:
-        status: under_review
       description: >-
         Configuration for RSVP LSP IPv4 Interface.
       type: object


### PR DESCRIPTION
Removal of under_review stdout warnings when otg tests are run, this warning comes from objects whose review is complete but xstatus is still under_review. Issue link https://github.com/open-traffic-generator/models/issues/310.

No script,test changes required for this PR . The redocly link is https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/xstatus_changes/artifacts/openapi.yaml&nocors