### PR TITLE
Change default value of vlan tpid to 65535

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -13901,7 +13901,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 33024
+          default: 65535
           format: uint32
           maximum: 65535
         step:
@@ -13978,7 +13978,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 33024
+          default: 65535
           format: uint32
           maximum: 65535
         values:
@@ -13989,7 +13989,7 @@ components:
             maximum: 65535
           x-field-uid: 3
           default:
-          - 33024
+          - 65535
         increment:
           $ref: '#/components/schemas/Pattern.Flow.Vlan.Tpid.Counter'
           x-field-uid: 5

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -9974,7 +9974,7 @@ message PatternFlowVlanId {
 message PatternFlowVlanTpidCounter {
 
   // Description missing in models
-  // default = 33024
+  // default = 65535
   optional uint32 start = 1;
 
   // Description missing in models
@@ -10023,11 +10023,11 @@ message PatternFlowVlanTpid {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 33024
+  // default = 65535
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [33024]
+  // default = [65535]
   repeated uint32 values = 3;
 
   // Description missing in models

--- a/flow/packet-headers/vlan.yaml
+++ b/flow/packet-headers/vlan.yaml
@@ -43,6 +43,6 @@ components:
               Protocol identifier
             format: integer
             length: 16
-            default: 33024
+            default: 65535
             features: [count, metric_tags]
           x-field-uid: 4


### PR DESCRIPTION
Issue: For a simple flow headers configuration with ethernet and vlan, an additional vlan header is seen in packet capture.

Problem: Current default value of tpid in model (33024, i.e. 0x8100 - reserved for ethertype vlan) causes part of the payload to be interpreted as an extra vlan header in the mentioned configuration. The same issue is not seen when vlan header is followed by ipv4/ipv6.