### PR TITLE
Revisit common properties used in Layer1 configuration

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -256,6 +256,8 @@ components:
         layer1:
           description: |-
             The layer1 settings that will be configured on the traffic generator.
+            Since layer1 settings usually vary across variety of test ports, these
+            most likely won't be portable.
           type: array
           items:
             $ref: '#/components/schemas/Layer1'
@@ -945,9 +947,9 @@ components:
           x-field-uid: 1
         speed:
           description: |-
-            Set the speed if supported.
+            Set the speed if supported. When no speed is explicitly set, the current
+            speed of underlying test interface shall be assumed.
           type: string
-          default: speed_10_gbps
           x-field-uid: 2
           x-enum:
             speed_10_fd_mbps:
@@ -989,7 +991,9 @@ components:
           - speed_400_gbps
         media:
           description: |-
-            Set the type of media interface if supported.
+            Set the type of media for test interface if supported. When no media
+            type is explicitly set, the current media type of underlying test
+            interface shall be assumed.
           type: string
           x-field-uid: 3
           x-enum:
@@ -1005,13 +1009,16 @@ components:
           - sgmii
         promiscuous:
           description: |-
-            Enable promiscuous mode if supported.
+            Enable promiscuous mode on test interface. A warning shall be raised if
+            this field is set to `true`, even when it's not supported, ignoring
+            the setting altogether.
           type: boolean
           default: true
           x-field-uid: 4
         mtu:
           description: |-
-            Set the maximum transmission unit size if supported.
+            Set the maximum transmission unit size. A warning shall be raised if
+            the specified value is valid but not supported, ignoring the setting altogether.
           type: integer
           format: uint32
           minimum: 64
@@ -1020,15 +1027,28 @@ components:
           x-field-uid: 5
         ieee_media_defaults:
           description: |-
+            Under Review: Information TBD
+
             Set to true to override the auto_negotiate, link_training
             and rs_fec settings for gigabit ethernet interfaces.
           type: boolean
           x-field-uid: 6
+          x-status:
+            status: under-review
+            info: This field is currently under review for pending exploration on
+              use cases
+            information: Information TBD
         auto_negotiate:
           description: |-
+            Deprecated: Information TBD
+
             Enable/disable auto negotiation.
           type: boolean
           x-field-uid: 7
+          x-status:
+            status: deprecated
+            info: Please use `AutoNegotiation` instead
+            information: Information TBD
         auto_negotiation:
           $ref: '#/components/schemas/Layer1.AutoNegotiation'
           x-field-uid: 8

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -1027,7 +1027,7 @@ components:
           x-field-uid: 5
         ieee_media_defaults:
           description: |-
-            Under Review: Information TBD
+            Under Review: This field is currently under review for pending exploration on use cases
 
             Set to true to override the auto_negotiate, link_training
             and rs_fec settings for gigabit ethernet interfaces.
@@ -1035,20 +1035,20 @@ components:
           x-field-uid: 6
           x-status:
             status: under-review
-            info: This field is currently under review for pending exploration on
-              use cases
-            information: Information TBD
+            information: This field is currently under review for pending exploration
+              on use cases
         auto_negotiate:
           description: |-
-            Deprecated: Information TBD
+            Under Review: This field is currently under review for pending exploration on use cases, given that a separate configuration called `AutoNegotiation` already exists.
 
             Enable/disable auto negotiation.
           type: boolean
           x-field-uid: 7
           x-status:
-            status: deprecated
-            info: Please use `AutoNegotiation` instead
-            information: Information TBD
+            status: under-review
+            information: This field is currently under review for pending exploration
+              on use cases, given that a separate configuration called `AutoNegotiation`
+              already exists.
         auto_negotiation:
           $ref: '#/components/schemas/Layer1.AutoNegotiation'
           x-field-uid: 8

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -539,13 +539,15 @@ message Layer1 {
   // default = 1500
   optional uint32 mtu = 5;
 
-  // Under Review: Information TBD
+  // Under Review: This field is currently under review for pending exploration on use
+  // cases
   // 
   // Set to true to override the auto_negotiate, link_training
   // and rs_fec settings for gigabit ethernet interfaces.
   optional bool ieee_media_defaults = 6;
 
-  // Deprecated: Information TBD
+  // Under Review: This field is currently under review for pending exploration on use
+  // cases, given that a separate configuration called `AutoNegotiation` already exists.
   // 
   // Enable/disable auto negotiation.
   optional bool auto_negotiate = 7;

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -28,6 +28,8 @@ message Config {
   repeated Lag lags = 2;
 
   // The layer1 settings that will be configured on the traffic generator.
+  // Since layer1 settings usually vary across variety of test ports, these
+  // most likely won't be portable.
   repeated Layer1 layer1 = 3;
 
   // The capture settings that will be configured on the traffic generator.
@@ -509,8 +511,8 @@ message Layer1 {
       speed_400_gbps = 12;
     }
   }
-  // Set the speed if supported.
-  // default = Speed.Enum.speed_10_gbps
+  // Set the speed if supported. When no speed is explicitly set, the current
+  // speed of underlying test interface shall be assumed.
   optional Speed.Enum speed = 2;
 
   message Media {
@@ -521,21 +523,30 @@ message Layer1 {
       sgmii = 3;
     }
   }
-  // Set the type of media interface if supported.
+  // Set the type of media for test interface if supported. When no media
+  // type is explicitly set, the current media type of underlying test
+  // interface shall be assumed.
   optional Media.Enum media = 3;
 
-  // Enable promiscuous mode if supported.
+  // Enable promiscuous mode on test interface. A warning shall be raised if
+  // this field is set to `true`, even when it's not supported, ignoring
+  // the setting altogether.
   // default = True
   optional bool promiscuous = 4;
 
-  // Set the maximum transmission unit size if supported.
+  // Set the maximum transmission unit size. A warning shall be raised if
+  // the specified value is valid but not supported, ignoring the setting altogether.
   // default = 1500
   optional uint32 mtu = 5;
 
+  // Under Review: Information TBD
+  // 
   // Set to true to override the auto_negotiate, link_training
   // and rs_fec settings for gigabit ethernet interfaces.
   optional bool ieee_media_defaults = 6;
 
+  // Deprecated: Information TBD
+  // 
   // Enable/disable auto negotiation.
   optional bool auto_negotiate = 7;
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,6 +22,8 @@ components:
         layer1:
           description: |-
             The layer1 settings that will be configured on the traffic generator.
+            Since layer1 settings usually vary across variety of test ports, these
+            most likely won't be portable.
           type: array
           items:
             $ref: '../layer1/layer1.yaml#/components/schemas/Layer1'

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -18,9 +18,9 @@ components:
           x-field-uid: 1
         speed:
           description: |-
-            Set the speed if supported.
+            Set the speed if supported. When no speed is explicitly set, the current
+            speed of underlying test interface shall be assumed.
           type: string
-          default: speed_10_gbps
           x-field-uid: 2
           x-enum:
             speed_10_fd_mbps:
@@ -49,7 +49,9 @@ components:
               x-field-uid: 12
         media:
           description: |-
-            Set the type of media interface if supported.
+            Set the type of media for test interface if supported. When no media
+            type is explicitly set, the current media type of underlying test
+            interface shall be assumed.
           type: string
           x-field-uid: 3
           x-enum:
@@ -61,13 +63,16 @@ components:
               x-field-uid: 3
         promiscuous:
           description: |-
-            Enable promiscuous mode if supported.
+            Enable promiscuous mode on test interface. A warning shall be raised if
+            this field is set to `true`, even when it's not supported, ignoring
+            the setting altogether.
           type: boolean
           default: true
           x-field-uid: 4
         mtu:
           description: |-
-            Set the maximum transmission unit size if supported.
+            Set the maximum transmission unit size. A warning shall be raised if
+            the specified value is valid but not supported, ignoring the setting altogether.
           type: integer
           format: uint32
           minimum: 64
@@ -80,11 +85,17 @@ components:
             and rs_fec settings for gigabit ethernet interfaces.
           type: boolean
           x-field-uid: 6
+          x-status:
+            status: under-review
+            info: This field is currently under review for pending exploration on use cases
         auto_negotiate:
           description: |-
             Enable/disable auto negotiation.
           type: boolean
           x-field-uid: 7
+          x-status:
+            status: deprecated
+            info: Please use `AutoNegotiation` instead
         auto_negotiation:
           $ref: '#/components/schemas/Layer1.AutoNegotiation'
           x-field-uid: 8

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -87,15 +87,15 @@ components:
           x-field-uid: 6
           x-status:
             status: under-review
-            info: This field is currently under review for pending exploration on use cases
+            information: This field is currently under review for pending exploration on use cases
         auto_negotiate:
           description: |-
             Enable/disable auto negotiation.
           type: boolean
           x-field-uid: 7
           x-status:
-            status: deprecated
-            info: Please use `AutoNegotiation` instead
+            status: under-review
+            information: This field is currently under review for pending exploration on use cases, given that a separate configuration called `AutoNegotiation` already exists.
         auto_negotiation:
           $ref: '#/components/schemas/Layer1.AutoNegotiation'
           x-field-uid: 8


### PR DESCRIPTION
Changes proposed below can be visualized in the [data model tree](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/opt-layer1/artifacts/openapi.yaml#tag/Configuration/operation/set_config).

1. Added documentation to emphasize on the fact that layer1 settings are not portable
2. Removed default from speed
3. Documented behavior for missing values in certain commonly used properties
4. Marked `auto_negotiate` and `ieee_media_defaults` as `under-review`