### PR TITLE
Dev port disaggregation

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -6580,16 +6580,37 @@ components:
           x-field-uid: 1
         rx_name:
           description: |
+            Deprecated: This property is deprecated in favor of property rx_names
+
             The unique name of a port that is the intended receive port.
 
             x-constraint:
             - /components/schemas/Port/properties/name
             - /components/schemas/Lag/properties/name
+          x-status:
+            status: deprecated
+            information: This property is deprecated in favor of property rx_names
           type: string
           x-constraint:
           - /components/schemas/Port/properties/name
           - /components/schemas/Lag/properties/name
           x-field-uid: 2
+        rx_names:
+          description: |
+            Unique names of ports that are intended receive ports.
+
+            x-constraint:
+            - /components/schemas/Port/properties/name
+            - /components/schemas/Lag/properties/name
+          type: array
+          items:
+            description: |-
+              The unique name of a port that is the intended receive port.
+            type: string
+          x-constraint:
+          - /components/schemas/Port/properties/name
+          - /components/schemas/Lag/properties/name
+          x-field-uid: 3
     Flow.Router:
       description: |-
         A container for declaring a map of 1..n transmit devices to 1..n receive devices. This allows for a single flow to have  different tx to rx device flows such as a single one to one map or a  many to many map.
@@ -7959,10 +7980,10 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-        tx_rx_ratio:
+        rx_tx_ratio:
           description: |-
-            Tx Rx ratio.
-          $ref: '#/components/schemas/Flow.TxRxRatio'
+            Rx Tx ratio.
+          $ref: '#/components/schemas/Flow.RxTxRatio'
           x-field-uid: 6
         timestamps:
           description: |-
@@ -7975,12 +7996,10 @@ components:
             Latency metrics.
           $ref: '#/components/schemas/Flow.Latency.Metrics'
           x-field-uid: 4
-        rx_per_port:
+        predefined_metric_tags:
           description: |-
-            Enables Rx port level disaggregation with metrics tag name set as "rx_port_name".
-            The Rx port names can be found under tagged_metrics tag names in flow metrics response.
-          type: boolean
-          default: false
+            Predefined metric tags
+          $ref: '#/components/schemas/Flow.Predefined.Tags'
           x-field-uid: 5
     Flow.Latency.Metrics:
       description: |-
@@ -8014,9 +8033,21 @@ components:
           enum:
           - store_forward
           - cut_through
-    Flow.TxRxRatio:
+    Flow.Predefined.Tags:
       description: |-
-        Tx Rx ratio is the ratio of expected number of Rx packets across all Rx ports to the Tx packets
+        List of predefined flow tracking options, outside packet fields, that can be enabled.
+      type: object
+      properties:
+        rx_name:
+          description: |-
+            Enables Rx port or lag level disaggregation with predefined metrics tag name set as "rx_name".
+            The Rx port / lag names can be found under tagged_metrics tag names in flow metrics response.
+          type: boolean
+          default: false
+          x-field-uid: 1
+    Flow.RxTxRatio:
+      description: |-
+        Rx Tx ratio is the ratio of expected number of Rx packets across all Rx ports to the Tx packets
         for the configured flow. It is a factor by which the Tx packet count is multiplied to calculate
         the sum of expected Rx packet count, across all Rx ports. This will be used to calculate loss
         percentage of flow at aggregate level.
@@ -8024,26 +8055,20 @@ components:
       properties:
         choice:
           type: string
-          default: one
+          default: value
           x-field-uid: 1
           x-enum:
-            one:
-              x-field-uid: 1
             rx_count:
+              x-field-uid: 1
+            value:
               x-field-uid: 2
-            custom:
-              x-field-uid: 3
           enum:
-          - one
           - rx_count
-          - custom
-        one:
-          $ref: '#/components/schemas/Flow.TxRxRatio.Ecmp'
-          x-field-uid: 2
+          - value
         rx_count:
-          $ref: '#/components/schemas/Flow.TxRxRatio.RxCount'
-          x-field-uid: 3
-        custom:
+          $ref: '#/components/schemas/Flow.RxTxRatio.RxCount'
+          x-field-uid: 2
+        value:
           description: |-
             Should be a positive, non-zero value. A custom integer value (>1) can be specified for
             loss calculation for cases when there are multiple destination addresses configured within one flow,
@@ -8053,11 +8078,8 @@ components:
           type: number
           format: float
           default: 1.0
-          x-field-uid: 4
-    Flow.TxRxRatio.Ecmp:
-      description: |-
-        This is for cases where Rx packet count across all ports is expected to match the Tx packet count.
-    Flow.TxRxRatio.RxCount:
+          x-field-uid: 3
+    Flow.RxTxRatio.RxCount:
       description: |-
         This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets
         received across all Rx ports is a multiple of Rx port count and Tx packets.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -10308,19 +10308,19 @@ components:
           x-enum:
             hex:
               x-field-uid: 1
-            string:
+            str:
               x-field-uid: 2
           x-field-uid: 1
           enum:
           - hex
-          - string
+          - str
         hex:
           description: |-
             Value represented in hexadecimal format
           type: string
           format: hex
           x-field-uid: 2
-        string:
+        str:
           description: |-
             Value represented in string format
           type: string

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7959,9 +7959,9 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-        tx_rx_replication_factor:
+        tx_rx_ratio:
           description: |-
-            Tx Rx replication factor.
+            Tx Rx ratio.
           $ref: '#/components/schemas/Flow.TxRxReplication'
           x-field-uid: 6
         timestamps:
@@ -8016,8 +8016,8 @@ components:
           - cut_through
     Flow.TxRxReplication:
       description: |-
-        Tx Rx replication factor is required to determine the ratio of expected number of Rx packets across all Rx ports
-        to the Tx packets for the configured flow.
+        Tx Rx ratio is the expected number of Rx packets across all Rx ports to the Tx packets
+        for the configured flow.
       type: object
       properties:
         choice:
@@ -8038,12 +8038,12 @@ components:
         one:
           $ref: '#/components/schemas/Flow.TxRxReplication.Ecmp'
           x-field-uid: 2
-        rx_ports_count:
+        rx_count:
           $ref: '#/components/schemas/Flow.TxRxReplication.RxCount'
           x-field-uid: 3
         custom:
           description: |-
-            Should be a positive, non-zero value. We may need to specify a custom integer value for
+            Should be a positive, non-zero value. A custom integer value (>1) can be specified for
             loss calculation for cases when there are multiple destination addresses configured within one flow,
             but DUT is configured to replicate only to a subset of Rx ports. For cases when Tx side generates two
             packets from each source in 1:1 protection mode but only one of the two packets are received by the
@@ -8054,7 +8054,7 @@ components:
           x-field-uid: 4
     Flow.TxRxReplication.Ecmp:
       description: |-
-        This is typically for cases where Rx packet count across all ports is expected to match the Tx packet count.
+        This is for cases where Rx packet count across all ports is expected to match the Tx packet count.
     Flow.TxRxReplication.RxCount:
       description: |-
         This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -6597,7 +6597,7 @@ components:
           x-field-uid: 2
         rx_names:
           description: |
-            Unique name of ports or lags that are intended receiving endpoints.
+            Unique name of ports or lags that are intended receive endpoints.
 
             x-constraint:
             - /components/schemas/Port/properties/name
@@ -6605,7 +6605,7 @@ components:
           type: array
           items:
             description: |-
-              The unique name of a port that is the intended receive port.
+              The unique name of a port or lag that is the intended receive port.
             type: string
           x-constraint:
           - /components/schemas/Port/properties/name

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -10255,7 +10255,6 @@ components:
           description: |-
             Value represented in string format
           type: string
-          format: string
           x-field-uid: 3
     Metric.Timestamp:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -6881,7 +6881,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable
             for configured offset and length inside corresponding header field
-            Note: "rx_port_name" is reserved for rx port level disaggregation
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7959,12 +7959,10 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-        rx_tx_ratio:
+        tx_rx_replication_factor:
           description: |-
-            Tx Rx multiplication factor, required for loss measurement. Should be a positive, non-zero value.
-          type: number
-          format: float
-          default: 1
+            Tx Rx replication factor.
+          $ref: '#/components/schemas/Flow.TxRxReplication'
           x-field-uid: 6
         timestamps:
           description: |-
@@ -7980,6 +7978,7 @@ components:
         rx_per_port:
           description: |-
             Enables Rx port level disaggregation with metrics tag name set as "rx_port_name".
+            The Rx port names can be found under tagged_metrics tag names in flow metrics response.
           type: boolean
           default: false
           x-field-uid: 5
@@ -8015,6 +8014,51 @@ components:
           enum:
           - store_forward
           - cut_through
+    Flow.TxRxReplication:
+      description: |-
+        Tx Rx replication factor is required to determine the ratio of expected number of Rx packets across all Rx ports
+        to the Tx packets for the configured flow.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: one
+          x-field-uid: 1
+          x-enum:
+            one:
+              x-field-uid: 1
+            rx_ports_count:
+              x-field-uid: 2
+            custom:
+              x-field-uid: 3
+          enum:
+          - one
+          - rx_ports_count
+          - custom
+        one:
+          $ref: '#/components/schemas/Flow.TxRxReplication.Ecmp'
+          x-field-uid: 2
+        rx_ports_count:
+          $ref: '#/components/schemas/Flow.TxRxReplication.RxCount'
+          x-field-uid: 3
+        custom:
+          description: |-
+            Should be a positive, non-zero value. We may need to specify a custom integer value for
+            loss calculation for cases when there are multiple destination addresses configured within one flow,
+            but DUT is configured to replicate only to a subset of Rx ports. For cases when Tx side generates two
+            packets from each source in 1:1 protection mode but only one of the two packets are received by the
+            Rx port, we may need to specify a fractional value instead.
+          type: number
+          format: float
+          default: 1.0
+          x-field-uid: 4
+    Flow.TxRxReplication.Ecmp:
+      description: |-
+        This is typically for cases where Rx packet count across all ports is expected to match the Tx packet count.
+    Flow.TxRxReplication.RxCount:
+      description: |-
+        This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets
+        received across all Rx ports is a multiple of Rx port count and Tx packets.
     Event:
       description: |-
         The optional container for event configuration.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7961,10 +7961,10 @@ components:
           x-field-uid: 2
         rx_tx_ratio:
           description: |-
-            Tx Rx multiplication factor, required for loss measurement.
+            Tx Rx multiplication factor, required for loss measurement. Should be a positive, non-zero value.
           type: number
           format: float
-          default: 0
+          default: 1
           x-field-uid: 6
         timestamps:
           description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -6597,7 +6597,7 @@ components:
           x-field-uid: 2
         rx_names:
           description: |
-            Unique names of ports that are intended receive ports.
+            Unique name of ports or lags that are intended receiving endpoints.
 
             x-constraint:
             - /components/schemas/Port/properties/name
@@ -8070,7 +8070,8 @@ components:
           x-field-uid: 2
         value:
           description: |-
-            Should be a positive, non-zero value. A custom integer value (>1) can be specified for
+            Should be a positive, non-zero value. The default value of 1, is when the Rx packet count across
+            all ports is expected to match the Tx packet count. A custom integer value (>1) can be specified for
             loss calculation for cases when there are multiple destination addresses configured within one flow,
             but DUT is configured to replicate only to a subset of Rx ports. For cases when Tx side generates two
             packets from each source in 1:1 protection mode but only one of the two packets are received by the

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8081,7 +8081,7 @@ components:
           x-field-uid: 3
     Flow.RxTxRatio.RxCount:
       description: |-
-        This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets
+        This is for cases where one copy of Tx packet is received on all Rx ports and so the sum total of Rx packets
         received across all Rx ports is a multiple of Rx port count and Tx packets.
     Event:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7959,6 +7959,13 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
+        rx_tx_ratio:
+          description: |-
+            Tx Rx multiplication factor, required for loss measurement.
+          type: number
+          format: float
+          default: 0
+          x-field-uid: 6
         timestamps:
           description: |-
             Enables additional flow metric first and last timestamps.
@@ -7970,9 +7977,9 @@ components:
             Latency metrics.
           $ref: '#/components/schemas/Flow.Latency.Metrics'
           x-field-uid: 4
-        rx_port_disaggregation:
+        rx_per_port:
           description: |-
-            Enables port level disaggregation with metrics tag name set as "rx_port_name".
+            Enables Rx port level disaggregation with metrics tag name set as "rx_port_name".
           type: boolean
           default: false
           x-field-uid: 5

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7962,7 +7962,7 @@ components:
         tx_rx_ratio:
           description: |-
             Tx Rx ratio.
-          $ref: '#/components/schemas/Flow.TxRxReplication'
+          $ref: '#/components/schemas/Flow.TxRxRatio'
           x-field-uid: 6
         timestamps:
           description: |-
@@ -8014,10 +8014,12 @@ components:
           enum:
           - store_forward
           - cut_through
-    Flow.TxRxReplication:
+    Flow.TxRxRatio:
       description: |-
-        Tx Rx ratio is the expected number of Rx packets across all Rx ports to the Tx packets
-        for the configured flow.
+        Tx Rx ratio is the ratio of expected number of Rx packets across all Rx ports to the Tx packets
+        for the configured flow. It is a factor by which the Tx packet count is multiplied to calculate
+        the sum of expected Rx packet count, across all Rx ports. This will be used to calculate loss
+        percentage of flow at aggregate level.
       type: object
       properties:
         choice:
@@ -8036,10 +8038,10 @@ components:
           - rx_count
           - custom
         one:
-          $ref: '#/components/schemas/Flow.TxRxReplication.Ecmp'
+          $ref: '#/components/schemas/Flow.TxRxRatio.Ecmp'
           x-field-uid: 2
         rx_count:
-          $ref: '#/components/schemas/Flow.TxRxReplication.RxCount'
+          $ref: '#/components/schemas/Flow.TxRxRatio.RxCount'
           x-field-uid: 3
         custom:
           description: |-
@@ -8052,10 +8054,10 @@ components:
           format: float
           default: 1.0
           x-field-uid: 4
-    Flow.TxRxReplication.Ecmp:
+    Flow.TxRxRatio.Ecmp:
       description: |-
         This is for cases where Rx packet count across all ports is expected to match the Tx packet count.
-    Flow.TxRxReplication.RxCount:
+    Flow.TxRxRatio.RxCount:
       description: |-
         This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets
         received across all Rx ports is a multiple of Rx port count and Tx packets.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8027,13 +8027,13 @@ components:
           x-enum:
             one:
               x-field-uid: 1
-            rx_ports_count:
+            rx_count:
               x-field-uid: 2
             custom:
               x-field-uid: 3
           enum:
           - one
-          - rx_ports_count
+          - rx_count
           - custom
         one:
           $ref: '#/components/schemas/Flow.TxRxReplication.Ecmp'

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -4643,6 +4643,8 @@ message FlowPort {
   // required = true
   string tx_name = 1;
 
+  // Deprecated: This property is deprecated in favor of property rx_names
+  // 
   // The unique name of a port that is the intended receive port.
   // 
   // x-constraint:
@@ -4650,6 +4652,14 @@ message FlowPort {
   // - /components/schemas/Lag/properties/name
   // 
   optional string rx_name = 2;
+
+  // Unique names of ports that are intended receive ports.
+  // 
+  // x-constraint:
+  // - /components/schemas/Port/properties/name
+  // - /components/schemas/Lag/properties/name
+  // 
+  repeated string rx_names = 3;
 }
 
 // A container for declaring a map of 1..n transmit devices to 1..n receive devices.
@@ -5761,8 +5771,8 @@ message FlowMetrics {
   // default = False
   optional bool loss = 2;
 
-  // Tx Rx ratio.
-  optional FlowTxRxRatio tx_rx_ratio = 6;
+  // Rx Tx ratio.
+  optional FlowRxTxRatio rx_tx_ratio = 6;
 
   // Enables additional flow metric first and last timestamps.
   // default = False
@@ -5771,10 +5781,8 @@ message FlowMetrics {
   // Latency metrics.
   optional FlowLatencyMetrics latency = 4;
 
-  // Enables Rx port level disaggregation with metrics tag name set as rx_port_name.
-  // The Rx port names can be found under tagged_metrics tag names in flow metrics response.
-  // default = False
-  optional bool rx_per_port = 5;
+  // Predefined metric tags
+  optional FlowPredefinedTags predefined_metric_tags = 5;
 }
 
 // The optional container for per flow latency metric configuration.
@@ -5813,32 +5821,39 @@ message FlowLatencyMetrics {
   optional Mode.Enum mode = 2;
 }
 
-// Tx Rx ratio is the ratio of expected number of Rx packets across all Rx ports to
+// List of predefined flow tracking options, outside packet fields, that can be enabled.
+message FlowPredefinedTags {
+
+  // Enables Rx port or lag level disaggregation with predefined metrics tag name set
+  // as rx_name.
+  // The Rx port / lag names can be found under tagged_metrics tag names in flow metrics
+  // response.
+  // default = False
+  optional bool rx_name = 1;
+}
+
+// Rx Tx ratio is the ratio of expected number of Rx packets across all Rx ports to
 // the Tx packets
 // for the configured flow. It is a factor by which the Tx packet count is multiplied
 // to calculate
 // the sum of expected Rx packet count, across all Rx ports. This will be used to calculate
 // loss
 // percentage of flow at aggregate level.
-message FlowTxRxRatio {
+message FlowRxTxRatio {
 
   message Choice {
     enum Enum {
       unspecified = 0;
-      one = 1;
-      rx_count = 2;
-      custom = 3;
+      rx_count = 1;
+      value = 2;
     }
   }
   // Description missing in models
-  // default = Choice.Enum.one
+  // default = Choice.Enum.value
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowTxRxRatioEcmp one = 2;
-
-  // Description missing in models
-  optional FlowTxRxRatioRxCount rx_count = 3;
+  optional FlowRxTxRatioRxCount rx_count = 2;
 
   // Should be a positive, non-zero value. A custom integer value (>1) can be specified
   // for
@@ -5850,18 +5865,13 @@ message FlowTxRxRatio {
   // received by the
   // Rx port, we may need to specify a fractional value instead.
   // default = 1.0
-  optional float custom = 4;
-}
-
-// This is for cases where Rx packet count across all ports is expected to match the
-// Tx packet count.
-message FlowTxRxRatioEcmp {
+  optional float value = 3;
 }
 
 // This is for cases where one copy each Tx packet is received on all Rx ports and so
 // the sum total of Rx packets
 // received across all Rx ports is a multiple of Rx port count and Tx packets.
-message FlowTxRxRatioRxCount {
+message FlowRxTxRatioRxCount {
 }
 
 // The optional container for event configuration.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5761,8 +5761,9 @@ message FlowMetrics {
   // default = False
   optional bool loss = 2;
 
-  // Tx Rx multiplication factor, required for loss measurement.
-  // default = 0
+  // Tx Rx multiplication factor, required for loss measurement. Should be a positive,
+  // non-zero value.
+  // default = 1
   optional float rx_tx_ratio = 6;
 
   // Enables additional flow metric first and last timestamps.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5868,7 +5868,7 @@ message FlowRxTxRatio {
   optional float value = 3;
 }
 
-// This is for cases where one copy each Tx packet is received on all Rx ports and so
+// This is for cases where one copy of Tx packet is received on all Rx ports and so
 // the sum total of Rx packets
 // received across all Rx ports is a multiple of Rx port count and Tx packets.
 message FlowRxTxRatioRxCount {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5761,6 +5761,10 @@ message FlowMetrics {
   // default = False
   optional bool loss = 2;
 
+  // Tx Rx multiplication factor, required for loss measurement.
+  // default = 0
+  optional float rx_tx_ratio = 6;
+
   // Enables additional flow metric first and last timestamps.
   // default = False
   optional bool timestamps = 3;
@@ -5768,9 +5772,9 @@ message FlowMetrics {
   // Latency metrics.
   optional FlowLatencyMetrics latency = 4;
 
-  // Enables port level disaggregation with metrics tag name set as rx_port_name.
+  // Enables Rx port level disaggregation with metrics tag name set as rx_port_name.
   // default = False
-  optional bool rx_port_disaggregation = 5;
+  optional bool rx_per_port = 5;
 }
 
 // The optional container for per flow latency metric configuration.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -4653,7 +4653,7 @@ message FlowPort {
   // 
   optional string rx_name = 2;
 
-  // Unique names of ports that are intended receive ports.
+  // Unique name of ports or lags that are intended receiving endpoints.
   // 
   // x-constraint:
   // - /components/schemas/Port/properties/name
@@ -5855,8 +5855,10 @@ message FlowRxTxRatio {
   // Description missing in models
   optional FlowRxTxRatioRxCount rx_count = 2;
 
-  // Should be a positive, non-zero value. A custom integer value (>1) can be specified
-  // for
+  // Should be a positive, non-zero value. The default value of 1, is when the Rx packet
+  // count across
+  // all ports is expected to match the Tx packet count. A custom integer value (>1) can
+  // be specified for
   // loss calculation for cases when there are multiple destination addresses configured
   // within one flow,
   // but DUT is configured to replicate only to a subset of Rx ports. For cases when Tx

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5761,10 +5761,8 @@ message FlowMetrics {
   // default = False
   optional bool loss = 2;
 
-  // Tx Rx multiplication factor, required for loss measurement. Should be a positive,
-  // non-zero value.
-  // default = 1
-  optional float rx_tx_ratio = 6;
+  // Tx Rx replication factor.
+  optional FlowTxRxReplication tx_rx_replication_factor = 6;
 
   // Enables additional flow metric first and last timestamps.
   // default = False
@@ -5774,6 +5772,7 @@ message FlowMetrics {
   optional FlowLatencyMetrics latency = 4;
 
   // Enables Rx port level disaggregation with metrics tag name set as rx_port_name.
+  // The Rx port names can be found under tagged_metrics tag names in flow metrics response.
   // default = False
   optional bool rx_per_port = 5;
 }
@@ -5812,6 +5811,53 @@ message FlowLatencyMetrics {
   // standard.
   // default = Mode.Enum.store_forward
   optional Mode.Enum mode = 2;
+}
+
+// Tx Rx replication factor is required to determine the ratio of expected number of
+// Rx packets across all Rx ports
+// to the Tx packets for the configured flow.
+message FlowTxRxReplication {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      one = 1;
+      rx_ports_count = 2;
+      custom = 3;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.one
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  optional FlowTxRxReplicationEcmp one = 2;
+
+  // Description missing in models
+  optional FlowTxRxReplicationRxCount rx_ports_count = 3;
+
+  // Should be a positive, non-zero value. We may need to specify a custom integer value
+  // for
+  // loss calculation for cases when there are multiple destination addresses configured
+  // within one flow,
+  // but DUT is configured to replicate only to a subset of Rx ports. For cases when Tx
+  // side generates two
+  // packets from each source in 1:1 protection mode but only one of the two packets are
+  // received by the
+  // Rx port, we may need to specify a fractional value instead.
+  // default = 1.0
+  optional float custom = 4;
+}
+
+// This is typically for cases where Rx packet count across all ports is expected to
+// match the Tx packet count.
+message FlowTxRxReplicationEcmp {
+}
+
+// This is for cases where one copy each Tx packet is received on all Rx ports and so
+// the sum total of Rx packets
+// received across all Rx ports is a multiple of Rx port count and Tx packets.
+message FlowTxRxReplicationRxCount {
 }
 
 // The optional container for event configuration.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5762,7 +5762,7 @@ message FlowMetrics {
   optional bool loss = 2;
 
   // Tx Rx ratio.
-  optional FlowTxRxReplication tx_rx_ratio = 6;
+  optional FlowTxRxRatio tx_rx_ratio = 6;
 
   // Enables additional flow metric first and last timestamps.
   // default = False
@@ -5813,9 +5813,14 @@ message FlowLatencyMetrics {
   optional Mode.Enum mode = 2;
 }
 
-// Tx Rx ratio is the expected number of Rx packets across all Rx ports to the Tx packets
-// for the configured flow.
-message FlowTxRxReplication {
+// Tx Rx ratio is the ratio of expected number of Rx packets across all Rx ports to
+// the Tx packets
+// for the configured flow. It is a factor by which the Tx packet count is multiplied
+// to calculate
+// the sum of expected Rx packet count, across all Rx ports. This will be used to calculate
+// loss
+// percentage of flow at aggregate level.
+message FlowTxRxRatio {
 
   message Choice {
     enum Enum {
@@ -5830,10 +5835,10 @@ message FlowTxRxReplication {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowTxRxReplicationEcmp one = 2;
+  optional FlowTxRxRatioEcmp one = 2;
 
   // Description missing in models
-  optional FlowTxRxReplicationRxCount rx_count = 3;
+  optional FlowTxRxRatioRxCount rx_count = 3;
 
   // Should be a positive, non-zero value. A custom integer value (>1) can be specified
   // for
@@ -5850,13 +5855,13 @@ message FlowTxRxReplication {
 
 // This is for cases where Rx packet count across all ports is expected to match the
 // Tx packet count.
-message FlowTxRxReplicationEcmp {
+message FlowTxRxRatioEcmp {
 }
 
 // This is for cases where one copy each Tx packet is received on all Rx ports and so
 // the sum total of Rx packets
 // received across all Rx ports is a multiple of Rx port count and Tx packets.
-message FlowTxRxReplicationRxCount {
+message FlowTxRxRatioRxCount {
 }
 
 // The optional container for event configuration.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5761,8 +5761,8 @@ message FlowMetrics {
   // default = False
   optional bool loss = 2;
 
-  // Tx Rx replication factor.
-  optional FlowTxRxReplication tx_rx_replication_factor = 6;
+  // Tx Rx ratio.
+  optional FlowTxRxReplication tx_rx_ratio = 6;
 
   // Enables additional flow metric first and last timestamps.
   // default = False
@@ -5813,9 +5813,8 @@ message FlowLatencyMetrics {
   optional Mode.Enum mode = 2;
 }
 
-// Tx Rx replication factor is required to determine the ratio of expected number of
-// Rx packets across all Rx ports
-// to the Tx packets for the configured flow.
+// Tx Rx ratio is the expected number of Rx packets across all Rx ports to the Tx packets
+// for the configured flow.
 message FlowTxRxReplication {
 
   message Choice {
@@ -5834,9 +5833,9 @@ message FlowTxRxReplication {
   optional FlowTxRxReplicationEcmp one = 2;
 
   // Description missing in models
-  optional FlowTxRxReplicationRxCount rx_ports_count = 3;
+  optional FlowTxRxReplicationRxCount rx_count = 3;
 
-  // Should be a positive, non-zero value. We may need to specify a custom integer value
+  // Should be a positive, non-zero value. A custom integer value (>1) can be specified
   // for
   // loss calculation for cases when there are multiple destination addresses configured
   // within one flow,
@@ -5849,8 +5848,8 @@ message FlowTxRxReplication {
   optional float custom = 4;
 }
 
-// This is typically for cases where Rx packet count across all ports is expected to
-// match the Tx packet count.
+// This is for cases where Rx packet count across all ports is expected to match the
+// Tx packet count.
 message FlowTxRxReplicationEcmp {
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -4653,7 +4653,7 @@ message FlowPort {
   // 
   optional string rx_name = 2;
 
-  // Unique name of ports or lags that are intended receiving endpoints.
+  // Unique name of ports or lags that are intended receive endpoints.
   // 
   // x-constraint:
   // - /components/schemas/Port/properties/name

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -4850,7 +4850,6 @@ message FlowCustomMetricTag {
 
   // Name used to identify the metrics associated with the values applicable
   // for configured offset and length inside corresponding header field
-  // Note: rx_port_name is reserved for rx port level disaggregation
   // required = true
   string name = 1;
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -7514,7 +7514,7 @@ message FlowMetricTagValue {
     enum Enum {
       unspecified = 0;
       hex = 1;
-      string = 2;
+      str = 2;
     }
   }
   // Available formats for metric tag value
@@ -7525,7 +7525,7 @@ message FlowMetricTagValue {
   optional string hex = 2;
 
   // Value represented in string format
-  optional string string = 3;
+  optional string str = 3;
 }
 
 // The container for timestamp metrics.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5821,7 +5821,7 @@ message FlowTxRxReplication {
     enum Enum {
       unspecified = 0;
       one = 1;
-      rx_ports_count = 2;
+      rx_count = 2;
       custom = 3;
     }
   }

--- a/flow/endpoint.yaml
+++ b/flow/endpoint.yaml
@@ -58,11 +58,11 @@ components:
           x-field-uid: 2
         rx_names:
           description: |-
-            Unique name of ports or lags that are intended receiving endpoints.
+            Unique name of ports or lags that are intended receive endpoints.
           type: array
           items:
             description: |-
-              The unique name of a port that is the intended receive port.
+              The unique name of a port or lag that is the intended receive port.
             type: string
           x-constraint:
           - '/components/schemas/Port/properties/name'

--- a/flow/endpoint.yaml
+++ b/flow/endpoint.yaml
@@ -58,7 +58,7 @@ components:
           x-field-uid: 2
         rx_names:
           description: |-
-            Unique names of ports that are intended receive ports.
+            Unique name of ports or lags that are intended receiving endpoints.
           type: array
           items:
             description: |-

--- a/flow/endpoint.yaml
+++ b/flow/endpoint.yaml
@@ -46,12 +46,28 @@ components:
         rx_name:
           description: |-
             The unique name of a port that is the intended receive port.
+          x-status:
+            status: deprecated
+            information: |-
+              This property is deprecated in favor of property rx_names
           type: string
           x-constraint:
           - '/components/schemas/Port/properties/name'
           - '/components/schemas/Lag/properties/name'
 
           x-field-uid: 2
+        rx_names:
+          description: |-
+            Unique names of ports that are intended receive ports.
+          type: array
+          items:
+            description: |-
+              The unique name of a port that is the intended receive port.
+            type: string
+          x-constraint:
+          - '/components/schemas/Port/properties/name'
+          - '/components/schemas/Lag/properties/name'
+          x-field-uid: 3
     Flow.Router:
       description: >-
         A container for declaring a map of 1..n transmit devices

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -19,6 +19,13 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
+        rx_tx_ratio:
+          description: |-
+            Tx Rx multiplication factor, required for loss measurement.
+          type: number
+          format: float
+          default: 0
+          x-field-uid: 6
         timestamps:
           description: |-
             Enables additional flow metric first and last timestamps.
@@ -30,9 +37,9 @@ components:
             Latency metrics.
           $ref: '#/components/schemas/Flow.Latency.Metrics'
           x-field-uid: 4
-        rx_port_disaggregation:
+        rx_per_port:
           description: |-
-            Enables port level disaggregation with metrics tag name set as "rx_port_name".
+            Enables Rx port level disaggregation with metrics tag name set as "rx_port_name".
           type: boolean
           default: false
           x-field-uid: 5

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -19,12 +19,10 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-        rx_tx_ratio:
+        tx_rx_replication_factor:
           description: |-
-            Tx Rx multiplication factor, required for loss measurement. Should be a positive, non-zero value.
-          type: number
-          format: float
-          default: 1
+            Tx Rx replication factor.
+          $ref: '#/components/schemas/Flow.TxRxReplication'
           x-field-uid: 6
         timestamps:
           description: |-
@@ -40,6 +38,7 @@ components:
         rx_per_port:
           description: |-
             Enables Rx port level disaggregation with metrics tag name set as "rx_port_name".
+            The Rx port names can be found under tagged_metrics tag names in flow metrics response.
           type: boolean
           default: false
           x-field-uid: 5
@@ -82,3 +81,44 @@ components:
               x-field-uid: 1
             cut_through:
               x-field-uid: 2
+    Flow.TxRxReplication:
+      description: |-
+        Tx Rx replication factor is required to determine the ratio of expected number of Rx packets across all Rx ports
+        to the Tx packets for the configured flow.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: one
+          x-field-uid: 1
+          x-enum:
+            one:
+              x-field-uid: 1
+            rx_ports_count:
+              x-field-uid: 2
+            custom:
+              x-field-uid: 3
+        one:
+          $ref: '#/components/schemas/Flow.TxRxReplication.Ecmp'
+          x-field-uid: 2
+        rx_ports_count:
+          $ref: '#/components/schemas/Flow.TxRxReplication.RxCount'
+          x-field-uid: 3
+        custom:
+          description: |-
+            Should be a positive, non-zero value. We may need to specify a custom integer value for
+            loss calculation for cases when there are multiple destination addresses configured within one flow,
+            but DUT is configured to replicate only to a subset of Rx ports. For cases when Tx side generates two
+            packets from each source in 1:1 protection mode but only one of the two packets are received by the
+            Rx port, we may need to specify a fractional value instead.
+          type: number
+          format: float
+          default: 1.0
+          x-field-uid: 4
+    Flow.TxRxReplication.Ecmp:
+      description: |-
+        This is typically for cases where Rx packet count across all ports is expected to match the Tx packet count.
+    Flow.TxRxReplication.RxCount:
+      description: |-
+        This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets
+        received across all Rx ports is a multiple of Rx port count and Tx packets.

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -22,7 +22,7 @@ components:
         tx_rx_ratio:
           description: |-
             Tx Rx ratio.
-          $ref: '#/components/schemas/Flow.TxRxReplication'
+          $ref: '#/components/schemas/Flow.TxRxRatio'
           x-field-uid: 6
         timestamps:
           description: |-
@@ -81,10 +81,12 @@ components:
               x-field-uid: 1
             cut_through:
               x-field-uid: 2
-    Flow.TxRxReplication:
+    Flow.TxRxRatio:
       description: |-
-        Tx Rx ratio is the expected number of Rx packets across all Rx ports to the Tx packets
-        for the configured flow.
+        Tx Rx ratio is the ratio of expected number of Rx packets across all Rx ports to the Tx packets
+        for the configured flow. It is a factor by which the Tx packet count is multiplied to calculate
+        the sum of expected Rx packet count, across all Rx ports. This will be used to calculate loss
+        percentage of flow at aggregate level.
       type: object
       properties:
         choice:
@@ -99,10 +101,10 @@ components:
             custom:
               x-field-uid: 3
         one:
-          $ref: '#/components/schemas/Flow.TxRxReplication.Ecmp'
+          $ref: '#/components/schemas/Flow.TxRxRatio.Ecmp'
           x-field-uid: 2
         rx_count:
-          $ref: '#/components/schemas/Flow.TxRxReplication.RxCount'
+          $ref: '#/components/schemas/Flow.TxRxRatio.RxCount'
           x-field-uid: 3
         custom:
           description: |-
@@ -115,10 +117,10 @@ components:
           format: float
           default: 1.0
           x-field-uid: 4
-    Flow.TxRxReplication.Ecmp:
+    Flow.TxRxRatio.Ecmp:
       description: |-
         This is for cases where Rx packet count across all ports is expected to match the Tx packet count.
-    Flow.TxRxReplication.RxCount:
+    Flow.TxRxRatio.RxCount:
       description: |-
         This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets
         received across all Rx ports is a multiple of Rx port count and Tx packets.

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -19,9 +19,9 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-        tx_rx_replication_factor:
+        tx_rx_ratio:
           description: |-
-            Tx Rx replication factor.
+            Tx Rx ratio.
           $ref: '#/components/schemas/Flow.TxRxReplication'
           x-field-uid: 6
         timestamps:
@@ -83,8 +83,8 @@ components:
               x-field-uid: 2
     Flow.TxRxReplication:
       description: |-
-        Tx Rx replication factor is required to determine the ratio of expected number of Rx packets across all Rx ports
-        to the Tx packets for the configured flow.
+        Tx Rx ratio is the expected number of Rx packets across all Rx ports to the Tx packets
+        for the configured flow.
       type: object
       properties:
         choice:
@@ -101,12 +101,12 @@ components:
         one:
           $ref: '#/components/schemas/Flow.TxRxReplication.Ecmp'
           x-field-uid: 2
-        rx_ports_count:
+        rx_count:
           $ref: '#/components/schemas/Flow.TxRxReplication.RxCount'
           x-field-uid: 3
         custom:
           description: |-
-            Should be a positive, non-zero value. We may need to specify a custom integer value for
+            Should be a positive, non-zero value. A custom integer value (>1) can be specified for
             loss calculation for cases when there are multiple destination addresses configured within one flow,
             but DUT is configured to replicate only to a subset of Rx ports. For cases when Tx side generates two
             packets from each source in 1:1 protection mode but only one of the two packets are received by the
@@ -117,7 +117,7 @@ components:
           x-field-uid: 4
     Flow.TxRxReplication.Ecmp:
       description: |-
-        This is typically for cases where Rx packet count across all ports is expected to match the Tx packet count.
+        This is for cases where Rx packet count across all ports is expected to match the Tx packet count.
     Flow.TxRxReplication.RxCount:
       description: |-
         This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -94,7 +94,7 @@ components:
           x-enum:
             one:
               x-field-uid: 1
-            rx_ports_count:
+            rx_count:
               x-field-uid: 2
             custom:
               x-field-uid: 3

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -19,10 +19,10 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-        tx_rx_ratio:
+        rx_tx_ratio:
           description: |-
-            Tx Rx ratio.
-          $ref: '#/components/schemas/Flow.TxRxRatio'
+            Rx Tx ratio.
+          $ref: '#/components/schemas/Flow.RxTxRatio'
           x-field-uid: 6
         timestamps:
           description: |-
@@ -35,12 +35,10 @@ components:
             Latency metrics.
           $ref: '#/components/schemas/Flow.Latency.Metrics'
           x-field-uid: 4
-        rx_per_port:
+        predefined_metric_tags:
           description: |-
-            Enables Rx port level disaggregation with metrics tag name set as "rx_port_name".
-            The Rx port names can be found under tagged_metrics tag names in flow metrics response.
-          type: boolean
-          default: false
+            Predefined metric tags
+          $ref: '#/components/schemas/Flow.Predefined.Tags'
           x-field-uid: 5
     Flow.Latency.Metrics:
       description: |-
@@ -81,9 +79,21 @@ components:
               x-field-uid: 1
             cut_through:
               x-field-uid: 2
-    Flow.TxRxRatio:
+    Flow.Predefined.Tags:
       description: |-
-        Tx Rx ratio is the ratio of expected number of Rx packets across all Rx ports to the Tx packets
+        List of predefined flow tracking options, outside packet fields, that can be enabled.
+      type: object
+      properties:
+        rx_name:
+          description: |-
+            Enables Rx port or lag level disaggregation with predefined metrics tag name set as "rx_name".
+            The Rx port / lag names can be found under tagged_metrics tag names in flow metrics response.
+          type: boolean
+          default: false
+          x-field-uid: 1
+    Flow.RxTxRatio:
+      description: |-
+        Rx Tx ratio is the ratio of expected number of Rx packets across all Rx ports to the Tx packets
         for the configured flow. It is a factor by which the Tx packet count is multiplied to calculate
         the sum of expected Rx packet count, across all Rx ports. This will be used to calculate loss
         percentage of flow at aggregate level.
@@ -91,22 +101,17 @@ components:
       properties:
         choice:
           type: string
-          default: one
+          default: value
           x-field-uid: 1
           x-enum:
-            one:
-              x-field-uid: 1
             rx_count:
+              x-field-uid: 1
+            value:
               x-field-uid: 2
-            custom:
-              x-field-uid: 3
-        one:
-          $ref: '#/components/schemas/Flow.TxRxRatio.Ecmp'
-          x-field-uid: 2
         rx_count:
-          $ref: '#/components/schemas/Flow.TxRxRatio.RxCount'
-          x-field-uid: 3
-        custom:
+          $ref: '#/components/schemas/Flow.RxTxRatio.RxCount'
+          x-field-uid: 2
+        value:
           description: |-
             Should be a positive, non-zero value. A custom integer value (>1) can be specified for
             loss calculation for cases when there are multiple destination addresses configured within one flow,
@@ -116,11 +121,8 @@ components:
           type: number
           format: float
           default: 1.0
-          x-field-uid: 4
-    Flow.TxRxRatio.Ecmp:
-      description: |-
-        This is for cases where Rx packet count across all ports is expected to match the Tx packet count.
-    Flow.TxRxRatio.RxCount:
+          x-field-uid: 3
+    Flow.RxTxRatio.RxCount:
       description: |-
         This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets
         received across all Rx ports is a multiple of Rx port count and Tx packets.

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -21,10 +21,10 @@ components:
           x-field-uid: 2
         rx_tx_ratio:
           description: |-
-            Tx Rx multiplication factor, required for loss measurement.
+            Tx Rx multiplication factor, required for loss measurement. Should be a positive, non-zero value.
           type: number
           format: float
-          default: 0
+          default: 1
           x-field-uid: 6
         timestamps:
           description: |-

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -113,7 +113,8 @@ components:
           x-field-uid: 2
         value:
           description: |-
-            Should be a positive, non-zero value. A custom integer value (>1) can be specified for
+            Should be a positive, non-zero value. The default value of 1, is when the Rx packet count across
+            all ports is expected to match the Tx packet count. A custom integer value (>1) can be specified for
             loss calculation for cases when there are multiple destination addresses configured within one flow,
             but DUT is configured to replicate only to a subset of Rx ports. For cases when Tx side generates two
             packets from each source in 1:1 protection mode but only one of the two packets are received by the

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -30,6 +30,12 @@ components:
             Latency metrics.
           $ref: '#/components/schemas/Flow.Latency.Metrics'
           x-field-uid: 4
+        rx_port_disaggregation:
+          description: |-
+            Enables port level disaggregation with metrics tag name set as "rx_port_name".
+          type: boolean
+          default: false
+          x-field-uid: 5
     Flow.Latency.Metrics:
       description: |-
         The optional container for per flow latency metric configuration.

--- a/flow/metrics.yaml
+++ b/flow/metrics.yaml
@@ -124,5 +124,5 @@ components:
           x-field-uid: 3
     Flow.RxTxRatio.RxCount:
       description: |-
-        This is for cases where one copy each Tx packet is received on all Rx ports and so the sum total of Rx packets
+        This is for cases where one copy of Tx packet is received on all Rx ports and so the sum total of Rx packets
         received across all Rx ports is a multiple of Rx port count and Tx packets.

--- a/flow/packet-headers/custom.yaml
+++ b/flow/packet-headers/custom.yaml
@@ -36,6 +36,7 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable
             for configured offset and length inside corresponding header field
+            Note: "rx_port_name" is reserved for rx port level disaggregation
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1

--- a/flow/packet-headers/custom.yaml
+++ b/flow/packet-headers/custom.yaml
@@ -36,7 +36,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable
             for configured offset and length inside corresponding header field
-            Note: "rx_port_name" is reserved for rx port level disaggregation
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -287,7 +287,6 @@ components:
         string:
           description: Value represented in string format
           type: string
-          format: string
           x-field-uid: 3
     Metric.Timestamp:
       description: |-

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -276,7 +276,7 @@ components:
           x-enum:
             hex:
               x-field-uid: 1
-            string:
+            str:
               x-field-uid: 2
           x-field-uid: 1
         hex:
@@ -284,7 +284,7 @@ components:
           type: string
           format: hex
           x-field-uid: 2
-        string:
+        str:
           description: Value represented in string format
           type: string
           x-field-uid: 3

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -276,12 +276,19 @@ components:
           x-enum:
             hex:
               x-field-uid: 1
+            string:
+              x-field-uid: 2
           x-field-uid: 1
         hex:
           description: Value represented in hexadecimal format
           type: string
           format: hex
           x-field-uid: 2
+        string:
+          description: Value represented in string format
+          type: string
+          format: string
+          x-field-uid: 3
     Metric.Timestamp:
       description: |-
         The container for timestamp metrics.


### PR DESCRIPTION
Support to address issue #319 (Metrics response disaggregation based on Rx ports).

This is Rx port level disaggregation of metrics response required for multi Rx port device (and raw) traffic. Also addressed is support for specifying Rx/Tx frames ratio.

Example code snippet
```
config.Ports().Add().SetName("p1").SetLocation("localhost:5555")
config.Ports().Add().SetName("p2").SetLocation("localhost:5555")
config.Ports().Add().SetName("p3").SetLocation("localhost:5555")
```

For control plane BGP sessions configured on P1, P2 and P3 with device names
p1d1peer1rrv4, p2d1peer1rrv4 and p3d1peer1rrv4 respectively.
Following is the data plane configuration

```
flow := config.Flows().Add()
flow.Metrics().SetEnable(true).PredefinedMetricTags().SetRxName(true)
```

We are expecting Tx and Rx packets to match in this example and hence the Tx Rx ratio is set to "one"
```
flow.Metrics().RxTxRatio().SetChoice("value")
flow.Duration().FixedPackets().SetPackets(1000)

flow.SetName("f1").TxRx().Device().
	SetTxNames([]string{"p1d1peer1rrv4"}).
	SetRxNames([]string{"p2d1peer1rrv4", "p3d1peer1rrv4"})

flowEth := flow.Packet().Add().Ethernet()
flowEth.Src().SetValue("00:00:01:01:01:01")
flowEth.Dst().SetChoice("auto")

flowIp := flow.Packet().Add().Ipv4()
flowIp.Src().SetValue("10.10.10.1")
flowIp.Dst().SetValues([]string{"20.20.20.1", "30.30.30.1"})

client.SetConfig(config)
```

Query for metrics results
```
client.GetFlowMetrics(nil, nil)

Flow      Frames Tx      Bytes Tx      Frames Rx     Bytes Rx      Tags
f1        1000           64000         1000          64000
f1                                     500           32000         rx_name: p2
f1                                     500           32000         rx_name: p3

```
Note: The “rx_name” would be in-built tag name for Rx ports and cannot be used for any egress tracking name.
