### PR TITLE
Support for MED and Local Preference for BGPv4/v6 metric state.

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -12072,6 +12072,18 @@ components:
         as_path:
           x-field-uid: 8
           $ref: '#/components/schemas/Result.BgpAsPath'
+        local_preference:
+          x-field-uid: 9
+          description: |-
+            The local preference is a well-known attribute and the value is used for route selection. The route with the highest local preference value is preferred.
+          type: integer
+          format: uint32
+        multi_exit_discriminator:
+          x-field-uid: 10
+          description: |-
+            The multi exit discriminator (MED) is an optional non-transitive attribute and the value is used for route selection. The route with the lowest MED value is preferred.
+          type: integer
+          format: uint32
     BgpPrefixIpv6Unicast.State:
       description: |-
         IPv6 unicast prefix.
@@ -12130,6 +12142,18 @@ components:
         as_path:
           x-field-uid: 8
           $ref: '#/components/schemas/Result.BgpAsPath'
+        local_preference:
+          x-field-uid: 9
+          description: |-
+            The local preference is a well-known attribute and the value is used for route selection. The route with the highest local preference value is preferred.
+          type: integer
+          format: uint32
+        multi_exit_discriminator:
+          x-field-uid: 10
+          description: |-
+            The multi exit discriminator (MED) is an optional non-transitive attribute and the value is used for route selection. The route with the lowest MED value is preferred.
+          type: integer
+          format: uint32
     Result.BgpCommunity:
       description: |-
         BGP communities provide additional capability for tagging routes and  for modifying BGP routing policy on upstream and downstream routers. BGP community is a 32-bit number which is broken into 16-bit AS number and  a 16-bit custom value.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8614,6 +8614,14 @@ message BgpPrefixIpv4UnicastState {
 
   // Description missing in models
   optional ResultBgpAsPath as_path = 8;
+
+  // The local preference is a well-known attribute and the value is used for route selection.
+  // The route with the highest local preference value is preferred.
+  optional uint32 local_preference = 9;
+
+  // The multi exit discriminator (MED) is an optional non-transitive attribute and the
+  // value is used for route selection. The route with the lowest MED value is preferred.
+  optional uint32 multi_exit_discriminator = 10;
 }
 
 // IPv6 unicast prefix.
@@ -8650,6 +8658,14 @@ message BgpPrefixIpv6UnicastState {
 
   // Description missing in models
   optional ResultBgpAsPath as_path = 8;
+
+  // The local preference is a well-known attribute and the value is used for route selection.
+  // The route with the highest local preference value is preferred.
+  optional uint32 local_preference = 9;
+
+  // The multi exit discriminator (MED) is an optional non-transitive attribute and the
+  // value is used for route selection. The route with the lowest MED value is preferred.
+  optional uint32 multi_exit_discriminator = 10;
 }
 
 // BGP communities provide additional capability for tagging routes and  for modifying

--- a/result/bgpprefix.yaml
+++ b/result/bgpprefix.yaml
@@ -169,6 +169,12 @@ components:
         as_path:
           x-include: '#/components/schemas/BgpPrefix.State/properties/as_path'
           x-field-uid: 8
+        local_preference:
+          x-include: '#/components/schemas/BgpPrefix.State/properties/local_preference'
+          x-field-uid: 9
+        multi_exit_discriminator:
+          x-include: '#/components/schemas/BgpPrefix.State/properties/multi_exit_discriminator'
+          x-field-uid: 10
     BgpPrefixIpv6Unicast.State:
       description: >-
         IPv6 unicast prefix.
@@ -200,6 +206,12 @@ components:
         as_path:
           x-include: '#/components/schemas/BgpPrefix.State/properties/as_path'
           x-field-uid: 8
+        local_preference:
+          x-include: '#/components/schemas/BgpPrefix.State/properties/local_preference'
+          x-field-uid: 9
+        multi_exit_discriminator:
+          x-include: '#/components/schemas/BgpPrefix.State/properties/multi_exit_discriminator'
+          x-field-uid: 10
     BgpPrefix.State:
       description: >-
         BGP peer prefix.
@@ -249,3 +261,17 @@ components:
         as_path:
           $ref: './resultbgpaspath.yaml#/components/schemas/Result.BgpAsPath'
           x-field-uid: 7
+        local_preference:
+          description: >-
+            The local preference is a well-known attribute and the value is used for route selection.
+            The route with the highest local preference value is preferred.
+          type: integer
+          format : uint32
+          x-field-uid: 8
+        multi_exit_discriminator:
+          description: >-
+            The multi exit discriminator (MED) is an optional non-transitive attribute and the value is used for route selection.
+            The route with the lowest MED value is preferred.
+          type: integer
+          format : uint32
+          x-field-uid: 9


### PR DESCRIPTION
Support is needed for fetching Local Preference and MED values received  for IPv4 and IPv6 prefixes from Device under Test as received by test port. RIB/Learned information filter must be enabled. 
More details are present in linked issue ( [https://github.com/open-traffic-generator/models/issues/325](https://github.com/open-traffic-generator/models/issues/325))

The redocli view of the changes is available @ https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/bgp_li_med_localpref/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_states.
[ New attributes for MED and LocalPref @ Responses/200/bgp_prefixes/ipv4_unicast_prefixes and ipv6_unicast_prefixes in above link ] 
Example snappi config and fetching of Bgp State and access of MED and LocalPreference via OTG APIs.( Note that this is a sample script added for API usage illustration only ) .

Go snappi example: 
```go
package gosnappi_test

import (
	"fmt"
	"log"
	"strings"
	"testing"

	"github.com/open-traffic-generator/snappi/gosnappi"
)
func TestDevices(t *testing.T) {
	api := gosnappi.NewApi()
	api.NewGrpcTransport().SetLocation("127.0.0.1:50001")
	config := api.NewConfig()
	device := config.Devices().Add().SetName("d1")
	device1 := config.Devices().Add().SetName("d2")

	eth := device.Ethernets().Add().
		SetPortName("p1").
		SetName("p1_eth1").
		SetMac("00:00:11:11:00:00").
		SetMtu(1500)
	eth.Ipv4Addresses().Add().SetName("p1_ip1").SetGateway("20.20.20.1").SetAddress("20.20.20.2")
	bgp := device.Bgp().SetName("p1_d1_bgp")
	bgp.SerRouterId("1.1.1.1")
	bgpiface1 = bgp.Ipv4Interfaces().Add()..SetIpv4Name("p1_ip1")
	bgppeer1 :=     bgpiface1.peers()..v4peer().Add().SetName("p1_bgp1").SetPeerAddress("20.20.20.1").SetAsType("ebgp").SetAsNumber("100")
	bgppeer1.LearnedInformationFilter().SetUnicastIpv4Prefix(true)
	rr1 := bgppeer1.
	       V4Routes().
                Add().
                SetName("rr1")
        rr1.Addresses().Add().
                SetAddress("10.10.10.0").
                SetPrefix(24).
                SetCount(2).
                SetStep(2)
        rr1.Advanced().
                SetMultiExitDiscriminator(100).
                SetLocalPreference(0)

	eth1 := device1.Ethernets().Add().
		SetPortName("p2").
		SetName("p2_eth1").
		SetMac("00:00:12:11:00:00").
		SetMtu(1500)
	eth1.Ipv4Addresses().Add().SetName("p2_ip1").SetGateway("20.20.20.2").SetAddress("20.20.20.1")
	bgp1 := device1.Bgp().SetName("p2_d1_bgp")
	bgp1.SerRouterId("20.20.20.20")
	bgpiface2 = bgp1.Ipv4Interfaces().Add()..SetIpv4Name("p2_ip1")
	bgppeer2 :=        bgpiface2.peers()..v4peer().Add().SetName("p2_bgp1").SetPeerAddress("20.20.20.2").SetAsType("ebgp").SetAsNumber("200")
	bgppeer2.LearnedInformationFilter().SetUnicastIpv4Prefix(true)
	rr2 := bgppeer1.
	       V4Routes().
                Add().
                SetName("rr2")
        rr2.Addresses().Add().
                SetAddress("11.10.10.0").
                SetPrefix(24).
                SetCount(2).
                SetStep(2)
        rr2.Advanced().
                SetMultiExitDiscriminator(100).
                SetLocalPreference(0)
	//fmt.Println(config.ToJson())

	api.SetConfig(config)
	peerNames := []string{}
	for _, d := range config.Devices().Items() {
		bgp := d.Bgp()
		for _, ip := range bgp.Ipv4Interfaces().Items() {
			for _, peer := range ip.Peers().Items() {
				peerNames = append(dNames, peer.Name())
			}
		}
	}
       
      /* Start protocols , ensure sessions are up , check that routes are received , then fetch state as shown below
         to confirm is LocalPreference and MED is received as expected */

       req := client.Api().NewStatesRequest()
        req.BgpPrefixes().SetBgpPeerNames(peerNames)
        res, err := client.GetStates(req)
        if err != nil {
                return nil, err
        }
	
        /*  Loop through all peers in result */
        for _, prefixesPerPeer := range res.BgpPrefixes().Items() {
                        /* Set of prefixes received by each peer */
                        for _, ipv4Prefix := range prefixesPerPeer.Ipv4UnicastPrefixes().Items() {
                                    if ipv4Prefix.MultiExitDiscriminator() != 100{
         			         // do something
		                    }
		                    if ipv4Prefix.LocalPreference() != 0{
			                 // do something
		                   }
		      }
	}
}
```



