### PR TITLE
Bgp rib rx metric

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -10423,6 +10423,8 @@ components:
                 x-field-uid: 14
               fsm_state:
                 x-field-uid: 15
+              end_of_rib_received:
+                x-field-uid: 16
             enum:
             - session_state
             - session_flap_count
@@ -10439,6 +10441,7 @@ components:
             - notifications_sent
             - notifications_received
             - fsm_state
+            - end_of_rib_received
           x-field-uid: 2
     Bgpv4.Metric:
       description: |-
@@ -10553,6 +10556,12 @@ components:
           - opensent
           - openconfirm
           - established
+        end_of_rib_received:
+          description: |-
+            Number of End-of-RIB markers received indicating the completion of the initial routing update for a  particular <AFI, SAFI> address family after the session is established. For the IPv4 unicast address family, the End-of-RIB marker is an UPDATE message with the minimum length. For any other address family, it is an UPDATE message that contains only the MP_UNREACH_NLRI attribute with  no withdrawn routes for that <AFI, SAFI>.
+          type: integer
+          format: uint64
+          x-field-uid: 17
     Bgpv6.Metrics.Request:
       description: |-
         The request to retrieve BGPv6 per peer metrics/statistics.
@@ -10607,6 +10616,8 @@ components:
                 x-field-uid: 14
               fsm_state:
                 x-field-uid: 15
+              end_of_rib_received:
+                x-field-uid: 16
             enum:
             - session_state
             - session_flap_count
@@ -10623,6 +10634,7 @@ components:
             - notifications_sent
             - notifications_received
             - fsm_state
+            - end_of_rib_received
           x-field-uid: 2
     Bgpv6.Metric:
       description: |-
@@ -10737,6 +10749,12 @@ components:
           - opensent
           - openconfirm
           - established
+        end_of_rib_received:
+          description: |-
+            Number of End-of-RIB markers received indicating the completion of the initial routing update for a  particular <AFI, SAFI> address family after the session is established. For the IPv4 unicast address family, the End-of-RIB marker is an UPDATE message with the minimum length. For any other address family, it is an UPDATE message that contains only the MP_UNREACH_NLRI attribute with  no withdrawn routes for that <AFI, SAFI>.
+          type: integer
+          format: uint64
+          x-field-uid: 17
     Isis.Metrics.Request:
       description: |-
         The request to retrieve ISIS per Router metrics/statistics.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -7586,6 +7586,7 @@ message Bgpv4MetricsRequest {
       notifications_sent = 13;
       notifications_received = 14;
       fsm_state = 15;
+      end_of_rib_received = 16;
     }
   }
   // The list of column names that the returned result set will contain. If the list is
@@ -7673,6 +7674,13 @@ message Bgpv4Metric {
   // remote peer. Established refers to the state where the BGP session with the peer
   // is established.
   optional FsmState.Enum fsm_state = 16;
+
+  // Number of End-of-RIB markers received indicating the completion of the initial routing
+  // update for a  particular <AFI, SAFI> address family after the session is established.
+  // For the IPv4 unicast address family, the End-of-RIB marker is an UPDATE message with
+  // the minimum length. For any other address family, it is an UPDATE message that contains
+  // only the MP_UNREACH_NLRI attribute with  no withdrawn routes for that <AFI, SAFI>.
+  optional uint64 end_of_rib_received = 17;
 }
 
 // The request to retrieve BGPv6 per peer metrics/statistics.
@@ -7704,6 +7712,7 @@ message Bgpv6MetricsRequest {
       notifications_sent = 13;
       notifications_received = 14;
       fsm_state = 15;
+      end_of_rib_received = 16;
     }
   }
   // The list of column names that the returned result set will contain. If the list is
@@ -7791,6 +7800,13 @@ message Bgpv6Metric {
   // remote peer. Established refers to the state where the BGP session with the peer
   // is established.
   optional FsmState.Enum fsm_state = 16;
+
+  // Number of End-of-RIB markers received indicating the completion of the initial routing
+  // update for a  particular <AFI, SAFI> address family after the session is established.
+  // For the IPv4 unicast address family, the End-of-RIB marker is an UPDATE message with
+  // the minimum length. For any other address family, it is an UPDATE message that contains
+  // only the MP_UNREACH_NLRI attribute with  no withdrawn routes for that <AFI, SAFI>.
+  optional uint64 end_of_rib_received = 17;
 }
 
 // The request to retrieve ISIS per Router metrics/statistics.

--- a/result/bgpv4.yaml
+++ b/result/bgpv4.yaml
@@ -58,6 +58,8 @@ components:
                 x-field-uid: 14
               fsm_state:
                 x-field-uid: 15
+              end_of_rib_received:
+                x-field-uid: 16
           x-field-uid: 2
     Bgpv4.Metric:
       description: >-
@@ -170,3 +172,13 @@ components:
               x-field-uid: 5
             established:
               x-field-uid: 6
+        end_of_rib_received:
+          description: >-
+            Number of End-of-RIB markers received indicating the completion of the initial routing update for a 
+            particular <AFI, SAFI> address family after the session is established.
+            For the IPv4 unicast address family, the End-of-RIB marker is an UPDATE message with the minimum length.
+            For any other address family, it is an UPDATE message that contains only the MP_UNREACH_NLRI attribute with 
+            no withdrawn routes for that <AFI, SAFI>.
+          type: integer
+          format: uint64
+          x-field-uid: 17

--- a/result/bgpv6.yaml
+++ b/result/bgpv6.yaml
@@ -59,6 +59,8 @@ components:
                 x-field-uid: 14
               fsm_state:
                 x-field-uid: 15
+              end_of_rib_received:
+                x-field-uid: 16
           x-field-uid: 2
     Bgpv6.Metric:
       description: >-
@@ -171,3 +173,13 @@ components:
               x-field-uid: 5
             established:
               x-field-uid: 6
+        end_of_rib_received:
+          description: >-
+            Number of End-of-RIB markers received indicating the completion of the initial routing update for a 
+            particular <AFI, SAFI> address family after the session is established.
+            For the IPv4 unicast address family, the End-of-RIB marker is an UPDATE message with the minimum length.
+            For any other address family, it is an UPDATE message that contains only the MP_UNREACH_NLRI attribute with 
+            no withdrawn routes for that <AFI, SAFI>.
+          type: integer
+          format: uint64
+          x-field-uid: 17


### PR DESCRIPTION
Support needed for End-of-RIB Rx in per peer telemetry to verify if DUT has correctly sent EoRs during GR tests.

More details are present in linked issue ( [Support for End-of-RIB Rx in BGPv4/v6 per peer metrics](https://github.com/open-traffic-generator/models/issues/328))

The redocli view of the changes is available @ https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/bgp_rib_rx_metric/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_metrics .
[ 1) New end_of_rib_received counter @ Responses/200/[bgpv4_metrics|bgpv6_metrics]/end_of_rib_received   
   2) New end_of_rib_received column name in Request/[bgpv4|bgpv6]/column_names ] 

Example snappi config and fetching of Bgp metric and access end_of_rib_received via OTG APIs.( Note that this is a sample script added for API usage illustration only ) .

Go snappi example: 
```go
package gosnappi_test

import (
	"fmt"
	"log"
	"strings"
	"testing"

	"github.com/open-traffic-generator/snappi/gosnappi"
)
func TestDevices(t *testing.T) {
	api := gosnappi.NewApi()
	api.NewGrpcTransport().SetLocation("127.0.0.1:50001")
	config := api.NewConfig()
	device := config.Devices().Add().SetName("d1")
	device1 := config.Devices().Add().SetName("d2")

	eth := device.Ethernets().Add().
		SetPortName("p1").
		SetName("p1_eth1").
		SetMac("00:00:11:11:00:00").
		SetMtu(1500)
	eth.Ipv4Addresses().Add().SetName("p1_ip1").SetGateway("20.20.20.1").SetAddress("20.20.20.2")
	bgp := device.Bgp().SetName("p1_d1_bgp")
	bgp.SerRouterId("1.1.1.1")
	bgpiface1 = bgp.Ipv4Interfaces().Add()..SetIpv4Name("p1_ip1")
	bgppeer1 :=     bgpiface1.peers()..v4peer().Add().SetName("p1_bgp1").SetPeerAddress("20.20.20.1").SetAsType("ebgp").SetAsNumber("100")
        bgppeer1.GracefulRestart().SetEnableGr(true)
	rr1 := bgppeer1.
	       V4Routes().
                Add().
                SetName("rr1")
        rr1.Addresses().Add().
                SetAddress("10.10.10.0").
                SetPrefix(24).
                SetCount(2).
                SetStep(2)
       
       eth1 := device1.Ethernets().Add().
		SetPortName("p2").
		SetName("p2_eth1").
		SetMac("00:00:12:11:00:00").
		SetMtu(1500)
	eth1.Ipv4Addresses().Add().SetName("p2_ip1").SetGateway("20.20.20.2").SetAddress("20.20.20.1")
	bgp1 := device1.Bgp().SetName("p2_d1_bgp")
	bgp1.SerRouterId("20.20.20.20")
	bgpiface2 = bgp1.Ipv4Interfaces().Add().SetIpv4Name("p2_ip1")
	bgppeer2 :=        
     bgpiface2.peers().v4peer().Add().SetName("p2_bgp1").SetPeerAddress("20.20.20.2").SetAsType("ebgp").SetAsNumber("200")
        bgppeer2.GracefulRestart().SetEnableGr(true)
	rr2 := bgppeer1.
	       V4Routes().
                Add().
                SetName("rr2")
        rr2.Addresses().Add().
                SetAddress("11.10.10.0").
                SetPrefix(24).
                SetCount(2).
                SetStep(2)
	//fmt.Println(config.ToJson())

	api.SetConfig(config)      
      
/* Start protocols , ensure sessions are up   */
      
      /* Ensure that peer1 has sent 2 EoRs on session up in a waitFor loop or after appropriate time */
      
      /* Trigger restart on peer1 */
         s := client.Api().NewControlAction().
                 SetChoice(gosnappi.ControlActionChoice.PROTOCOL)
        s.Protocol().
                SetChoice(gosnappi.ActionProtocolChoice.BGP).
                Bgp().
                SetChoice(gosnappi.ActionProtocolBgpChoice.INITIATE_GRACEFUL_RESTART).
                InitiateGracefulRestart().
                SetPeerNames([]string{"p1_bgp1"}).
                SetRestartDelay(20)
        client.SetControlAction(s)

       time.Sleep(30 * time.Second)
      /* After restart and using multiple polling or proper wait , ensure on peer2 
          that peer1 has sent 2 more EoRs ( for IPv4 and IPv6 ) */

        req := client.Api().NewMetricsRequest()
        req.Bgpv4().SetPeerNames([]string{"p1_bgp1"})
        res, err := client.GetMetrics(req)
        if err != nil {
                return nil, err
        }
            
        /*  Loop through all peers in result */
        for _, prefixesPerPeer := range res.Bgpv4Metrics().Items() {
         
	}
        for _, d := range res.Bgpv4Metrics().Items() {
                //For IPv4 and IPv6 Unicast AFI/SAFI EoRs rxed twice : once initially and once after restart 
                if d.EndOfRibReceived() != 4{  
                       // Report error and take action etc.
                }
        }

}
```
