### PR TITLE
On the fly bgp peer add/remove: through SetControlState protocol/bgp

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8873,11 +8873,14 @@ components:
               x-field-uid: 2
             lacp:
               x-field-uid: 3
+            bgp:
+              x-field-uid: 4
           x-field-uid: 1
           enum:
           - all
           - route
           - lacp
+          - bgp
         all:
           $ref: '#/components/schemas/State.Protocol.All'
           x-field-uid: 2
@@ -8887,6 +8890,9 @@ components:
         lacp:
           $ref: '#/components/schemas/State.Protocol.Lacp'
           x-field-uid: 4
+        bgp:
+          $ref: '#/components/schemas/State.Protocol.Bgp'
+          x-field-uid: 5
     State.Port.Link:
       description: |-
         Sets the link of configured ports.
@@ -9093,6 +9099,55 @@ components:
         state:
           description: |-
             The LACP Member admin state. 'up' will send LACPDUs with 'sync' flag set on selected member ports. 'down' will send LACPDUs with 'sync' flag unset on selected member ports.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          enum:
+          - up
+          - down
+    State.Protocol.Bgp:
+      description: |-
+        Sets state of configured BGP
+      type: object
+      required:
+      - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            session:
+              x-field-uid: 1
+          x-field-uid: 1
+          enum:
+          - session
+        session:
+          $ref: '#/components/schemas/State.Protocol.Bgp.Session'
+          x-field-uid: 2
+    State.Protocol.Bgp.Session:
+      description: |-
+        Sets session state of configured BGP peers
+      required:
+      - state
+      properties:
+        peer_names:
+          description: |
+            The names of BGP peers for which the state has to be applied. An empty or null list will control all BGP peers.
+
+            x-constraint:
+            - /components/schemas/Port/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Port/properties/name
+          x-field-uid: 1
+        state:
+          description: |-
+            The BGP peer session state.
           type: string
           x-field-uid: 2
           x-enum:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -9119,17 +9119,17 @@ components:
         choice:
           type: string
           x-enum:
-            session:
+            peers:
               x-field-uid: 1
           x-field-uid: 1
           enum:
-          - session
-        session:
-          $ref: '#/components/schemas/State.Protocol.Bgp.Session'
+          - peers
+        peers:
+          $ref: '#/components/schemas/State.Protocol.Bgp.Peers'
           x-field-uid: 2
-    State.Protocol.Bgp.Session:
+    State.Protocol.Bgp.Peers:
       description: |-
-        Sets session state of configured BGP peers
+        Sets state of configured BGP peers
       required:
       - state
       properties:
@@ -9147,7 +9147,7 @@ components:
           x-field-uid: 1
         state:
           description: |-
-            The BGP peer session state.
+            The desired state of BGP peer.
           type: string
           x-field-uid: 2
           x-enum:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -9220,9 +9220,9 @@ components:
         state:
           description: "The desired state of BGP peer. If the desired state is 'up',\
             \ underlying IP interface(s) would be brought up automatically (if not\
-            \ already up) and the associated BGP peers would start advertising routes.\
-            \ If the desired state is 'down', the associated BGP peers would stop\
-            \ advertising routes. "
+            \ already up), would attempt to bring up the BGP session(s) and advertise\
+            \ route(s), if configured. If the desired state is 'down', BGP session(s)\
+            \ would be brought down. "
           type: string
           x-field-uid: 2
           x-enum:
@@ -9271,9 +9271,9 @@ components:
           x-field-uid: 1
         state:
           description: "The desired state of ISIS router. If the desired state is\
-            \ 'up', the associated ISIS routers would start advertising routes. If\
-            \ the desired state is 'down', the associated ISIS routers would stop\
-            \ advertising routes. "
+            \ 'up', would attempt to bring up the ISIS session(s) with respective\
+            \ peer(s) and advertise route(s), if configured. If the desired state\
+            \ is 'down', would bring down ISIS session(s) with respective peer(s). "
           type: string
           x-field-uid: 2
           x-enum:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 0.12.5
+  version: 0.13.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -9138,12 +9138,14 @@ components:
             The names of BGP peers for which the state has to be applied. An empty or null list will control all BGP peers.
 
             x-constraint:
-            - /components/schemas/Port/properties/name
+            - /components/schemas/Bgp.V4Peer/properties/name
+            - /components/schemas/Bgp.V6Peer/properties/name
           type: array
           items:
             type: string
           x-constraint:
-          - /components/schemas/Port/properties/name
+          - /components/schemas/Bgp.V4Peer/properties/name
+          - /components/schemas/Bgp.V6Peer/properties/name
           x-field-uid: 1
         state:
           description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8900,6 +8900,9 @@ components:
         bgp:
           $ref: '#/components/schemas/State.Protocol.Bgp'
           x-field-uid: 5
+        isis:
+          $ref: '#/components/schemas/State.Protocol.Isis'
+          x-field-uid: 6
     State.Port.Link:
       description: |-
         Sets the link of configured ports.
@@ -9079,12 +9082,18 @@ components:
           x-enum:
             admin:
               x-field-uid: 1
+            member_ports:
+              x-field-uid: 2
           x-field-uid: 1
           enum:
           - admin
+          - member_ports
         admin:
           $ref: '#/components/schemas/State.Protocol.Lacp.Admin'
           x-field-uid: 2
+        member_ports:
+          $ref: '#/components/schemas/State.Protocol.Lacp.MemberPorts'
+          x-field-uid: 3
     State.Protocol.Lacp.Admin:
       description: |-
         Sets admin state of LACP configured on LAG members
@@ -9106,6 +9115,37 @@ components:
         state:
           description: |-
             The LACP Member admin state. 'up' will send LACPDUs with 'sync' flag set on selected member ports. 'down' will send LACPDUs with 'sync' flag unset on selected member ports.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          enum:
+          - up
+          - down
+    State.Protocol.Lacp.MemberPorts:
+      description: |-
+        Sets state of LACP member ports configured on LAG.
+      required:
+      - state
+      properties:
+        lag_member_names:
+          description: |
+            The names of LAG members (ports) for which the state has to be applied. An empty or null list will control all LAG members.
+
+            x-constraint:
+            - /components/schemas/Port/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Port/properties/name
+          x-field-uid: 1
+        state:
+          description: |-
+            The desired LACP member port state.
           type: string
           x-field-uid: 2
           x-enum:
@@ -9157,6 +9197,55 @@ components:
         state:
           description: |-
             The desired state of BGP peer.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          enum:
+          - up
+          - down
+    State.Protocol.Isis:
+      description: |-
+        Sets state of configured ISIS routers.
+      type: object
+      required:
+      - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            routers:
+              x-field-uid: 1
+          x-field-uid: 1
+          enum:
+          - routers
+        routers:
+          $ref: '#/components/schemas/State.Protocol.Isis.Routers'
+          x-field-uid: 2
+    State.Protocol.Isis.Routers:
+      description: |-
+        Sets state of configured ISIS routers.
+      required:
+      - state
+      properties:
+        router_names:
+          description: |
+            The names of ISIS routers for which the state has to be applied. An empty or null list will control all ISIS routers.
+
+            x-constraint:
+            - /components/schemas/Device.IsisRouter/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Device.IsisRouter/properties/name
+          x-field-uid: 1
+        state:
+          description: |-
+            The desired state of ISIS router.
           type: string
           x-field-uid: 2
           x-enum:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8902,12 +8902,15 @@ components:
               x-field-uid: 3
             bgp:
               x-field-uid: 4
+            isis:
+              x-field-uid: 5
           x-field-uid: 1
           enum:
           - all
           - route
           - lacp
           - bgp
+          - isis
         all:
           $ref: '#/components/schemas/State.Protocol.All'
           x-field-uid: 2
@@ -9215,8 +9218,11 @@ components:
           - /components/schemas/Bgp.V6Peer/properties/name
           x-field-uid: 1
         state:
-          description: |-
-            The desired state of BGP peer.
+          description: "The desired state of BGP peer. If the desired state is 'up',\
+            \ underlying IP interface(s) would be brought up automatically (if not\
+            \ already up) and the associated BGP peers would start advertising routes.\
+            \ If the desired state is 'down', the associated BGP peers would stop\
+            \ advertising routes. "
           type: string
           x-field-uid: 2
           x-enum:
@@ -9264,8 +9270,10 @@ components:
           - /components/schemas/Device.IsisRouter/properties/name
           x-field-uid: 1
         state:
-          description: |-
-            The desired state of ISIS router.
+          description: "The desired state of ISIS router. If the desired state is\
+            \ 'up', the associated ISIS routers would start advertising routes. If\
+            \ the desired state is 'down', the associated ISIS routers would stop\
+            \ advertising routes. "
           type: string
           x-field-uid: 2
           x-enum:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6931,9 +6931,9 @@ message StateProtocolBgpPeers {
     }
   }
   // The desired state of BGP peer. If the desired state is 'up', underlying IP interface(s)
-  // would be brought up automatically (if not already up) and the associated BGP peers
-  // would start advertising routes. If the desired state is 'down', the associated BGP
-  // peers would stop advertising routes.
+  // would be brought up automatically (if not already up), would attempt to bring up
+  // the BGP session(s) and advertise route(s), if configured. If the desired state is
+  // 'down', BGP session(s) would be brought down.
   // required = true
   optional State.Enum state = 2;
 }
@@ -6973,9 +6973,10 @@ message StateProtocolIsisRouters {
       down = 2;
     }
   }
-  // The desired state of ISIS router. If the desired state is 'up', the associated ISIS
-  // routers would start advertising routes. If the desired state is 'down', the associated
-  // ISIS routers would stop advertising routes.
+  // The desired state of ISIS router. If the desired state is 'up', would attempt to
+  // bring up the ISIS session(s) with respective peer(s) and advertise route(s), if configured.
+  // If the desired state is 'down', would bring down ISIS session(s) with respective
+  // peer(s).
   // required = true
   optional State.Enum state = 2;
 }

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6849,7 +6849,7 @@ message StateProtocolBgp {
   message Choice {
     enum Enum {
       unspecified = 0;
-      session = 1;
+      peers = 1;
     }
   }
   // Description missing in models
@@ -6857,11 +6857,11 @@ message StateProtocolBgp {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  StateProtocolBgpSession session = 2;
+  StateProtocolBgpPeers peers = 2;
 }
 
-// Sets session state of configured BGP peers
-message StateProtocolBgpSession {
+// Sets state of configured BGP peers
+message StateProtocolBgpPeers {
 
   // The names of BGP peers for which the state has to be applied. An empty or null list
   // will control all BGP peers.
@@ -6878,7 +6878,7 @@ message StateProtocolBgpSession {
       down = 2;
     }
   }
-  // The BGP peer session state.
+  // The desired state of BGP peer.
   // required = true
   optional State.Enum state = 2;
 }

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6867,7 +6867,8 @@ message StateProtocolBgpPeers {
   // will control all BGP peers.
   // 
   // x-constraint:
-  // - /components/schemas/Port/properties/name
+  // - /components/schemas/Bgp.V4Peer/properties/name
+  // - /components/schemas/Bgp.V6Peer/properties/name
   // 
   repeated string peer_names = 1;
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6677,6 +6677,9 @@ message StateProtocol {
 
   // Description missing in models
   StateProtocolBgp bgp = 5;
+
+  // Description missing in models
+  StateProtocolIsis isis = 6;
 }
 
 // Sets the link of configured ports.
@@ -6815,6 +6818,7 @@ message StateProtocolLacp {
     enum Enum {
       unspecified = 0;
       admin = 1;
+      member_ports = 2;
     }
   }
   // Description missing in models
@@ -6823,6 +6827,9 @@ message StateProtocolLacp {
 
   // Description missing in models
   StateProtocolLacpAdmin admin = 2;
+
+  // Description missing in models
+  StateProtocolLacpMemberPorts member_ports = 3;
 }
 
 // Sets admin state of LACP configured on LAG members
@@ -6846,6 +6853,29 @@ message StateProtocolLacpAdmin {
   // The LACP Member admin state. 'up' will send LACPDUs with 'sync' flag set on selected
   // member ports. 'down' will send LACPDUs with 'sync' flag unset on selected member
   // ports.
+  // required = true
+  optional State.Enum state = 2;
+}
+
+// Sets state of LACP member ports configured on LAG.
+message StateProtocolLacpMemberPorts {
+
+  // The names of LAG members (ports) for which the state has to be applied. An empty
+  // or null list will control all LAG members.
+  // 
+  // x-constraint:
+  // - /components/schemas/Port/properties/name
+  // 
+  repeated string lag_member_names = 1;
+
+  message State {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // The desired LACP member port state.
   // required = true
   optional State.Enum state = 2;
 }
@@ -6887,6 +6917,46 @@ message StateProtocolBgpPeers {
     }
   }
   // The desired state of BGP peer.
+  // required = true
+  optional State.Enum state = 2;
+}
+
+// Sets state of configured ISIS routers.
+message StateProtocolIsis {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      routers = 1;
+    }
+  }
+  // Description missing in models
+  // required = true
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  StateProtocolIsisRouters routers = 2;
+}
+
+// Sets state of configured ISIS routers.
+message StateProtocolIsisRouters {
+
+  // The names of ISIS routers for which the state has to be applied. An empty or null
+  // list will control all ISIS routers.
+  // 
+  // x-constraint:
+  // - /components/schemas/Device.IsisRouter/properties/name
+  // 
+  repeated string router_names = 1;
+
+  message State {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // The desired state of ISIS router.
   // required = true
   optional State.Enum state = 2;
 }

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 0.12.5
+/* Open Traffic Generator API 0.13.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -42,10 +42,10 @@ message Config {
   repeated Flow flows = 6;
 
   // Description missing in models
-  optional Event events = 7;
+  Event events = 7;
 
   // Description missing in models
-  optional ConfigOptions options = 8;
+  ConfigOptions options = 8;
 
   // LLDP protocol that will be configured on traffic generator.
   repeated Lldp lldp = 9;
@@ -55,10 +55,10 @@ message Config {
 message ConfigOptions {
 
   // Description missing in models
-  optional PortOptions port_options = 1;
+  PortOptions port_options = 1;
 
   // Description missing in models
-  optional ProtocolOptions protocol_options = 2;
+  ProtocolOptions protocol_options = 2;
 }
 
 // An abstract test port.
@@ -79,7 +79,7 @@ message Port {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 2;
+  optional string name = 2;
 }
 
 // Common port options that apply to all configured Port objects.
@@ -99,7 +99,7 @@ message Lag {
   repeated LagPort ports = 1;
 
   // Description missing in models
-  optional LagProtocol protocol = 2;
+  LagProtocol protocol = 2;
 
   // Specifies the mininum number of member interfaces that must be active for the aggregate
   // interface to be available.
@@ -112,7 +112,7 @@ message Lag {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 4;
+  optional string name = 4;
 }
 
 // The container for a port's ethernet interface and LAG protocol settings
@@ -124,10 +124,10 @@ message LagPort {
   // - /components/schemas/Port/properties/name
   // 
   // required = true
-  string port_name = 1;
+  optional string port_name = 1;
 
   // Description missing in models
-  optional LagPortLacp lacp = 2;
+  LagPortLacp lacp = 2;
 
   // Description missing in models
   // required = true
@@ -149,10 +149,10 @@ message LagProtocol {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional LagProtocolLacp lacp = 2;
+  LagProtocolLacp lacp = 2;
 
   // Description missing in models
-  optional LagProtocolStatic static = 3;
+  LagProtocolStatic static = 3;
 }
 
 // The container for static link aggregation protocol settings.
@@ -219,7 +219,7 @@ message DeviceEthernetBase {
 
   // Media Access Control address.
   // required = true
-  string mac = 1;
+  optional string mac = 1;
 
   // Maximum Transmission Unit.
   // default = 1500
@@ -231,14 +231,14 @@ message DeviceEthernetBase {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 4;
+  optional string name = 4;
 }
 
 // An Ethernet interface with IPv4 and IPv6 addresses.
 message DeviceEthernet {
 
   // Device connection to physical, LAG or another device.
-  optional EthernetConnection connection = 2;
+  EthernetConnection connection = 2;
 
   // List of IPv4 addresses and their gateways.
   repeated DeviceIpv4 ipv4_addresses = 3;
@@ -249,7 +249,7 @@ message DeviceEthernet {
 
   // Media Access Control address.
   // required = true
-  string mac = 5;
+  optional string mac = 5;
 
   // Maximum Transmission Unit.
   // default = 1500
@@ -261,7 +261,7 @@ message DeviceEthernet {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 8;
+  optional string name = 8;
 }
 
 // Ethernet interface connection to a port, LAG or VXLAN tunnel.
@@ -330,7 +330,7 @@ message DeviceVlan {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 4;
+  optional string name = 4;
 }
 
 // An IPv4 interface with gateway
@@ -338,14 +338,14 @@ message DeviceIpv4 {
 
   // The IPv4 address of the gateway
   // required = true
-  string gateway = 1;
+  optional string gateway = 1;
 
   // Description missing in models
-  optional DeviceIpv4GatewayMAC gateway_mac = 2;
+  DeviceIpv4GatewayMAC gateway_mac = 2;
 
   // The IPv4 address
   // required = true
-  string address = 3;
+  optional string address = 3;
 
   // The prefix of the IPv4 address.
   // default = 24
@@ -354,7 +354,7 @@ message DeviceIpv4 {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 5;
+  optional string name = 5;
 }
 
 // An IPv4 Loopback interface.
@@ -367,7 +367,7 @@ message DeviceIpv4Loopback {
   // - /components/schemas/Device.Ethernet/properties/name
   // 
   // required = true
-  string eth_name = 1;
+  optional string eth_name = 1;
 
   // The IPv4 Loopback address with prefix length of 32.
   // default = 0.0.0.0
@@ -376,7 +376,7 @@ message DeviceIpv4Loopback {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 3;
+  optional string name = 3;
 }
 
 // By default auto(resolved gateway mac) is set.  Setting a value would mean that ARP
@@ -412,14 +412,14 @@ message DeviceIpv6 {
 
   // The IPv6 gateway address.
   // required = true
-  string gateway = 1;
+  optional string gateway = 1;
 
   // Description missing in models
-  optional DeviceIpv6GatewayMAC gateway_mac = 2;
+  DeviceIpv6GatewayMAC gateway_mac = 2;
 
   // The IPv6 address.
   // required = true
-  string address = 3;
+  optional string address = 3;
 
   // The network prefix.
   // default = 64
@@ -428,7 +428,7 @@ message DeviceIpv6 {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 5;
+  optional string name = 5;
 }
 
 // An IPv6 Loopback interface
@@ -441,7 +441,7 @@ message DeviceIpv6Loopback {
   // - /components/schemas/Device.Ethernet/properties/name
   // 
   // required = true
-  string eth_name = 1;
+  optional string eth_name = 1;
 
   // The IPv6 Loopback address with prefix length of 128.
   // default = ::0
@@ -450,7 +450,7 @@ message DeviceIpv6Loopback {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 3;
+  optional string name = 3;
 }
 
 // By default auto(resolved gateway mac) is set. Setting a value would mean that ND
@@ -540,15 +540,15 @@ message Layer1 {
   optional bool auto_negotiate = 7;
 
   // Description missing in models
-  optional Layer1AutoNegotiation auto_negotiation = 8;
+  Layer1AutoNegotiation auto_negotiation = 8;
 
   // Description missing in models
-  optional Layer1FlowControl flow_control = 9;
+  Layer1FlowControl flow_control = 9;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 10;
+  optional string name = 10;
 }
 
 // Configuration for auto negotiation settings
@@ -610,10 +610,10 @@ message Layer1FlowControl {
   optional Choice.Enum choice = 2;
 
   // Description missing in models
-  optional Layer1Ieee8021qbb ieee_802_1qbb = 3;
+  Layer1Ieee8021qbb ieee_802_1qbb = 3;
 
   // Description missing in models
-  optional Layer1Ieee8023x ieee_802_3x = 4;
+  Layer1Ieee8023x ieee_802_3x = 4;
 }
 
 // A container for ieee 802.3x rx pause settings
@@ -714,7 +714,7 @@ message Capture {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 6;
+  optional string name = 6;
 }
 
 // Configuration for capture filters
@@ -737,19 +737,19 @@ message CaptureFilter {
   // Offset from last filter in the list. If no filters are present it is offset from
   // position 0. Multiple custom filters can be present, the length of each custom filter
   // is the length of the value being filtered.
-  optional CaptureCustom custom = 2;
+  CaptureCustom custom = 2;
 
   // Description missing in models
-  optional CaptureEthernet ethernet = 3;
+  CaptureEthernet ethernet = 3;
 
   // Description missing in models
-  optional CaptureVlan vlan = 4;
+  CaptureVlan vlan = 4;
 
   // Description missing in models
-  optional CaptureIpv4 ipv4 = 5;
+  CaptureIpv4 ipv4 = 5;
 
   // Description missing in models
-  optional CaptureIpv6 ipv6 = 6;
+  CaptureIpv6 ipv6 = 6;
 }
 
 // Description missing in models
@@ -795,106 +795,106 @@ message CaptureField {
 message CaptureEthernet {
 
   // Description missing in models
-  optional CaptureField src = 1;
+  CaptureField src = 1;
 
   // Description missing in models
-  optional CaptureField dst = 2;
+  CaptureField dst = 2;
 
   // Description missing in models
-  optional CaptureField ether_type = 3;
+  CaptureField ether_type = 3;
 
   // Description missing in models
-  optional CaptureField pfc_queue = 4;
+  CaptureField pfc_queue = 4;
 }
 
 // Description missing in models
 message CaptureVlan {
 
   // Description missing in models
-  optional CaptureField priority = 1;
+  CaptureField priority = 1;
 
   // Description missing in models
-  optional CaptureField cfi = 2;
+  CaptureField cfi = 2;
 
   // Description missing in models
-  optional CaptureField id = 3;
+  CaptureField id = 3;
 
   // Description missing in models
-  optional CaptureField protocol = 4;
+  CaptureField protocol = 4;
 }
 
 // Description missing in models
 message CaptureIpv4 {
 
   // Description missing in models
-  optional CaptureField version = 1;
+  CaptureField version = 1;
 
   // Description missing in models
-  optional CaptureField header_length = 2;
+  CaptureField header_length = 2;
 
   // Description missing in models
-  optional CaptureField priority = 3;
+  CaptureField priority = 3;
 
   // Description missing in models
-  optional CaptureField total_length = 4;
+  CaptureField total_length = 4;
 
   // Description missing in models
-  optional CaptureField identification = 5;
+  CaptureField identification = 5;
 
   // Description missing in models
-  optional CaptureField reserved = 6;
+  CaptureField reserved = 6;
 
   // Description missing in models
-  optional CaptureField dont_fragment = 7;
+  CaptureField dont_fragment = 7;
 
   // Description missing in models
-  optional CaptureField more_fragments = 8;
+  CaptureField more_fragments = 8;
 
   // Description missing in models
-  optional CaptureField fragment_offset = 9;
+  CaptureField fragment_offset = 9;
 
   // Description missing in models
-  optional CaptureField time_to_live = 10;
+  CaptureField time_to_live = 10;
 
   // Description missing in models
-  optional CaptureField protocol = 11;
+  CaptureField protocol = 11;
 
   // Description missing in models
-  optional CaptureField header_checksum = 12;
+  CaptureField header_checksum = 12;
 
   // Description missing in models
-  optional CaptureField src = 13;
+  CaptureField src = 13;
 
   // Description missing in models
-  optional CaptureField dst = 14;
+  CaptureField dst = 14;
 }
 
 // Description missing in models
 message CaptureIpv6 {
 
   // Description missing in models
-  optional CaptureField version = 1;
+  CaptureField version = 1;
 
   // Description missing in models
-  optional CaptureField traffic_class = 2;
+  CaptureField traffic_class = 2;
 
   // Description missing in models
-  optional CaptureField flow_label = 3;
+  CaptureField flow_label = 3;
 
   // Description missing in models
-  optional CaptureField payload_length = 4;
+  CaptureField payload_length = 4;
 
   // Description missing in models
-  optional CaptureField next_header = 5;
+  CaptureField next_header = 5;
 
   // Description missing in models
-  optional CaptureField hop_limit = 6;
+  CaptureField hop_limit = 6;
 
   // Description missing in models
-  optional CaptureField src = 7;
+  CaptureField src = 7;
 
   // Description missing in models
-  optional CaptureField dst = 8;
+  CaptureField dst = 8;
 }
 
 // A container for emulated interfaces, loopback interfaces and protocol configurations.
@@ -913,22 +913,22 @@ message Device {
 
   // The properties of an IS-IS router and its children,  such as IS-IS interfaces and
   // route ranges.
-  optional DeviceIsisRouter isis = 4;
+  DeviceIsisRouter isis = 4;
 
   // The properties of BGP router and its children,  such as BGPv4, BGPv6 peers and their
   // route ranges.
-  optional DeviceBgpRouter bgp = 5;
+  DeviceBgpRouter bgp = 5;
 
   // Configuration of VXLAN tunnel interfaces RFC Ref: https://datatracker.ietf.org/doc/html/rfc7348
-  optional DeviceVxlan vxlan = 6;
+  DeviceVxlan vxlan = 6;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 7;
+  optional string name = 7;
 
   // The properties of an RSVP router and its children.
-  optional DeviceRsvp rsvp = 8;
+  DeviceRsvp rsvp = 8;
 }
 
 // Common options that apply to all configured protocols and interfaces.
@@ -947,23 +947,23 @@ message DeviceIsisRouter {
 
   // This contains the properties of a Multi-Instance-capable routers or MI-RTR. Each
   // router can emulate one ISIS instance at a time.
-  optional DeviceIsisMultiInstance instance = 1;
+  DeviceIsisMultiInstance instance = 1;
 
   // The System ID for this emulated ISIS router, e.g. 640100010000.
   // required = true
-  string system_id = 2;
+  optional string system_id = 2;
 
   // List of ISIS interfaces for this router.
   repeated IsisInterface interfaces = 3;
 
   // Contains basic properties of an ISIS Router.
-  optional IsisBasic basic = 4;
+  IsisBasic basic = 4;
 
   // Contains advance properties of an ISIS Router..
-  optional IsisAdvanced advanced = 5;
+  IsisAdvanced advanced = 5;
 
   // ISIS Router authentication properties.
-  optional IsisAuthentication router_auth = 6;
+  IsisAuthentication router_auth = 6;
 
   // Emulated ISIS IPv4 routes.
   repeated IsisV4RouteRange v4_routes = 7;
@@ -974,7 +974,7 @@ message DeviceIsisRouter {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 9;
+  optional string name = 9;
 }
 
 // This container properties of an Multi-Instance-capable router (MI-RTR).
@@ -1000,7 +1000,7 @@ message IsisInterface {
   // - /components/schemas/Device.Ethernet/properties/name
   // 
   // required = true
-  string eth_name = 1;
+  optional string eth_name = 1;
 
   // The default metric cost for the interface.
   // default = 10
@@ -1031,10 +1031,10 @@ message IsisInterface {
   optional LevelType.Enum level_type = 4;
 
   // Settings of Level 1 Hello.
-  optional IsisInterfaceLevel l1_settings = 5;
+  IsisInterfaceLevel l1_settings = 5;
 
   // Settings of Level 2 Hello.
-  optional IsisInterfaceLevel l2_settings = 6;
+  IsisInterfaceLevel l2_settings = 6;
 
   // Contains the properties of multiple topologies.
   repeated IsisMT multi_topology_ids = 7;
@@ -1044,13 +1044,13 @@ message IsisInterface {
 
   // The Circuit authentication method used for the interfaces on this emulated ISIS v4/v6
   // router.
-  optional IsisInterfaceAuthentication authentication = 9;
+  IsisInterfaceAuthentication authentication = 9;
 
   // Optional container for advanced interface properties.
-  optional IsisInterfaceAdvanced advanced = 10;
+  IsisInterfaceAdvanced advanced = 10;
 
   // Link protection on the ISIS link between two interfaces.
-  optional IsisInterfaceLinkProtection link_protection = 11;
+  IsisInterfaceLinkProtection link_protection = 11;
 
   // This contains list of SRLG values for the link between two interfaces.
   repeated uint32 srlg_values = 12;
@@ -1058,7 +1058,7 @@ message IsisInterface {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 13;
+  optional string name = 13;
 }
 
 // Configuration for the properties of Level 1 Hello.
@@ -1118,7 +1118,7 @@ message LinkStateTE {
   optional uint32 max_reservable_bandwidth = 4;
 
   // Configuration of bandwidths of priority 0 through priority 7.
-  optional LinkStatepriorityBandwidths priority_bandwidths = 5;
+  LinkStatepriorityBandwidths priority_bandwidths = 5;
 }
 
 // Specifies the amount of bandwidth that can be reserved with a setup priority of 0
@@ -1173,7 +1173,7 @@ message IsisInterfaceAuthentication {
   }
   // The circuit authentication method.
   // required = true
-  AuthType.Enum auth_type = 1;
+  optional AuthType.Enum auth_type = 1;
 
   // MD5 key to be used for authentication.
   optional string md5 = 2;
@@ -1344,11 +1344,11 @@ message IsisAuthentication {
 
   // The Area authentication method used for the emulated ISIS router.
   // This is used for L1 LSPs.
-  optional IsisAuthenticationBase area_auth = 2;
+  IsisAuthenticationBase area_auth = 2;
 
   // The Domain authentication method used for the emulated ISIS router.
   // This is used for L2 LSPs.
-  optional IsisAuthenticationBase domain_auth = 3;
+  IsisAuthenticationBase domain_auth = 3;
 }
 
 // Optional container for ISIS authentication properties.
@@ -1363,7 +1363,7 @@ message IsisAuthenticationBase {
   }
   // The authentication method.
   // required = true
-  AuthType.Enum auth_type = 1;
+  optional AuthType.Enum auth_type = 1;
 
   // Authentication as an MD5 key.
   optional string md5 = 2;
@@ -1420,7 +1420,7 @@ message IsisV4RouteRange {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 5;
+  optional string name = 5;
 
   // Specifies whether the sub-TLV for IPv4/IPv6 Extended Reachability Attribute Flags
   // will be advertised or not.
@@ -1445,7 +1445,7 @@ message V4RouteAddress {
 
   // The starting address of the network.
   // required = true
-  string address = 1;
+  optional string address = 1;
 
   // The IPv4 network prefix length to be applied to the address.
   // default = 24
@@ -1466,7 +1466,7 @@ message V6RouteAddress {
 
   // The starting address of the network.
   // required = true
-  string address = 1;
+  optional string address = 1;
 
   // The IPv6 network prefix length to be applied to the address.
   // default = 64
@@ -1487,7 +1487,7 @@ message MACRouteAddress {
 
   // The starting address of the MAC Range.
   // required = true
-  string address = 1;
+  optional string address = 1;
 
   // The MAC prefix length to be applied to the address.
   // default = 48
@@ -1551,7 +1551,7 @@ message IsisV6RouteRange {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 5;
+  optional string name = 5;
 
   // Specifies whether the sub-TLV for IPv4/IPv6 Extended Reachability Attribute Flags
   // will be advertised or not.
@@ -1577,7 +1577,7 @@ message DeviceBgpRouter {
   // The BGP router ID is a unique identifier used by BGP. It is a 32-bit value that is
   // often represented by an IPv4 address.
   // required = true
-  string router_id = 1;
+  optional string router_id = 1;
 
   // This contains an array of references to IPv4 interfaces,  each of which will have
   // list of peers to different destinations.
@@ -1709,7 +1709,7 @@ message BgpV4Peer {
 
   // IPv4 address of the BGP peer for the session.
   // required = true
-  string peer_address = 1;
+  optional string peer_address = 1;
 
   // This contains the list of Ethernet Virtual Private Network (EVPN) Ethernet Segments
   // (ES) Per BGP Peer for IPv4 Address Family Identifier (AFI).
@@ -1748,11 +1748,11 @@ message BgpV4Peer {
   // attribute in 'as_path' field  in any Route Range should be changed from default value
   // 'do_not_include_local_as' to any other value.
   // required = true
-  AsType.Enum as_type = 3;
+  optional AsType.Enum as_type = 3;
 
   // Autonomous System Number (AS number or ASN)
   // required = true
-  uint32 as_number = 4;
+  optional uint32 as_number = 4;
 
   message AsNumberWidth {
     enum Enum {
@@ -1767,13 +1767,13 @@ message BgpV4Peer {
   optional AsNumberWidth.Enum as_number_width = 5;
 
   // Description missing in models
-  optional BgpAdvanced advanced = 6;
+  BgpAdvanced advanced = 6;
 
   // Description missing in models
-  optional BgpCapability capability = 7;
+  BgpCapability capability = 7;
 
   // Description missing in models
-  optional BgpLearnedInformationFilter learned_information_filter = 8;
+  BgpLearnedInformationFilter learned_information_filter = 8;
 
   // Emulated BGPv4 route ranges.
   repeated BgpV4RouteRange v4_routes = 9;
@@ -1794,10 +1794,10 @@ message BgpV4Peer {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 13;
+  optional string name = 13;
 
   // Description missing in models
-  optional BgpGracefulRestart graceful_restart = 14;
+  BgpGracefulRestart graceful_restart = 14;
 }
 
 // Configuration for emulated BGPv4 peers and routes on a single IPv4 interface.
@@ -1811,7 +1811,7 @@ message BgpV4Interface {
   // - /components/schemas/Device.Ipv4Loopback/properties/name
   // 
   // required = true
-  string ipv4_name = 1;
+  optional string ipv4_name = 1;
 
   // This contains the list of BGPv4 peers configured on this interface.
   repeated BgpV4Peer peers = 2;
@@ -1823,7 +1823,7 @@ message BgpV4Interface {
 message BgpV4EthernetSegment {
 
   // Designated Forwarder (DF) election configuration.
-  optional BgpEthernetSegmentDfElection df_election = 1;
+  BgpEthernetSegmentDfElection df_election = 1;
 
   // This contains the list of EVIs.
   repeated BgpV4EvpnEvis evis = 2;
@@ -1850,7 +1850,7 @@ message BgpV4EthernetSegment {
   optional uint32 esi_label = 5;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 6;
+  BgpRouteAdvanced advanced = 6;
 
   // Optional community settings.
   repeated BgpCommunity communities = 7;
@@ -1885,7 +1885,7 @@ message BgpV4EthernetSegment {
   repeated BgpExtCommunity ext_communities = 8;
 
   // Optional AS PATH settings.
-  optional BgpAsPath as_path = 9;
+  BgpAsPath as_path = 9;
 }
 
 // Configuration for Designated Forwarder (DF) election among the Provider Edge (PE)
@@ -2099,7 +2099,7 @@ message BgpV4EvpnEvis {
   optional Choice.Enum choice = 1;
 
   // EVPN VXLAN instance to be configured per Ethernet Segment.
-  optional BgpV4EviVxlan evi_vxlan = 2;
+  BgpV4EviVxlan evi_vxlan = 2;
 }
 
 // Configuration for BGP EVPN EVI. Advertises following routes -
@@ -2136,7 +2136,7 @@ message BgpV4EviVxlan {
 
   // Colon separated Extended Community value of 6 Bytes - AS number: Value identifying
   // an EVI.            Example - for the as_2octet 60005:100.
-  optional BgpRouteDistinguisher route_distinguisher = 5;
+  BgpRouteDistinguisher route_distinguisher = 5;
 
   // List of Layer 2 Virtual Network Identifier (L2VNI) export targets associated with
   // this EVI.
@@ -2152,7 +2152,7 @@ message BgpV4EviVxlan {
   repeated BgpRouteTarget l3_route_target_import = 9;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 10;
+  BgpRouteAdvanced advanced = 10;
 
   // Optional community settings.
   repeated BgpCommunity communities = 11;
@@ -2187,7 +2187,7 @@ message BgpV4EviVxlan {
   repeated BgpExtCommunity ext_communities = 12;
 
   // Optional AS PATH settings.
-  optional BgpAsPath as_path = 13;
+  BgpAsPath as_path = 13;
 }
 
 // Configuration for Broadcast Domains per EVI.
@@ -2217,7 +2217,7 @@ message BgpV4EviVxlanBroadcastDomain {
 message BgpCMacIpRange {
 
   // Host MAC address range per Broadcast Domain.
-  optional MACRouteAddress mac_addresses = 1;
+  MACRouteAddress mac_addresses = 1;
 
   // Layer 2 Virtual Network Identifier (L2VNI) to be advertised with MAC/IP Advertisement
   // Route (Type 2)
@@ -2225,10 +2225,10 @@ message BgpCMacIpRange {
   optional uint32 l2vni = 2;
 
   // Host IPv4 address range per Broadcast Domain.
-  optional V4RouteAddress ipv4_addresses = 3;
+  V4RouteAddress ipv4_addresses = 3;
 
   // Host IPv6 address range per Broadcast Domain.
-  optional V6RouteAddress ipv6_addresses = 4;
+  V6RouteAddress ipv6_addresses = 4;
 
   // Layer 3 Virtual Network Identifier (L3VNI) to be advertised with MAC/IP Advertisement
   // Route (Type 2).
@@ -2240,7 +2240,7 @@ message BgpCMacIpRange {
   optional bool include_default_gateway = 6;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 7;
+  BgpRouteAdvanced advanced = 7;
 
   // Optional community settings.
   repeated BgpCommunity communities = 8;
@@ -2275,12 +2275,12 @@ message BgpCMacIpRange {
   repeated BgpExtCommunity ext_communities = 9;
 
   // Optional AS PATH settings.
-  optional BgpAsPath as_path = 10;
+  BgpAsPath as_path = 10;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 11;
+  optional string name = 11;
 }
 
 // BGP Route Distinguisher.
@@ -2535,21 +2535,21 @@ message BgpV4RouteRange {
   optional string next_hop_ipv6_address = 5;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 6;
+  BgpRouteAdvanced advanced = 6;
 
   // Optional community settings.
   repeated BgpCommunity communities = 7;
 
   // Description missing in models
-  optional BgpAsPath as_path = 8;
+  BgpAsPath as_path = 8;
 
   // Description missing in models
-  optional BgpAddPath add_path = 9;
+  BgpAddPath add_path = 9;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 10;
+  optional string name = 10;
 
   // Deprecated: This property is deprecated in favor of property extended_communities
   // 
@@ -2631,25 +2631,25 @@ message BgpExtendedCommunity {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitive2OctetAsType transitive_2octet_as_type = 2;
+  BgpExtendedCommunityTransitive2OctetAsType transitive_2octet_as_type = 2;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitiveIpv4AddressType transitive_ipv4_address_type = 3;
+  BgpExtendedCommunityTransitiveIpv4AddressType transitive_ipv4_address_type = 3;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitive4OctetAsType transitive_4octet_as_type = 4;
+  BgpExtendedCommunityTransitive4OctetAsType transitive_4octet_as_type = 4;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitiveOpaqueType transitive_opaque_type = 5;
+  BgpExtendedCommunityTransitiveOpaqueType transitive_opaque_type = 5;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitiveEvpnType transitive_evpn_type = 6;
+  BgpExtendedCommunityTransitiveEvpnType transitive_evpn_type = 6;
 
   // Description missing in models
-  optional BgpExtendedCommunityNonTransitive2OctetAsType non_transitive_2octet_as_type = 7;
+  BgpExtendedCommunityNonTransitive2OctetAsType non_transitive_2octet_as_type = 7;
 
   // Description missing in models
-  optional BgpExtendedCommunityCustomType custom = 8;
+  BgpExtendedCommunityCustomType custom = 8;
 }
 
 // The Route Target Community identifies one or more routers that may receive a set
@@ -2699,10 +2699,10 @@ message BgpExtendedCommunityTransitive2OctetAsType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitive2OctetAsTypeRouteTarget route_target_subtype = 2;
+  BgpExtendedCommunityTransitive2OctetAsTypeRouteTarget route_target_subtype = 2;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitive2OctetAsTypeRouteOrigin route_origin_subtype = 3;
+  BgpExtendedCommunityTransitive2OctetAsTypeRouteOrigin route_origin_subtype = 3;
 }
 
 // The Route Origin Community identifies one or more routers that inject a set of routes
@@ -2751,10 +2751,10 @@ message BgpExtendedCommunityTransitiveIpv4AddressType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitiveIpv4AddressTypeRouteTarget route_target_subtype = 2;
+  BgpExtendedCommunityTransitiveIpv4AddressTypeRouteTarget route_target_subtype = 2;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitiveIpv4AddressTypeRouteOrigin route_origin_subtype = 3;
+  BgpExtendedCommunityTransitiveIpv4AddressTypeRouteOrigin route_origin_subtype = 3;
 }
 
 // The Route Target Community identifies one or more routers that may receive a set
@@ -2804,10 +2804,10 @@ message BgpExtendedCommunityTransitive4OctetAsType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitive4OctetAsTypeRouteTarget route_target_subtype = 2;
+  BgpExtendedCommunityTransitive4OctetAsTypeRouteTarget route_target_subtype = 2;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitive4OctetAsTypeRouteOrigin route_origin_subtype = 3;
+  BgpExtendedCommunityTransitive4OctetAsTypeRouteOrigin route_origin_subtype = 3;
 }
 
 // The Color Community contains locally administrator defined 'color' value which is
@@ -2865,10 +2865,10 @@ message BgpExtendedCommunityTransitiveOpaqueType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitiveOpaqueTypeColor color_subtype = 2;
+  BgpExtendedCommunityTransitiveOpaqueTypeColor color_subtype = 2;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitiveOpaqueTypeEncapsulation encapsulation_subtype = 3;
+  BgpExtendedCommunityTransitiveOpaqueTypeEncapsulation encapsulation_subtype = 3;
 }
 
 // The Router MAC EVPN Community is defined in RFC9135 and normally sent only for EVPN
@@ -2894,7 +2894,7 @@ message BgpExtendedCommunityTransitiveEvpnType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional BgpExtendedCommunityTransitiveEvpnTypeRouterMac router_mac_subtype = 2;
+  BgpExtendedCommunityTransitiveEvpnTypeRouterMac router_mac_subtype = 2;
 }
 
 // The Link Bandwidth Extended Community attribute is defined in draft-ietf-idr-link-bandwidth.
@@ -2928,7 +2928,7 @@ message BgpExtendedCommunityNonTransitive2OctetAsType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional BgpExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth link_bandwidth_subtype = 2;
+  BgpExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth link_bandwidth_subtype = 2;
 }
 
 // Add a custom Extended Community with a combination of types , sub-types and values
@@ -2996,21 +2996,21 @@ message BgpV6RouteRange {
   optional string next_hop_ipv6_address = 5;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 6;
+  BgpRouteAdvanced advanced = 6;
 
   // Optional community settings.
   repeated BgpCommunity communities = 7;
 
   // Description missing in models
-  optional BgpAsPath as_path = 8;
+  BgpAsPath as_path = 8;
 
   // Description missing in models
-  optional BgpAddPath add_path = 9;
+  BgpAddPath add_path = 9;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 10;
+  optional string name = 10;
 
   // Deprecated: This property is deprecated in favor of property extended_communities
   // 
@@ -3076,7 +3076,7 @@ message BgpSrteV4Policy {
   // Specifies a single node or a set of nodes (e.g. an anycast address). It is selected
   // on the basis of the SR Policy type (AFI).
   // required = true
-  string ipv4_endpoint = 3;
+  optional string ipv4_endpoint = 3;
 
   message NextHopMode {
     enum Enum {
@@ -3113,13 +3113,13 @@ message BgpSrteV4Policy {
   optional string next_hop_ipv6_address = 7;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 8;
+  BgpRouteAdvanced advanced = 8;
 
   // Description missing in models
-  optional BgpAddPath add_path = 9;
+  BgpAddPath add_path = 9;
 
   // Description missing in models
-  optional BgpAsPath as_path = 10;
+  BgpAsPath as_path = 10;
 
   // Optional Community settings.
   repeated BgpCommunity communities = 11;
@@ -3159,7 +3159,7 @@ message BgpSrteV4Policy {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 14;
+  optional string name = 14;
 
   // If enabled means that this part of the configuration including any active 'children'
   // nodes will be advertised to peer.  If disabled, this means that though config is
@@ -3173,25 +3173,25 @@ message BgpSrteV4Policy {
 message BgpSrteV4TunnelTlv {
 
   // Description missing in models
-  optional BgpSrteRemoteEndpointSubTlv remote_endpoint_sub_tlv = 1;
+  BgpSrteRemoteEndpointSubTlv remote_endpoint_sub_tlv = 1;
 
   // Description missing in models
-  optional BgpSrteColorSubTlv color_sub_tlv = 2;
+  BgpSrteColorSubTlv color_sub_tlv = 2;
 
   // Description missing in models
-  optional BgpSrteBindingSubTlv binding_sub_tlv = 3;
+  BgpSrteBindingSubTlv binding_sub_tlv = 3;
 
   // Description missing in models
-  optional BgpSrtePreferenceSubTlv preference_sub_tlv = 4;
+  BgpSrtePreferenceSubTlv preference_sub_tlv = 4;
 
   // Description missing in models
-  optional BgpSrtePolicyPrioritySubTlv policy_priority_sub_tlv = 5;
+  BgpSrtePolicyPrioritySubTlv policy_priority_sub_tlv = 5;
 
   // Description missing in models
-  optional BgpSrtePolicyNameSubTlv policy_name_sub_tlv = 6;
+  BgpSrtePolicyNameSubTlv policy_name_sub_tlv = 6;
 
   // Description missing in models
-  optional BgpSrteExplicitNullLabelPolicySubTlv explicit_null_label_policy_sub_tlv = 7;
+  BgpSrteExplicitNullLabelPolicySubTlv explicit_null_label_policy_sub_tlv = 7;
 
   // Description missing in models
   repeated BgpSrteSegmentList segment_lists = 8;
@@ -3199,7 +3199,7 @@ message BgpSrteV4TunnelTlv {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 9;
+  optional string name = 9;
 
   // If enabled means that this part of the configuration including any active 'children'
   // nodes will be advertised to peer.  If disabled, this means that though config is
@@ -3336,7 +3336,7 @@ message BgpSrteSegmentList {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 3;
+  optional string name = 3;
 
   // If enabled means that this part of the configuration including any active 'children'
   // nodes will be advertised to peer.  If disabled, this means that though config is
@@ -3382,45 +3382,45 @@ message BgpSrteSegment {
   // SID for SRv6.
   // Type  K: IPv6 Local and Remote addresses for SRv6.
   // required = true
-  SegmentType.Enum segment_type = 1;
+  optional SegmentType.Enum segment_type = 1;
 
   // Description missing in models
-  optional BgpSrteSegmentATypeSubTlv type_a = 2;
+  BgpSrteSegmentATypeSubTlv type_a = 2;
 
   // Description missing in models
-  optional BgpSrteSegmentBTypeSubTlv type_b = 3;
+  BgpSrteSegmentBTypeSubTlv type_b = 3;
 
   // Description missing in models
-  optional BgpSrteSegmentCTypeSubTlv type_c = 4;
+  BgpSrteSegmentCTypeSubTlv type_c = 4;
 
   // Description missing in models
-  optional BgpSrteSegmentDTypeSubTlv type_d = 5;
+  BgpSrteSegmentDTypeSubTlv type_d = 5;
 
   // Description missing in models
-  optional BgpSrteSegmentETypeSubTlv type_e = 6;
+  BgpSrteSegmentETypeSubTlv type_e = 6;
 
   // Description missing in models
-  optional BgpSrteSegmentFTypeSubTlv type_f = 7;
+  BgpSrteSegmentFTypeSubTlv type_f = 7;
 
   // Description missing in models
-  optional BgpSrteSegmentGTypeSubTlv type_g = 8;
+  BgpSrteSegmentGTypeSubTlv type_g = 8;
 
   // Description missing in models
-  optional BgpSrteSegmentHTypeSubTlv type_h = 9;
+  BgpSrteSegmentHTypeSubTlv type_h = 9;
 
   // Description missing in models
-  optional BgpSrteSegmentITypeSubTlv type_i = 10;
+  BgpSrteSegmentITypeSubTlv type_i = 10;
 
   // Description missing in models
-  optional BgpSrteSegmentJTypeSubTlv type_j = 11;
+  BgpSrteSegmentJTypeSubTlv type_j = 11;
 
   // Description missing in models
-  optional BgpSrteSegmentKTypeSubTlv type_k = 12;
+  BgpSrteSegmentKTypeSubTlv type_k = 12;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 13;
+  optional string name = 13;
 
   // If enabled means that this part of the configuration including any active 'children'
   // nodes will be advertised to peer.  If disabled, this means that though config is
@@ -3497,10 +3497,10 @@ message BgpSrteSegmentBTypeSubTlv {
 
   // SRv6 SID.
   // required = true
-  string srv6_sid = 2;
+  optional string srv6_sid = 2;
 
   // Optional SRv6 Endpoint Behavior and SID Structure.
-  optional BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 3;
+  BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 3;
 }
 
 // Type C: IPv4 Node Address with optional SID.
@@ -3516,10 +3516,10 @@ message BgpSrteSegmentCTypeSubTlv {
 
   // IPv4 address representing a node.
   // required = true
-  string ipv4_node_address = 3;
+  optional string ipv4_node_address = 3;
 
   // Optional SR-MPLS SID.
-  optional BgpSrteSrMplsSid sr_mpls_sid = 4;
+  BgpSrteSrMplsSid sr_mpls_sid = 4;
 }
 
 // Type D: IPv6 Node Address with optional SID for SR MPLS.
@@ -3535,10 +3535,10 @@ message BgpSrteSegmentDTypeSubTlv {
 
   // IPv6 address representing a node.
   // required = true
-  string ipv6_node_address = 3;
+  optional string ipv6_node_address = 3;
 
   // Optional SR-MPLS SID.
-  optional BgpSrteSrMplsSid sr_mpls_sid = 4;
+  BgpSrteSrMplsSid sr_mpls_sid = 4;
 }
 
 // Type E: IPv4 Address and Local Interface ID with optional SID
@@ -3554,10 +3554,10 @@ message BgpSrteSegmentETypeSubTlv {
 
   // IPv4 address representing a node.
   // required = true
-  string ipv4_node_address = 3;
+  optional string ipv4_node_address = 3;
 
   // Optional SR-MPLS SID.
-  optional BgpSrteSrMplsSid sr_mpls_sid = 4;
+  BgpSrteSrMplsSid sr_mpls_sid = 4;
 }
 
 // Type F: IPv4 Local and Remote addresses with optional SID.
@@ -3569,14 +3569,14 @@ message BgpSrteSegmentFTypeSubTlv {
 
   // Local IPv4 Address.
   // required = true
-  string local_ipv4_address = 2;
+  optional string local_ipv4_address = 2;
 
   // Remote IPv4 Address.
   // required = true
-  string remote_ipv4_address = 3;
+  optional string remote_ipv4_address = 3;
 
   // Optional SR-MPLS SID.
-  optional BgpSrteSrMplsSid sr_mpls_sid = 4;
+  BgpSrteSrMplsSid sr_mpls_sid = 4;
 }
 
 // Type G: IPv6 Address, Interface ID for local and remote pair with optional SID for
@@ -3593,7 +3593,7 @@ message BgpSrteSegmentGTypeSubTlv {
 
   // IPv6 address representing a node.
   // required = true
-  string local_ipv6_node_address = 3;
+  optional string local_ipv6_node_address = 3;
 
   // Local Interface ID: The Interface Index as defined in [RFC8664].
   // default = 0
@@ -3601,10 +3601,10 @@ message BgpSrteSegmentGTypeSubTlv {
 
   // IPv6 address representing a node.
   // required = true
-  string remote_ipv6_node_address = 5;
+  optional string remote_ipv6_node_address = 5;
 
   // Optional SR-MPLS SID.
-  optional BgpSrteSrMplsSid sr_mpls_sid = 6;
+  BgpSrteSrMplsSid sr_mpls_sid = 6;
 }
 
 // Type H: IPv6 Local and Remote addresses with optional SID for SR MPLS.
@@ -3616,14 +3616,14 @@ message BgpSrteSegmentHTypeSubTlv {
 
   // Local IPv6 Address.
   // required = true
-  string local_ipv6_address = 2;
+  optional string local_ipv6_address = 2;
 
   // Remote IPv6 Address.
   // required = true
-  string remote_ipv6_address = 3;
+  optional string remote_ipv6_address = 3;
 
   // Optional SR-MPLS SID.
-  optional BgpSrteSrMplsSid sr_mpls_sid = 4;
+  BgpSrteSrMplsSid sr_mpls_sid = 4;
 }
 
 // Type I: IPv6 Node Address with optional SRv6 SID.
@@ -3635,13 +3635,13 @@ message BgpSrteSegmentITypeSubTlv {
 
   // IPv6 address representing a node.
   // required = true
-  string ipv6_node_address = 2;
+  optional string ipv6_node_address = 2;
 
   // Optional SRv6 SID.
   optional string srv6_sid = 3;
 
   // Optional SRv6 Endpoint Behavior and SID Structure.
-  optional BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 4;
+  BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 4;
 }
 
 // Type J: IPv6 Address, Interface ID for local and remote pair for SRv6 with optional
@@ -3662,7 +3662,7 @@ message BgpSrteSegmentJTypeSubTlv {
 
   // IPv6 address representing a node.
   // required = true
-  string local_ipv6_node_address = 4;
+  optional string local_ipv6_node_address = 4;
 
   // Local Interface ID: The Interface Index as defined in [RFC8664].
   // default = 0
@@ -3670,13 +3670,13 @@ message BgpSrteSegmentJTypeSubTlv {
 
   // IPv6 address representing a node.
   // required = true
-  string remote_ipv6_node_address = 6;
+  optional string remote_ipv6_node_address = 6;
 
   // Optional SRv6 SID.
   optional string srv6_sid = 7;
 
   // Optional SRv6 Endpoint Behavior and SID Structure.
-  optional BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 8;
+  BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 8;
 }
 
 // Type K: IPv6 Local and Remote addresses for SRv6 with optional SID.
@@ -3692,17 +3692,17 @@ message BgpSrteSegmentKTypeSubTlv {
 
   // IPv6 address representing a node.
   // required = true
-  string local_ipv6_address = 3;
+  optional string local_ipv6_address = 3;
 
   // IPv6 address representing a node.
   // required = true
-  string remote_ipv6_address = 4;
+  optional string remote_ipv6_address = 4;
 
   // Optional SRv6 SID.
   optional string srv6_sid = 5;
 
   // Optional SRv6 Endpoint Behavior and SID Structure.
-  optional BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 6;
+  BgpSrteSRv6SIDEndpointBehaviorAndStructure srv6_sid_endpoint_behavior = 6;
 }
 
 // Configuration for BGP Segment Routing Traffic Engineering policy.
@@ -3722,7 +3722,7 @@ message BgpSrteV6Policy {
   // Specifies a single node or a set of nodes (e.g., an anycast address). It is selected
   // on the basis of the SR Policy type (AFI).
   // required = true
-  string ipv6_endpoint = 3;
+  optional string ipv6_endpoint = 3;
 
   message NextHopMode {
     enum Enum {
@@ -3761,13 +3761,13 @@ message BgpSrteV6Policy {
   optional string next_hop_ipv6_address = 7;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 8;
+  BgpRouteAdvanced advanced = 8;
 
   // Description missing in models
-  optional BgpAddPath add_path = 9;
+  BgpAddPath add_path = 9;
 
   // Description missing in models
-  optional BgpAsPath as_path = 10;
+  BgpAsPath as_path = 10;
 
   // Optional community settings.
   repeated BgpCommunity communities = 11;
@@ -3807,7 +3807,7 @@ message BgpSrteV6Policy {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 14;
+  optional string name = 14;
 
   // If enabled means that this part of the configuration including any active 'children'
   // nodes will be advertised to peer.  If disabled, this means that though config is
@@ -3821,25 +3821,25 @@ message BgpSrteV6Policy {
 message BgpSrteV6TunnelTlv {
 
   // Description missing in models
-  optional BgpSrteRemoteEndpointSubTlv remote_endpoint_sub_tlv = 1;
+  BgpSrteRemoteEndpointSubTlv remote_endpoint_sub_tlv = 1;
 
   // Description missing in models
-  optional BgpSrteColorSubTlv color_sub_tlv = 2;
+  BgpSrteColorSubTlv color_sub_tlv = 2;
 
   // Description missing in models
-  optional BgpSrteBindingSubTlv binding_sub_tlv = 3;
+  BgpSrteBindingSubTlv binding_sub_tlv = 3;
 
   // Description missing in models
-  optional BgpSrtePreferenceSubTlv preference_sub_tlv = 4;
+  BgpSrtePreferenceSubTlv preference_sub_tlv = 4;
 
   // Description missing in models
-  optional BgpSrtePolicyPrioritySubTlv policy_priority_sub_tlv = 5;
+  BgpSrtePolicyPrioritySubTlv policy_priority_sub_tlv = 5;
 
   // Description missing in models
-  optional BgpSrtePolicyNameSubTlv policy_name_sub_tlv = 6;
+  BgpSrtePolicyNameSubTlv policy_name_sub_tlv = 6;
 
   // Description missing in models
-  optional BgpSrteExplicitNullLabelPolicySubTlv explicit_null_label_policy_sub_tlv = 7;
+  BgpSrteExplicitNullLabelPolicySubTlv explicit_null_label_policy_sub_tlv = 7;
 
   // Description missing in models
   repeated BgpSrteSegmentList segment_lists = 8;
@@ -3847,7 +3847,7 @@ message BgpSrteV6TunnelTlv {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 9;
+  optional string name = 9;
 
   // If enabled means that this part of the configuration including any active 'children'
   // nodes will be advertised to peer.  If disabled, this means that though config is
@@ -3894,10 +3894,10 @@ message BgpV6Peer {
 
   // IPv6 address of the BGP peer for the session
   // required = true
-  string peer_address = 1;
+  optional string peer_address = 1;
 
   // Description missing in models
-  optional BgpV6SegmentRouting segment_routing = 2;
+  BgpV6SegmentRouting segment_routing = 2;
 
   // This contains the list of Ethernet Virtual Private Network (EVPN) Ethernet Segments
   // (ES) Per BGP Peer for IPv6 Address Family Identifier (AFI).
@@ -3936,11 +3936,11 @@ message BgpV6Peer {
   // attribute in 'as_path' field  in any Route Range should be changed from default value
   // 'do_not_include_local_as' to any other value.
   // required = true
-  AsType.Enum as_type = 4;
+  optional AsType.Enum as_type = 4;
 
   // Autonomous System Number (AS number or ASN)
   // required = true
-  uint32 as_number = 5;
+  optional uint32 as_number = 5;
 
   message AsNumberWidth {
     enum Enum {
@@ -3955,13 +3955,13 @@ message BgpV6Peer {
   optional AsNumberWidth.Enum as_number_width = 6;
 
   // Description missing in models
-  optional BgpAdvanced advanced = 7;
+  BgpAdvanced advanced = 7;
 
   // Description missing in models
-  optional BgpCapability capability = 8;
+  BgpCapability capability = 8;
 
   // Description missing in models
-  optional BgpLearnedInformationFilter learned_information_filter = 9;
+  BgpLearnedInformationFilter learned_information_filter = 9;
 
   // Emulated BGPv4 route ranges.
   repeated BgpV4RouteRange v4_routes = 10;
@@ -3982,10 +3982,10 @@ message BgpV6Peer {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 14;
+  optional string name = 14;
 
   // Description missing in models
-  optional BgpGracefulRestart graceful_restart = 15;
+  BgpGracefulRestart graceful_restart = 15;
 }
 
 // Configuration for emulated BGPv6 peers and routes on a single IPv6 interface.
@@ -3999,7 +3999,7 @@ message BgpV6Interface {
   // - /components/schemas/Device.Ipv6Loopback/properties/name
   // 
   // required = true
-  string ipv6_name = 1;
+  optional string ipv6_name = 1;
 
   // This contains the list of BGPv6 peers configured on this interface.
   repeated BgpV6Peer peers = 2;
@@ -4047,7 +4047,7 @@ message BgpV6SegmentRouting {
 message BgpV6EthernetSegment {
 
   // Designated Forwarder (DF) election configuration.
-  optional BgpEthernetSegmentDfElection df_election = 1;
+  BgpEthernetSegmentDfElection df_election = 1;
 
   // This contains the list of EVIs.
   repeated BgpV6EvpnEvis evis = 2;
@@ -4074,7 +4074,7 @@ message BgpV6EthernetSegment {
   optional uint32 esi_label = 5;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 6;
+  BgpRouteAdvanced advanced = 6;
 
   // Optional community settings.
   repeated BgpCommunity communities = 7;
@@ -4109,7 +4109,7 @@ message BgpV6EthernetSegment {
   repeated BgpExtCommunity ext_communities = 8;
 
   // Optional AS PATH settings.
-  optional BgpAsPath as_path = 9;
+  BgpAsPath as_path = 9;
 }
 
 // This contains a list of different flavors of EVPN.
@@ -4129,7 +4129,7 @@ message BgpV6EvpnEvis {
   optional Choice.Enum choice = 1;
 
   // EVPN VXLAN instance to be configured per Ethernet Segment.
-  optional BgpV6EviVxlan evi_vxlan = 2;
+  BgpV6EviVxlan evi_vxlan = 2;
 }
 
 // Configuration for BGP EVPN EVI. Advertises following routes -
@@ -4166,7 +4166,7 @@ message BgpV6EviVxlan {
 
   // Colon separated Extended Community value of 6 Bytes - AS number: Value identifying
   // an EVI.            Example - for the as_2octet 60005:100.
-  optional BgpRouteDistinguisher route_distinguisher = 5;
+  BgpRouteDistinguisher route_distinguisher = 5;
 
   // List of Layer 2 Virtual Network Identifier (L2VNI) export targets associated with
   // this EVI.
@@ -4182,7 +4182,7 @@ message BgpV6EviVxlan {
   repeated BgpRouteTarget l3_route_target_import = 9;
 
   // Description missing in models
-  optional BgpRouteAdvanced advanced = 10;
+  BgpRouteAdvanced advanced = 10;
 
   // Optional community settings.
   repeated BgpCommunity communities = 11;
@@ -4217,7 +4217,7 @@ message BgpV6EviVxlan {
   repeated BgpExtCommunity ext_communities = 12;
 
   // Optional AS PATH settings.
-  optional BgpAsPath as_path = 13;
+  BgpAsPath as_path = 13;
 }
 
 // Configuration for Broadcast Domains per EVI.
@@ -4260,21 +4260,21 @@ message VxlanV4Tunnel {
   // - /components/schemas/Device.Ipv4Loopback/properties/name
   // 
   // required = true
-  string source_interface = 1;
+  optional string source_interface = 1;
 
   // Description missing in models
-  optional VxlanV4TunnelDestinationIPMode destination_ip_mode = 2;
+  VxlanV4TunnelDestinationIPMode destination_ip_mode = 2;
 
   // VXLAN Network Identifier (VNI) to distinguish network instances on the wire
   // required = true
-  uint32 vni = 3;
+  optional uint32 vni = 3;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 4;
+  optional string name = 4;
 }
 
 // Configuration and operational state parameters relating to IPv6 VXLAN tunnel end-point
@@ -4288,21 +4288,21 @@ message VxlanV6Tunnel {
   // - /components/schemas/Device.Ipv6Loopback/properties/name
   // 
   // required = true
-  string source_interface = 1;
+  optional string source_interface = 1;
 
   // Description missing in models
-  optional VxlanV6TunnelDestinationIPMode destination_ip_mode = 2;
+  VxlanV6TunnelDestinationIPMode destination_ip_mode = 2;
 
   // VXLAN Network Identifier (VNI) to distinguish network instances on the wire
   // required = true
-  uint32 vni = 3;
+  optional uint32 vni = 3;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 4;
+  optional string name = 4;
 }
 
 // Communication mode between the VTEPs, either unicast or multicast.
@@ -4320,10 +4320,10 @@ message VxlanV4TunnelDestinationIPMode {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional VxlanV4TunnelDestinationIPModeUnicast unicast = 2;
+  VxlanV4TunnelDestinationIPModeUnicast unicast = 2;
 
   // Description missing in models
-  optional VxlanV4TunnelDestinationIPModeMulticast multicast = 3;
+  VxlanV4TunnelDestinationIPModeMulticast multicast = 3;
 }
 
 // Communication mode between the VTEPs, either unicast or multicast.
@@ -4341,10 +4341,10 @@ message VxlanV6TunnelDestinationIPMode {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional VxlanV6TunnelDestinationIPModeUnicast unicast = 2;
+  VxlanV6TunnelDestinationIPModeUnicast unicast = 2;
 
   // Description missing in models
-  optional VxlanV6TunnelDestinationIPModeMulticast multicast = 3;
+  VxlanV6TunnelDestinationIPModeMulticast multicast = 3;
 }
 
 // Description missing in models
@@ -4446,11 +4446,11 @@ message RsvpIpv4Interface {
   // - /components/schemas/Device.Ipv4/properties/name
   // 
   // required = true
-  string ipv4_name = 1;
+  optional string ipv4_name = 1;
 
   // IPv4 address of the RSVP neighbor on this interface.
   // required = true
-  string neighbor_ip = 2;
+  optional string neighbor_ip = 2;
 
   // The user-defined label space start value. The LSPs for which this router acts as
   // a egress are assigned labels from this label pool.Thelabel_space_start and label_space_end
@@ -4512,10 +4512,10 @@ message RsvpLspIpv4Interface {
   // - /components/schemas/Device.Ipv4Loopback/properties/name
   // 
   // required = true
-  string ipv4_name = 1;
+  optional string ipv4_name = 1;
 
   // Contains properties of Tail(Egress) LSPs.
-  optional RsvpLspIpv4InterfaceP2PEgressIpv4Lsp p2p_egress_ipv4_lsps = 2;
+  RsvpLspIpv4InterfaceP2PEgressIpv4Lsp p2p_egress_ipv4_lsps = 2;
 
   // Array of point-to-point RSVP-TE P2P LSPs originating from this interface.
   repeated RsvpLspIpv4InterfaceP2PIngressIpv4Lsp p2p_ingress_ipv4_lsps = 3;
@@ -4527,7 +4527,7 @@ message RsvpLspIpv4InterfaceP2PEgressIpv4Lsp {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // The time in seconds between successive transmissions of RESV Refreshes. The actual
   // refresh interval is jittered by upto 50%. There is no specification specified maximum
@@ -4576,11 +4576,11 @@ message RsvpLspIpv4InterfaceP2PIngressIpv4Lsp {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // IPv4 address of the remote endpoint of the LSP.
   // required = true
-  string remote_address = 2;
+  optional string remote_address = 2;
 
   // The Tunnel ID of the RSVP LSP. Carried in the SESSION object in Path Messages.
   // default = 1
@@ -4623,23 +4623,23 @@ message RsvpLspIpv4InterfaceP2PIngressIpv4Lsp {
 
   // This contains the values of the fields to be included in the SESSION_ATTRIBUTE object
   // in the Path Message sent for the LSP.
-  optional RsvpSessionAttribute session_attribute = 9;
+  RsvpSessionAttribute session_attribute = 9;
 
   // This contains the values of the fields to be included in the TSPEC object in the
   // Path Message sent for the LSP.
-  optional RsvpTspec tspec = 10;
+  RsvpTspec tspec = 10;
 
   // This contains the values of the fields to be included in the FAST_REROUTE object
   // in the Path Message sent for the LSP.
   // This is an optional object . If this attribute is not included , the FAST_REROUTE
   // object will not be included.
-  optional RsvpFastReroute fast_reroute = 11;
+  RsvpFastReroute fast_reroute = 11;
 
   // This contains the values of the fields to be included in the ERO object in the Path
   // Message sent for the LSP.
   // This is an optional object . If this attribute is not included , the ERO object will
   // not be included.
-  optional RsvpEro ero = 12;
+  RsvpEro ero = 12;
 }
 
 // Configuration for RSVP-TE SESSION_ATTRIBUTE object included in Path Messages as defined
@@ -4710,7 +4710,7 @@ message RsvpSessionAttribute {
   // using which further constraints can be
   // set on the path calculated for the LSP based on the Admin Group settings in the IGP
   // (e.g ISIS or OSPF interface).
-  optional RsvpResourceAffinities resource_affinities = 10;
+  RsvpResourceAffinities resource_affinities = 10;
 }
 
 // This is an optional object. If included, the extended SESSION_ATTRIBUTE object is
@@ -4945,21 +4945,21 @@ message Flow {
   repeated FlowHeader egress_packet = 9;
 
   // The size of the packets.
-  optional FlowSize size = 3;
+  FlowSize size = 3;
 
   // The transmit rate of the packets.
-  optional FlowRate rate = 4;
+  FlowRate rate = 4;
 
   // The transmit duration of the packets.
-  optional FlowDuration duration = 5;
+  FlowDuration duration = 5;
 
   // Flow metrics.
-  optional FlowMetrics metrics = 6;
+  FlowMetrics metrics = 6;
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 7;
+  optional string name = 7;
 }
 
 // A container for different types of transmit and receive
@@ -4978,10 +4978,10 @@ message FlowTxRx {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowPort port = 2;
+  FlowPort port = 2;
 
   // Description missing in models
-  optional FlowRouter device = 3;
+  FlowRouter device = 3;
 }
 
 // A container for a transmit port and 0..n intended receive ports.
@@ -5000,7 +5000,7 @@ message FlowPort {
   // - /components/schemas/Lag/properties/name
   // 
   // required = true
-  string tx_name = 1;
+  optional string tx_name = 1;
 
   // Deprecated: This property is deprecated in favor of property rx_names
   // 
@@ -5140,61 +5140,61 @@ message FlowHeader {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowCustom custom = 2;
+  FlowCustom custom = 2;
 
   // Description missing in models
-  optional FlowEthernet ethernet = 3;
+  FlowEthernet ethernet = 3;
 
   // Description missing in models
-  optional FlowVlan vlan = 4;
+  FlowVlan vlan = 4;
 
   // Description missing in models
-  optional FlowVxlan vxlan = 5;
+  FlowVxlan vxlan = 5;
 
   // Description missing in models
-  optional FlowIpv4 ipv4 = 6;
+  FlowIpv4 ipv4 = 6;
 
   // Description missing in models
-  optional FlowIpv6 ipv6 = 7;
+  FlowIpv6 ipv6 = 7;
 
   // Description missing in models
-  optional FlowPfcPause pfcpause = 8;
+  FlowPfcPause pfcpause = 8;
 
   // Description missing in models
-  optional FlowEthernetPause ethernetpause = 9;
+  FlowEthernetPause ethernetpause = 9;
 
   // Description missing in models
-  optional FlowTcp tcp = 10;
+  FlowTcp tcp = 10;
 
   // Description missing in models
-  optional FlowUdp udp = 11;
+  FlowUdp udp = 11;
 
   // Description missing in models
-  optional FlowGre gre = 12;
+  FlowGre gre = 12;
 
   // Description missing in models
-  optional FlowGtpv1 gtpv1 = 13;
+  FlowGtpv1 gtpv1 = 13;
 
   // Description missing in models
-  optional FlowGtpv2 gtpv2 = 14;
+  FlowGtpv2 gtpv2 = 14;
 
   // Description missing in models
-  optional FlowArp arp = 15;
+  FlowArp arp = 15;
 
   // Description missing in models
-  optional FlowIcmp icmp = 16;
+  FlowIcmp icmp = 16;
 
   // Description missing in models
-  optional FlowIcmpv6 icmpv6 = 17;
+  FlowIcmpv6 icmpv6 = 17;
 
   // Description missing in models
-  optional FlowPpp ppp = 18;
+  FlowPpp ppp = 18;
 
   // Description missing in models
-  optional FlowIgmpv1 igmpv1 = 19;
+  FlowIgmpv1 igmpv1 = 19;
 
   // Description missing in models
-  optional FlowMpls mpls = 20;
+  FlowMpls mpls = 20;
 }
 
 // Custom packet header
@@ -5204,7 +5204,7 @@ message FlowCustom {
   // sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be
   // discarded. This packet header can be used in multiple places in the packet.
   // required = true
-  string bytes = 1;
+  optional string bytes = 1;
 
   // One or more metric tags can be used to enable tracking portion of or all bits
   // in a corresponding header field for metrics per each applicable value.
@@ -5220,7 +5220,7 @@ message FlowCustomMetricTag {
   // Name used to identify the metrics associated with the values applicable
   // for configured offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -5236,94 +5236,94 @@ message FlowCustomMetricTag {
 message FlowEthernet {
 
   // Description missing in models
-  optional PatternFlowEthernetDst dst = 1;
+  PatternFlowEthernetDst dst = 1;
 
   // Description missing in models
-  optional PatternFlowEthernetSrc src = 2;
+  PatternFlowEthernetSrc src = 2;
 
   // Description missing in models
-  optional PatternFlowEthernetEtherType ether_type = 3;
+  PatternFlowEthernetEtherType ether_type = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetPfcQueue pfc_queue = 4;
+  PatternFlowEthernetPfcQueue pfc_queue = 4;
 }
 
 // VLAN packet header
 message FlowVlan {
 
   // Description missing in models
-  optional PatternFlowVlanPriority priority = 1;
+  PatternFlowVlanPriority priority = 1;
 
   // Description missing in models
-  optional PatternFlowVlanCfi cfi = 2;
+  PatternFlowVlanCfi cfi = 2;
 
   // Description missing in models
-  optional PatternFlowVlanId id = 3;
+  PatternFlowVlanId id = 3;
 
   // Description missing in models
-  optional PatternFlowVlanTpid tpid = 4;
+  PatternFlowVlanTpid tpid = 4;
 }
 
 // VXLAN packet header
 message FlowVxlan {
 
   // Description missing in models
-  optional PatternFlowVxlanFlags flags = 1;
+  PatternFlowVxlanFlags flags = 1;
 
   // Description missing in models
-  optional PatternFlowVxlanReserved0 reserved0 = 2;
+  PatternFlowVxlanReserved0 reserved0 = 2;
 
   // Description missing in models
-  optional PatternFlowVxlanVni vni = 3;
+  PatternFlowVxlanVni vni = 3;
 
   // Description missing in models
-  optional PatternFlowVxlanReserved1 reserved1 = 4;
+  PatternFlowVxlanReserved1 reserved1 = 4;
 }
 
 // IPv4 packet header
 message FlowIpv4 {
 
   // Description missing in models
-  optional PatternFlowIpv4Version version = 1;
+  PatternFlowIpv4Version version = 1;
 
   // Description missing in models
-  optional PatternFlowIpv4HeaderLength header_length = 2;
+  PatternFlowIpv4HeaderLength header_length = 2;
 
   // Description missing in models
-  optional FlowIpv4Priority priority = 3;
+  FlowIpv4Priority priority = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TotalLength total_length = 4;
+  PatternFlowIpv4TotalLength total_length = 4;
 
   // Description missing in models
-  optional PatternFlowIpv4Identification identification = 5;
+  PatternFlowIpv4Identification identification = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4Reserved reserved = 6;
+  PatternFlowIpv4Reserved reserved = 6;
 
   // Description missing in models
-  optional PatternFlowIpv4DontFragment dont_fragment = 7;
+  PatternFlowIpv4DontFragment dont_fragment = 7;
 
   // Description missing in models
-  optional PatternFlowIpv4MoreFragments more_fragments = 8;
+  PatternFlowIpv4MoreFragments more_fragments = 8;
 
   // Description missing in models
-  optional PatternFlowIpv4FragmentOffset fragment_offset = 9;
+  PatternFlowIpv4FragmentOffset fragment_offset = 9;
 
   // Description missing in models
-  optional PatternFlowIpv4TimeToLive time_to_live = 10;
+  PatternFlowIpv4TimeToLive time_to_live = 10;
 
   // Description missing in models
-  optional PatternFlowIpv4Protocol protocol = 11;
+  PatternFlowIpv4Protocol protocol = 11;
 
   // Description missing in models
-  optional PatternFlowIpv4HeaderChecksum header_checksum = 12;
+  PatternFlowIpv4HeaderChecksum header_checksum = 12;
 
   // Description missing in models
-  optional PatternFlowIpv4Src src = 13;
+  PatternFlowIpv4Src src = 13;
 
   // Description missing in models
-  optional PatternFlowIpv4Dst dst = 14;
+  PatternFlowIpv4Dst dst = 14;
 }
 
 // A container for ipv4 raw, tos, dscp ip priorities.
@@ -5342,262 +5342,262 @@ message FlowIpv4Priority {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional PatternFlowIpv4PriorityRaw raw = 2;
+  PatternFlowIpv4PriorityRaw raw = 2;
 
   // Description missing in models
-  optional FlowIpv4Tos tos = 3;
+  FlowIpv4Tos tos = 3;
 
   // Description missing in models
-  optional FlowIpv4Dscp dscp = 4;
+  FlowIpv4Dscp dscp = 4;
 }
 
 // Differentiated services code point (DSCP) packet field.
 message FlowIpv4Dscp {
 
   // Description missing in models
-  optional PatternFlowIpv4DscpPhb phb = 1;
+  PatternFlowIpv4DscpPhb phb = 1;
 
   // Description missing in models
-  optional PatternFlowIpv4DscpEcn ecn = 2;
+  PatternFlowIpv4DscpEcn ecn = 2;
 }
 
 // Type of service (TOS) packet field.
 message FlowIpv4Tos {
 
   // Description missing in models
-  optional PatternFlowIpv4TosPrecedence precedence = 1;
+  PatternFlowIpv4TosPrecedence precedence = 1;
 
   // Description missing in models
-  optional PatternFlowIpv4TosDelay delay = 2;
+  PatternFlowIpv4TosDelay delay = 2;
 
   // Description missing in models
-  optional PatternFlowIpv4TosThroughput throughput = 3;
+  PatternFlowIpv4TosThroughput throughput = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TosReliability reliability = 4;
+  PatternFlowIpv4TosReliability reliability = 4;
 
   // Description missing in models
-  optional PatternFlowIpv4TosMonetary monetary = 5;
+  PatternFlowIpv4TosMonetary monetary = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4TosUnused unused = 6;
+  PatternFlowIpv4TosUnused unused = 6;
 }
 
 // IPv6 packet header
 message FlowIpv6 {
 
   // Description missing in models
-  optional PatternFlowIpv6Version version = 1;
+  PatternFlowIpv6Version version = 1;
 
   // Description missing in models
-  optional PatternFlowIpv6TrafficClass traffic_class = 2;
+  PatternFlowIpv6TrafficClass traffic_class = 2;
 
   // Description missing in models
-  optional PatternFlowIpv6FlowLabel flow_label = 3;
+  PatternFlowIpv6FlowLabel flow_label = 3;
 
   // Description missing in models
-  optional PatternFlowIpv6PayloadLength payload_length = 4;
+  PatternFlowIpv6PayloadLength payload_length = 4;
 
   // Description missing in models
-  optional PatternFlowIpv6NextHeader next_header = 5;
+  PatternFlowIpv6NextHeader next_header = 5;
 
   // Description missing in models
-  optional PatternFlowIpv6HopLimit hop_limit = 6;
+  PatternFlowIpv6HopLimit hop_limit = 6;
 
   // Description missing in models
-  optional PatternFlowIpv6Src src = 7;
+  PatternFlowIpv6Src src = 7;
 
   // Description missing in models
-  optional PatternFlowIpv6Dst dst = 8;
+  PatternFlowIpv6Dst dst = 8;
 }
 
 // IEEE 802.1Qbb PFC Pause packet header.
 message FlowPfcPause {
 
   // Description missing in models
-  optional PatternFlowPfcPauseDst dst = 1;
+  PatternFlowPfcPauseDst dst = 1;
 
   // Description missing in models
-  optional PatternFlowPfcPauseSrc src = 2;
+  PatternFlowPfcPauseSrc src = 2;
 
   // Description missing in models
-  optional PatternFlowPfcPauseEtherType ether_type = 3;
+  PatternFlowPfcPauseEtherType ether_type = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPauseControlOpCode control_op_code = 4;
+  PatternFlowPfcPauseControlOpCode control_op_code = 4;
 
   // Description missing in models
-  optional PatternFlowPfcPauseClassEnableVector class_enable_vector = 5;
+  PatternFlowPfcPauseClassEnableVector class_enable_vector = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass0 pause_class_0 = 6;
+  PatternFlowPfcPausePauseClass0 pause_class_0 = 6;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass1 pause_class_1 = 7;
+  PatternFlowPfcPausePauseClass1 pause_class_1 = 7;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass2 pause_class_2 = 8;
+  PatternFlowPfcPausePauseClass2 pause_class_2 = 8;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass3 pause_class_3 = 9;
+  PatternFlowPfcPausePauseClass3 pause_class_3 = 9;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass4 pause_class_4 = 10;
+  PatternFlowPfcPausePauseClass4 pause_class_4 = 10;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass5 pause_class_5 = 11;
+  PatternFlowPfcPausePauseClass5 pause_class_5 = 11;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass6 pause_class_6 = 12;
+  PatternFlowPfcPausePauseClass6 pause_class_6 = 12;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass7 pause_class_7 = 13;
+  PatternFlowPfcPausePauseClass7 pause_class_7 = 13;
 }
 
 // IEEE 802.3x global ethernet pause packet header
 message FlowEthernetPause {
 
   // Description missing in models
-  optional PatternFlowEthernetPauseDst dst = 1;
+  PatternFlowEthernetPauseDst dst = 1;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseSrc src = 2;
+  PatternFlowEthernetPauseSrc src = 2;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseEtherType ether_type = 3;
+  PatternFlowEthernetPauseEtherType ether_type = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseControlOpCode control_op_code = 4;
+  PatternFlowEthernetPauseControlOpCode control_op_code = 4;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseTime time = 5;
+  PatternFlowEthernetPauseTime time = 5;
 }
 
 // TCP packet header
 message FlowTcp {
 
   // Description missing in models
-  optional PatternFlowTcpSrcPort src_port = 1;
+  PatternFlowTcpSrcPort src_port = 1;
 
   // Description missing in models
-  optional PatternFlowTcpDstPort dst_port = 2;
+  PatternFlowTcpDstPort dst_port = 2;
 
   // Description missing in models
-  optional PatternFlowTcpSeqNum seq_num = 3;
+  PatternFlowTcpSeqNum seq_num = 3;
 
   // Description missing in models
-  optional PatternFlowTcpAckNum ack_num = 4;
+  PatternFlowTcpAckNum ack_num = 4;
 
   // Description missing in models
-  optional PatternFlowTcpDataOffset data_offset = 5;
+  PatternFlowTcpDataOffset data_offset = 5;
 
   // Description missing in models
-  optional PatternFlowTcpEcnNs ecn_ns = 6;
+  PatternFlowTcpEcnNs ecn_ns = 6;
 
   // Description missing in models
-  optional PatternFlowTcpEcnCwr ecn_cwr = 7;
+  PatternFlowTcpEcnCwr ecn_cwr = 7;
 
   // Description missing in models
-  optional PatternFlowTcpEcnEcho ecn_echo = 8;
+  PatternFlowTcpEcnEcho ecn_echo = 8;
 
   // Description missing in models
-  optional PatternFlowTcpCtlUrg ctl_urg = 9;
+  PatternFlowTcpCtlUrg ctl_urg = 9;
 
   // Description missing in models
-  optional PatternFlowTcpCtlAck ctl_ack = 10;
+  PatternFlowTcpCtlAck ctl_ack = 10;
 
   // Description missing in models
-  optional PatternFlowTcpCtlPsh ctl_psh = 11;
+  PatternFlowTcpCtlPsh ctl_psh = 11;
 
   // Description missing in models
-  optional PatternFlowTcpCtlRst ctl_rst = 12;
+  PatternFlowTcpCtlRst ctl_rst = 12;
 
   // Description missing in models
-  optional PatternFlowTcpCtlSyn ctl_syn = 13;
+  PatternFlowTcpCtlSyn ctl_syn = 13;
 
   // Description missing in models
-  optional PatternFlowTcpCtlFin ctl_fin = 14;
+  PatternFlowTcpCtlFin ctl_fin = 14;
 
   // Description missing in models
-  optional PatternFlowTcpWindow window = 15;
+  PatternFlowTcpWindow window = 15;
 }
 
 // UDP packet header
 message FlowUdp {
 
   // Description missing in models
-  optional PatternFlowUdpSrcPort src_port = 1;
+  PatternFlowUdpSrcPort src_port = 1;
 
   // Description missing in models
-  optional PatternFlowUdpDstPort dst_port = 2;
+  PatternFlowUdpDstPort dst_port = 2;
 
   // Description missing in models
-  optional PatternFlowUdpLength length = 3;
+  PatternFlowUdpLength length = 3;
 
   // Description missing in models
-  optional PatternFlowUdpChecksum checksum = 4;
+  PatternFlowUdpChecksum checksum = 4;
 }
 
 // Standard GRE packet header (RFC2784)
 message FlowGre {
 
   // Description missing in models
-  optional PatternFlowGreChecksumPresent checksum_present = 1;
+  PatternFlowGreChecksumPresent checksum_present = 1;
 
   // Description missing in models
-  optional PatternFlowGreReserved0 reserved0 = 2;
+  PatternFlowGreReserved0 reserved0 = 2;
 
   // Description missing in models
-  optional PatternFlowGreVersion version = 3;
+  PatternFlowGreVersion version = 3;
 
   // Description missing in models
-  optional PatternFlowGreProtocol protocol = 4;
+  PatternFlowGreProtocol protocol = 4;
 
   // Description missing in models
-  optional PatternFlowGreChecksum checksum = 5;
+  PatternFlowGreChecksum checksum = 5;
 
   // Description missing in models
-  optional PatternFlowGreReserved1 reserved1 = 6;
+  PatternFlowGreReserved1 reserved1 = 6;
 }
 
 // GTPv1 packet header
 message FlowGtpv1 {
 
   // Description missing in models
-  optional PatternFlowGtpv1Version version = 1;
+  PatternFlowGtpv1Version version = 1;
 
   // Description missing in models
-  optional PatternFlowGtpv1ProtocolType protocol_type = 2;
+  PatternFlowGtpv1ProtocolType protocol_type = 2;
 
   // Description missing in models
-  optional PatternFlowGtpv1Reserved reserved = 3;
+  PatternFlowGtpv1Reserved reserved = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1EFlag e_flag = 4;
+  PatternFlowGtpv1EFlag e_flag = 4;
 
   // Description missing in models
-  optional PatternFlowGtpv1SFlag s_flag = 5;
+  PatternFlowGtpv1SFlag s_flag = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1PnFlag pn_flag = 6;
+  PatternFlowGtpv1PnFlag pn_flag = 6;
 
   // Description missing in models
-  optional PatternFlowGtpv1MessageType message_type = 7;
+  PatternFlowGtpv1MessageType message_type = 7;
 
   // Description missing in models
-  optional PatternFlowGtpv1MessageLength message_length = 8;
+  PatternFlowGtpv1MessageLength message_length = 8;
 
   // Description missing in models
-  optional PatternFlowGtpv1Teid teid = 9;
+  PatternFlowGtpv1Teid teid = 9;
 
   // Description missing in models
-  optional PatternFlowGtpv1SquenceNumber squence_number = 10;
+  PatternFlowGtpv1SquenceNumber squence_number = 10;
 
   // Description missing in models
-  optional PatternFlowGtpv1NPduNumber n_pdu_number = 11;
+  PatternFlowGtpv1NPduNumber n_pdu_number = 11;
 
   // Description missing in models
-  optional PatternFlowGtpv1NextExtensionHeaderType next_extension_header_type = 12;
+  PatternFlowGtpv1NextExtensionHeaderType next_extension_header_type = 12;
 
   // A list of optional extension headers.
   repeated FlowGtpExtension extension_headers = 13;
@@ -5607,75 +5607,75 @@ message FlowGtpv1 {
 message FlowGtpExtension {
 
   // Description missing in models
-  optional PatternFlowGtpExtensionExtensionLength extension_length = 1;
+  PatternFlowGtpExtensionExtensionLength extension_length = 1;
 
   // Description missing in models
-  optional PatternFlowGtpExtensionContents contents = 2;
+  PatternFlowGtpExtensionContents contents = 2;
 
   // Description missing in models
-  optional PatternFlowGtpExtensionNextExtensionHeader next_extension_header = 3;
+  PatternFlowGtpExtensionNextExtensionHeader next_extension_header = 3;
 }
 
 // GTPv2 packet header
 message FlowGtpv2 {
 
   // Description missing in models
-  optional PatternFlowGtpv2Version version = 1;
+  PatternFlowGtpv2Version version = 1;
 
   // Description missing in models
-  optional PatternFlowGtpv2PiggybackingFlag piggybacking_flag = 2;
+  PatternFlowGtpv2PiggybackingFlag piggybacking_flag = 2;
 
   // Description missing in models
-  optional PatternFlowGtpv2TeidFlag teid_flag = 3;
+  PatternFlowGtpv2TeidFlag teid_flag = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2Spare1 spare1 = 4;
+  PatternFlowGtpv2Spare1 spare1 = 4;
 
   // Description missing in models
-  optional PatternFlowGtpv2MessageType message_type = 5;
+  PatternFlowGtpv2MessageType message_type = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2MessageLength message_length = 6;
+  PatternFlowGtpv2MessageLength message_length = 6;
 
   // Description missing in models
-  optional PatternFlowGtpv2Teid teid = 7;
+  PatternFlowGtpv2Teid teid = 7;
 
   // Description missing in models
-  optional PatternFlowGtpv2SequenceNumber sequence_number = 8;
+  PatternFlowGtpv2SequenceNumber sequence_number = 8;
 
   // Description missing in models
-  optional PatternFlowGtpv2Spare2 spare2 = 9;
+  PatternFlowGtpv2Spare2 spare2 = 9;
 }
 
 // ARP packet header
 message FlowArp {
 
   // Description missing in models
-  optional PatternFlowArpHardwareType hardware_type = 1;
+  PatternFlowArpHardwareType hardware_type = 1;
 
   // Description missing in models
-  optional PatternFlowArpProtocolType protocol_type = 2;
+  PatternFlowArpProtocolType protocol_type = 2;
 
   // Description missing in models
-  optional PatternFlowArpHardwareLength hardware_length = 3;
+  PatternFlowArpHardwareLength hardware_length = 3;
 
   // Description missing in models
-  optional PatternFlowArpProtocolLength protocol_length = 4;
+  PatternFlowArpProtocolLength protocol_length = 4;
 
   // Description missing in models
-  optional PatternFlowArpOperation operation = 5;
+  PatternFlowArpOperation operation = 5;
 
   // Description missing in models
-  optional PatternFlowArpSenderHardwareAddr sender_hardware_addr = 6;
+  PatternFlowArpSenderHardwareAddr sender_hardware_addr = 6;
 
   // Description missing in models
-  optional PatternFlowArpSenderProtocolAddr sender_protocol_addr = 7;
+  PatternFlowArpSenderProtocolAddr sender_protocol_addr = 7;
 
   // Description missing in models
-  optional PatternFlowArpTargetHardwareAddr target_hardware_addr = 8;
+  PatternFlowArpTargetHardwareAddr target_hardware_addr = 8;
 
   // Description missing in models
-  optional PatternFlowArpTargetProtocolAddr target_protocol_addr = 9;
+  PatternFlowArpTargetProtocolAddr target_protocol_addr = 9;
 }
 
 // ICMP packet header
@@ -5692,26 +5692,26 @@ message FlowIcmp {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowIcmpEcho echo = 2;
+  FlowIcmpEcho echo = 2;
 }
 
 // Packet Header for ICMP echo request
 message FlowIcmpEcho {
 
   // Description missing in models
-  optional PatternFlowIcmpEchoType type = 1;
+  PatternFlowIcmpEchoType type = 1;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoCode code = 2;
+  PatternFlowIcmpEchoCode code = 2;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoChecksum checksum = 3;
+  PatternFlowIcmpEchoChecksum checksum = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoIdentifier identifier = 4;
+  PatternFlowIcmpEchoIdentifier identifier = 4;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoSequenceNumber sequence_number = 5;
+  PatternFlowIcmpEchoSequenceNumber sequence_number = 5;
 }
 
 // ICMPv6 packet header
@@ -5728,58 +5728,58 @@ message FlowIcmpv6 {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowIcmpv6Echo echo = 2;
+  FlowIcmpv6Echo echo = 2;
 }
 
 // Packet Header for ICMPv6 Echo
 message FlowIcmpv6Echo {
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoType type = 1;
+  PatternFlowIcmpv6EchoType type = 1;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoCode code = 2;
+  PatternFlowIcmpv6EchoCode code = 2;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoIdentifier identifier = 3;
+  PatternFlowIcmpv6EchoIdentifier identifier = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoSequenceNumber sequence_number = 4;
+  PatternFlowIcmpv6EchoSequenceNumber sequence_number = 4;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoChecksum checksum = 5;
+  PatternFlowIcmpv6EchoChecksum checksum = 5;
 }
 
 // PPP packet header
 message FlowPpp {
 
   // Description missing in models
-  optional PatternFlowPppAddress address = 1;
+  PatternFlowPppAddress address = 1;
 
   // Description missing in models
-  optional PatternFlowPppControl control = 2;
+  PatternFlowPppControl control = 2;
 
   // Description missing in models
-  optional PatternFlowPppProtocolType protocol_type = 3;
+  PatternFlowPppProtocolType protocol_type = 3;
 }
 
 // IGMPv1 packet header
 message FlowIgmpv1 {
 
   // Description missing in models
-  optional PatternFlowIgmpv1Version version = 1;
+  PatternFlowIgmpv1Version version = 1;
 
   // Description missing in models
-  optional PatternFlowIgmpv1Type type = 2;
+  PatternFlowIgmpv1Type type = 2;
 
   // Description missing in models
-  optional PatternFlowIgmpv1Unused unused = 3;
+  PatternFlowIgmpv1Unused unused = 3;
 
   // Description missing in models
-  optional PatternFlowIgmpv1Checksum checksum = 4;
+  PatternFlowIgmpv1Checksum checksum = 4;
 
   // Description missing in models
-  optional PatternFlowIgmpv1GroupAddress group_address = 5;
+  PatternFlowIgmpv1GroupAddress group_address = 5;
 }
 
 // MPLS packet header; When configuring multiple such headers, the count shall not exceed
@@ -5787,16 +5787,16 @@ message FlowIgmpv1 {
 message FlowMpls {
 
   // Description missing in models
-  optional PatternFlowMplsLabel label = 1;
+  PatternFlowMplsLabel label = 1;
 
   // Description missing in models
-  optional PatternFlowMplsTrafficClass traffic_class = 2;
+  PatternFlowMplsTrafficClass traffic_class = 2;
 
   // Description missing in models
-  optional PatternFlowMplsBottomOfStack bottom_of_stack = 3;
+  PatternFlowMplsBottomOfStack bottom_of_stack = 3;
 
   // Description missing in models
-  optional PatternFlowMplsTimeToLive time_to_live = 4;
+  PatternFlowMplsTimeToLive time_to_live = 4;
 }
 
 // The frame size which overrides the total length of the packet
@@ -5820,13 +5820,13 @@ message FlowSize {
   optional uint32 fixed = 2;
 
   // Description missing in models
-  optional FlowSizeIncrement increment = 3;
+  FlowSizeIncrement increment = 3;
 
   // Description missing in models
-  optional FlowSizeRandom random = 4;
+  FlowSizeRandom random = 4;
 
   // Description missing in models
-  optional FlowSizeWeightPairs weight_pairs = 5;
+  FlowSizeWeightPairs weight_pairs = 5;
 }
 
 // Frame size that increments from a starting size to
@@ -5978,16 +5978,16 @@ message FlowDuration {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowFixedPackets fixed_packets = 2;
+  FlowFixedPackets fixed_packets = 2;
 
   // Description missing in models
-  optional FlowFixedSeconds fixed_seconds = 3;
+  FlowFixedSeconds fixed_seconds = 3;
 
   // Description missing in models
-  optional FlowBurst burst = 4;
+  FlowBurst burst = 4;
 
   // Description missing in models
-  optional FlowContinuous continuous = 5;
+  FlowContinuous continuous = 5;
 }
 
 // Transmit will be continuous and will not stop automatically.
@@ -5998,7 +5998,7 @@ message FlowContinuous {
   optional uint32 gap = 1;
 
   // Description missing in models
-  optional FlowDelay delay = 2;
+  FlowDelay delay = 2;
 }
 
 // The optional container to specify the delay before starting
@@ -6045,7 +6045,7 @@ message FlowFixedPackets {
   optional uint32 gap = 2;
 
   // Description missing in models
-  optional FlowDelay delay = 3;
+  FlowDelay delay = 3;
 }
 
 // Transmit for a fixed number of seconds after which the flow will stop.
@@ -6060,7 +6060,7 @@ message FlowFixedSeconds {
   optional uint32 gap = 2;
 
   // Description missing in models
-  optional FlowDelay delay = 3;
+  FlowDelay delay = 3;
 }
 
 // Transmits continuous or fixed burst of packets.
@@ -6083,7 +6083,7 @@ message FlowBurst {
   optional uint32 gap = 3;
 
   // Description missing in models
-  optional FlowDurationInterBurstGap inter_burst_gap = 4;
+  FlowDurationInterBurstGap inter_burst_gap = 4;
 }
 
 // The optional container for specifying a gap between bursts.
@@ -6131,17 +6131,17 @@ message FlowMetrics {
   optional bool loss = 2;
 
   // Rx Tx ratio.
-  optional FlowRxTxRatio rx_tx_ratio = 6;
+  FlowRxTxRatio rx_tx_ratio = 6;
 
   // Enables additional flow metric first and last timestamps.
   // default = False
   optional bool timestamps = 3;
 
   // Latency metrics.
-  optional FlowLatencyMetrics latency = 4;
+  FlowLatencyMetrics latency = 4;
 
   // Predefined metric tags
-  optional FlowPredefinedTags predefined_metric_tags = 5;
+  FlowPredefinedTags predefined_metric_tags = 5;
 }
 
 // The optional container for per flow latency metric configuration.
@@ -6212,7 +6212,7 @@ message FlowRxTxRatio {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowRxTxRatioRxCount rx_count = 2;
+  FlowRxTxRatioRxCount rx_count = 2;
 
   // Should be a positive, non-zero value. The default value of 1, is when the Rx packet
   // count across
@@ -6245,13 +6245,13 @@ message Event {
   optional bool enable = 1;
 
   // Description missing in models
-  optional EventLink link = 2;
+  EventLink link = 2;
 
   // Description missing in models
-  optional EventRxRateThreshold rx_rate_threshold = 3;
+  EventRxRateThreshold rx_rate_threshold = 3;
 
   // Description missing in models
-  optional EventRouteAdvertiseWithdraw route_advertise_withdraw = 4;
+  EventRouteAdvertiseWithdraw route_advertise_withdraw = 4;
 }
 
 // The optional container for rx rate threshold event configuration.
@@ -6320,7 +6320,7 @@ message EventRequest {
 message EventSubscription {
 
   // Description missing in models
-  optional EventRequest events = 1;
+  EventRequest events = 1;
 
   // Indicates where a client wants to be notified of the events set in
   // the events property.
@@ -6339,18 +6339,18 @@ message Lldp {
   // The Chassis ID is a mandatory TLV which identifies the chassis component of the endpoint
   // identifier associated  with the transmitting LLDP agent. If mac address is specified
   // it should be in colon seperated mac address format.
-  optional LldpChassisId chassis_id = 2;
+  LldpChassisId chassis_id = 2;
 
   // The Port ID is a mandatory TLV which identifies the port component of the endpoint
   // identifier associated with  the transmitting LLDP agent. If the specified port is
   // an IEEE 802.3 Repeater port, then this TLV is optional.
-  optional LldpPortId port_id = 3;
+  LldpPortId port_id = 3;
 
   // The system name field shall contain an alpha-numeric string that indicates the system's
   // administratively assigned  name. The system name should be the system's fully qualified
   // domain name. If implementations support IETF RFC  3418, the sysName object should
   // be used for this field.
-  optional LldpSystemName system_name = 4;
+  LldpSystemName system_name = 4;
 
   // Specifies the amount of time in seconds a receiving device should maintain LLDP information
   // sent  by the device before discarding it.
@@ -6364,7 +6364,7 @@ message Lldp {
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  string name = 7;
+  optional string name = 7;
 }
 
 // LLDP connection to a test port. In future if more connection options arise  LLDP
@@ -6407,7 +6407,7 @@ message LldpChassisId {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional LldpChassisMacSubType mac_address_subtype = 2;
+  LldpChassisMacSubType mac_address_subtype = 2;
 
   // Name of an interface of the chassis that uniquely identifies the chassis.
   optional string interface_name_subtype = 3;
@@ -6438,7 +6438,7 @@ message LldpPortId {
   optional string mac_address_subtype = 2;
 
   // Description missing in models
-  optional LldpPortInterfaceNameSubType interface_name_subtype = 3;
+  LldpPortInterfaceNameSubType interface_name_subtype = 3;
 
   // The Locally assigned name configured in the Port ID TLV.
   optional string local_subtype = 4;
@@ -6519,7 +6519,7 @@ message Error {
   // - HTTP 5xx errors: https://datatracker.ietf.org/doc/html/rfc9110#section-15.6
   // - gRPC errors: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
   // required = true
-  int32 code = 1;
+  optional int32 code = 1;
 
   message Kind {
     enum Enum {
@@ -6559,7 +6559,7 @@ message ConfigUpdate {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional FlowsUpdate flows = 2;
+  FlowsUpdate flows = 2;
 }
 
 // A container of flows with associated properties to be updated without affecting the
@@ -6593,16 +6593,16 @@ message ControlState {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional StatePort port = 2;
+  StatePort port = 2;
 
   // Description missing in models
-  optional StateProtocol protocol = 3;
+  StateProtocol protocol = 3;
 
   // Description missing in models
-  optional StateTraffic traffic = 4;
+  StateTraffic traffic = 4;
 }
 
 // States associated with configured ports.
@@ -6617,13 +6617,13 @@ message StatePort {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional StatePortLink link = 2;
+  StatePortLink link = 2;
 
   // Description missing in models
-  optional StatePortCapture capture = 3;
+  StatePortCapture capture = 3;
 }
 
 // States associated with configured flows
@@ -6637,10 +6637,10 @@ message StateTraffic {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional StateTrafficFlowTransmit flow_transmit = 2;
+  StateTrafficFlowTransmit flow_transmit = 2;
 }
 
 // States associated with protocols on configured resources.
@@ -6656,16 +6656,16 @@ message StateProtocol {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional StateProtocolAll all = 2;
+  StateProtocolAll all = 2;
 
   // Description missing in models
-  optional StateProtocolRoute route = 3;
+  StateProtocolRoute route = 3;
 
   // Description missing in models
-  optional StateProtocolLacp lacp = 4;
+  StateProtocolLacp lacp = 4;
 }
 
 // Sets the link of configured ports.
@@ -6687,7 +6687,7 @@ message StatePortLink {
   }
   // The link state.
   // required = true
-  State.Enum state = 2;
+  optional State.Enum state = 2;
 }
 
 // Sets the capture state of configured ports
@@ -6712,7 +6712,7 @@ message StatePortCapture {
   }
   // The capture state.
   // required = true
-  State.Enum state = 2;
+  optional State.Enum state = 2;
 }
 
 // Provides state control of flow transmission.
@@ -6750,7 +6750,7 @@ message StateTrafficFlowTransmit {
   // Any flow that is stopped will start transmit at the beginning of the flow. The flow(s)
   // MUST NOT have their metric counters cleared.
   // required = true
-  State.Enum state = 2;
+  optional State.Enum state = 2;
 }
 
 // Sets all configured protocols to `start` or `stop` state.
@@ -6768,7 +6768,7 @@ message StateProtocolAll {
   }
   // Protocol states
   // required = true
-  State.Enum state = 1;
+  optional State.Enum state = 1;
 }
 
 // Sets the state of configured routes
@@ -6794,7 +6794,7 @@ message StateProtocolRoute {
   }
   // Route states
   // required = true
-  State.Enum state = 2;
+  optional State.Enum state = 2;
 }
 
 // Sets state of configured LACP
@@ -6808,10 +6808,10 @@ message StateProtocolLacp {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional StateProtocolLacpAdmin admin = 2;
+  StateProtocolLacpAdmin admin = 2;
 }
 
 // Sets admin state of LACP configured on LAG members
@@ -6836,7 +6836,7 @@ message StateProtocolLacpAdmin {
   // member ports. 'down' will send LACPDUs with 'sync' flag unset on selected member
   // ports.
   // required = true
-  State.Enum state = 2;
+  optional State.Enum state = 2;
 }
 
 // Request for triggering action against configured resources.
@@ -6850,10 +6850,10 @@ message ControlAction {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionProtocol protocol = 2;
+  ActionProtocol protocol = 2;
 }
 
 // Response for action triggered against configured resources along with warnings.
@@ -6863,7 +6863,7 @@ message ControlActionResponse {
   repeated string warnings = 1;
 
   // Description missing in models
-  optional ActionResponse response = 2;
+  ActionResponse response = 2;
 }
 
 // Response for action triggered against configured resources.
@@ -6877,10 +6877,10 @@ message ActionResponse {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionResponseProtocol protocol = 2;
+  ActionResponseProtocol protocol = 2;
 }
 
 // Actions associated with protocols on configured resources.
@@ -6896,16 +6896,16 @@ message ActionProtocol {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionProtocolIpv4 ipv4 = 2;
+  ActionProtocolIpv4 ipv4 = 2;
 
   // Description missing in models
-  optional ActionProtocolIpv6 ipv6 = 3;
+  ActionProtocolIpv6 ipv6 = 3;
 
   // Description missing in models
-  optional ActionProtocolBgp bgp = 4;
+  ActionProtocolBgp bgp = 4;
 }
 
 // Response for actions associated with protocols on configured resources.
@@ -6920,13 +6920,13 @@ message ActionResponseProtocol {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionResponseProtocolIpv4 ipv4 = 2;
+  ActionResponseProtocolIpv4 ipv4 = 2;
 
   // Description missing in models
-  optional ActionResponseProtocolIpv6 ipv6 = 3;
+  ActionResponseProtocolIpv6 ipv6 = 3;
 }
 
 // Actions associated with IPv4 on configured resources.
@@ -6940,10 +6940,10 @@ message ActionProtocolIpv4 {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionProtocolIpv4Ping ping = 2;
+  ActionProtocolIpv4Ping ping = 2;
 }
 
 // Response for actions associated with IPv4 on configured resources.
@@ -6957,10 +6957,10 @@ message ActionResponseProtocolIpv4 {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionResponseProtocolIpv4Ping ping = 2;
+  ActionResponseProtocolIpv4Ping ping = 2;
 }
 
 // Request for initiating ping between multiple source and destination pairs.
@@ -7004,11 +7004,11 @@ message ActionResponseProtocolIpv4PingResponse {
   // - /components/schemas/Device.Ipv4/properties/name
   // 
   // required = true
-  string src_name = 1;
+  optional string src_name = 1;
 
   // Destination IPv4 address used for ping.
   // required = true
-  string dst_ip = 2;
+  optional string dst_ip = 2;
 
   message Result {
     enum Enum {
@@ -7019,7 +7019,7 @@ message ActionResponseProtocolIpv4PingResponse {
   }
   // Result of the ping request.
   // required = true
-  Result.Enum result = 3;
+  optional Result.Enum result = 3;
 }
 
 // Actions associated with IPv6 on configured resources.
@@ -7033,10 +7033,10 @@ message ActionProtocolIpv6 {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionProtocolIpv6Ping ping = 2;
+  ActionProtocolIpv6Ping ping = 2;
 }
 
 // Response for actions associated with IPv6 on configured resources.
@@ -7050,10 +7050,10 @@ message ActionResponseProtocolIpv6 {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionResponseProtocolIpv6Ping ping = 2;
+  ActionResponseProtocolIpv6Ping ping = 2;
 }
 
 // Request for initiating ping between multiple source and destination pairs.
@@ -7097,11 +7097,11 @@ message ActionResponseProtocolIpv6PingResponse {
   // - /components/schemas/Device.Ipv6/properties/name
   // 
   // required = true
-  string src_name = 1;
+  optional string src_name = 1;
 
   // Destination IPv6 address used for ping.
   // required = true
-  string dst_ip = 2;
+  optional string dst_ip = 2;
 
   message Result {
     enum Enum {
@@ -7112,7 +7112,7 @@ message ActionResponseProtocolIpv6PingResponse {
   }
   // Result of the ping request.
   // required = true
-  Result.Enum result = 3;
+  optional Result.Enum result = 3;
 }
 
 // Actions associated with BGP on configured resources.
@@ -7127,13 +7127,13 @@ message ActionProtocolBgp {
   }
   // Description missing in models
   // required = true
-  Choice.Enum choice = 1;
+  optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional ActionProtocolBgpNotification notification = 2;
+  ActionProtocolBgpNotification notification = 2;
 
   // Description missing in models
-  optional ActionProtocolBgpInitiateGracefulRestart initiate_graceful_restart = 3;
+  ActionProtocolBgpInitiateGracefulRestart initiate_graceful_restart = 3;
 }
 
 // A NOTIFICATION message is sent when an error is detected with the BGP session, such
@@ -7176,25 +7176,25 @@ message ActionProtocolBgpNotification {
   optional Choice.Enum choice = 2;
 
   // Description missing in models
-  optional DeviceBgpCeaseError cease = 3;
+  DeviceBgpCeaseError cease = 3;
 
   // Description missing in models
-  optional DeviceBgpMessageHeaderError message_header_error = 4;
+  DeviceBgpMessageHeaderError message_header_error = 4;
 
   // Description missing in models
-  optional DeviceBgpOpenMessageError open_message_error = 5;
+  DeviceBgpOpenMessageError open_message_error = 5;
 
   // Description missing in models
-  optional DeviceBgpUpdateMessageError update_message_error = 6;
+  DeviceBgpUpdateMessageError update_message_error = 6;
 
   // Description missing in models
-  optional DeviceBgpHoldTimerExpired hold_timer_expired = 7;
+  DeviceBgpHoldTimerExpired hold_timer_expired = 7;
 
   // Description missing in models
-  optional DeviceBgpFiniteStateMachineError finite_state_machine_error = 8;
+  DeviceBgpFiniteStateMachineError finite_state_machine_error = 8;
 
   // Description missing in models
-  optional DeviceBgpCustomError custom = 9;
+  DeviceBgpCustomError custom = 9;
 }
 
 // Initiates BGP Graceful Restart process for the selected BGP peers. If no name is
@@ -7237,31 +7237,31 @@ message MetricsRequest {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional PortMetricsRequest port = 2;
+  PortMetricsRequest port = 2;
 
   // Description missing in models
-  optional FlowMetricsRequest flow = 3;
+  FlowMetricsRequest flow = 3;
 
   // Description missing in models
-  optional Bgpv4MetricsRequest bgpv4 = 4;
+  Bgpv4MetricsRequest bgpv4 = 4;
 
   // Description missing in models
-  optional Bgpv6MetricsRequest bgpv6 = 5;
+  Bgpv6MetricsRequest bgpv6 = 5;
 
   // Description missing in models
-  optional IsisMetricsRequest isis = 6;
+  IsisMetricsRequest isis = 6;
 
   // Description missing in models
-  optional LagMetricsRequest lag = 7;
+  LagMetricsRequest lag = 7;
 
   // Description missing in models
-  optional LacpMetricsRequest lacp = 8;
+  LacpMetricsRequest lacp = 8;
 
   // Description missing in models
-  optional LldpMetricsRequest lldp = 9;
+  LldpMetricsRequest lldp = 9;
 
   // Description missing in models
-  optional RsvpMetricsRequest rsvp = 10;
+  RsvpMetricsRequest rsvp = 10;
 }
 
 // Response containing chosen traffic generator metrics.
@@ -7444,7 +7444,7 @@ message FlowMetricsRequest {
   repeated MetricNames.Enum metric_names = 3;
 
   // Description missing in models
-  optional FlowTaggedMetricsFilter tagged_metrics = 4;
+  FlowTaggedMetricsFilter tagged_metrics = 4;
 }
 
 // Filter for tagged metrics
@@ -7538,10 +7538,10 @@ message FlowMetric {
   optional float loss = 12;
 
   // Description missing in models
-  optional MetricTimestamp timestamps = 13;
+  MetricTimestamp timestamps = 13;
 
   // Description missing in models
-  optional MetricLatency latency = 14;
+  MetricLatency latency = 14;
 
   // List of metrics corresponding to a set of values applicable
   // for configured metric tags in ingress or egress packet header fields of corresponding
@@ -7580,10 +7580,10 @@ message FlowTaggedMetric {
   optional float loss = 8;
 
   // Description missing in models
-  optional MetricTimestamp timestamps = 9;
+  MetricTimestamp timestamps = 9;
 
   // Description missing in models
-  optional MetricLatency latency = 10;
+  MetricLatency latency = 10;
 }
 
 // Description missing in models
@@ -7593,7 +7593,7 @@ message FlowMetricTag {
   optional string name = 1;
 
   // Description missing in models
-  optional FlowMetricTagValue value = 2;
+  FlowMetricTagValue value = 2;
 }
 
 // A container for metric tag value
@@ -8472,22 +8472,22 @@ message StatesRequest {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  optional Neighborsv4StatesRequest ipv4_neighbors = 2;
+  Neighborsv4StatesRequest ipv4_neighbors = 2;
 
   // Description missing in models
-  optional Neighborsv6StatesRequest ipv6_neighbors = 3;
+  Neighborsv6StatesRequest ipv6_neighbors = 3;
 
   // Description missing in models
-  optional BgpPrefixStateRequest bgp_prefixes = 4;
+  BgpPrefixStateRequest bgp_prefixes = 4;
 
   // Description missing in models
-  optional IsisLspsStateRequest isis_lsps = 5;
+  IsisLspsStateRequest isis_lsps = 5;
 
   // Description missing in models
-  optional LldpNeighborsStateRequest lldp_neighbors = 6;
+  LldpNeighborsStateRequest lldp_neighbors = 6;
 
   // Description missing in models
-  optional RsvpLspsStateRequest rsvp_lsps = 7;
+  RsvpLspsStateRequest rsvp_lsps = 7;
 }
 
 // Response containing chosen traffic generator states
@@ -8546,11 +8546,11 @@ message Neighborsv4State {
   // The name of the Ethernet interface associated with the Neighbor state (ARP cache
   // entry).
   // required = true
-  string ethernet_name = 1;
+  optional string ethernet_name = 1;
 
   // The IPv4 address of the neighbor.
   // required = true
-  string ipv4_address = 2;
+  optional string ipv4_address = 2;
 
   // The link-layer address (MAC) of the neighbor.
   optional string link_layer_address = 3;
@@ -8575,11 +8575,11 @@ message Neighborsv6State {
   // The name of the Ethernet interface associated with the Neighbor state (NDISC cache
   // entry).
   // required = true
-  string ethernet_name = 1;
+  optional string ethernet_name = 1;
 
   // The IPv6 address of the neighbor.
   // required = true
-  string ipv6_address = 2;
+  optional string ipv6_address = 2;
 
   // The link-layer address (MAC) of the neighbor.
   optional string link_layer_address = 3;
@@ -8718,7 +8718,7 @@ message BgpPrefixIpv4UnicastState {
   repeated ResultBgpCommunity communities = 7;
 
   // Description missing in models
-  optional ResultBgpAsPath as_path = 8;
+  ResultBgpAsPath as_path = 8;
 
   // The local preference is a well-known attribute and the value is used for route selection.
   // The route with the highest local preference value is preferred.
@@ -8762,7 +8762,7 @@ message BgpPrefixIpv6UnicastState {
   repeated ResultBgpCommunity communities = 7;
 
   // Description missing in models
-  optional ResultBgpAsPath as_path = 8;
+  ResultBgpAsPath as_path = 8;
 
   // The local preference is a well-known attribute and the value is used for route selection.
   // The route with the highest local preference value is preferred.
@@ -8867,7 +8867,7 @@ message IsisLspState {
   // the LSP number incremented by one. A router's learned LSP gets refreshed by 'remaining_lifetime'.
   // Then the sequence number is incremented by 1.
   // required = true
-  string lsp_id = 1;
+  optional string lsp_id = 1;
 
   message PduType {
     enum Enum {
@@ -8889,7 +8889,7 @@ message IsisLspState {
   optional uint32 pdu_length = 5;
 
   // LSP Type-Block flags.
-  optional IsisLspFlags flags = 6;
+  IsisLspFlags flags = 6;
 
   // IS Type - bits 1 and 2 indicate the type of Intermediate System.
   // 1 - ( i.e. bit 1 set) Level 1 Intermediate system.
@@ -8898,7 +8898,7 @@ message IsisLspState {
   optional uint32 is_type = 7;
 
   // It refers to Link State PDU State TLVs container.
-  optional IsisLspTlvs tlvs = 8;
+  IsisLspTlvs tlvs = 8;
 }
 
 // This contains the list of TLVs present in one LSP.
@@ -9077,7 +9077,7 @@ message IsisLspExtendedV4Prefix {
   optional RedistributionType.Enum redistribution_type = 4;
 
   // Description missing in models
-  optional IsisLspPrefixAttributes prefix_attributes = 5;
+  IsisLspPrefixAttributes prefix_attributes = 5;
 }
 
 // It defines list of IPv6 extended reachability information in one IPv6 Reachability
@@ -9129,7 +9129,7 @@ message IsisLspV6Prefix {
   optional OriginType.Enum origin_type = 5;
 
   // Description missing in models
-  optional IsisLspPrefixAttributes prefix_attributes = 6;
+  IsisLspPrefixAttributes prefix_attributes = 6;
 }
 
 // This contains the properties of ISIS Prefix attributes for  the extended IPv4 and
@@ -9337,7 +9337,7 @@ message RsvpIPv4LspState {
   optional string destination_address = 2;
 
   // It refers to the RSVP LSP properties.
-  optional RsvpLspState lsp = 3;
+  RsvpLspState lsp = 3;
 
   // It refers to RSVP RRO objects container.
   repeated RsvpLspIpv4Rro rros = 4;
@@ -9449,7 +9449,7 @@ message CaptureRequest {
   // - /components/schemas/Port/properties/name
   // 
   // required = true
-  string port_name = 1;
+  optional string port_name = 1;
 }
 
 // mac counter pattern
@@ -9476,7 +9476,7 @@ message PatternFlowEthernetDstMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -9520,10 +9520,10 @@ message PatternFlowEthernetDst {
   optional string auto = 4;
 
   // Description missing in models
-  optional PatternFlowEthernetDstCounter increment = 6;
+  PatternFlowEthernetDstCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowEthernetDstCounter decrement = 7;
+  PatternFlowEthernetDstCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -9555,7 +9555,7 @@ message PatternFlowEthernetSrcMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -9592,10 +9592,10 @@ message PatternFlowEthernetSrc {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetSrcCounter increment = 5;
+  PatternFlowEthernetSrcCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowEthernetSrcCounter decrement = 6;
+  PatternFlowEthernetSrcCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -9627,7 +9627,7 @@ message PatternFlowEthernetEtherTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -9671,10 +9671,10 @@ message PatternFlowEthernetEtherType {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowEthernetEtherTypeCounter increment = 6;
+  PatternFlowEthernetEtherTypeCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowEthernetEtherTypeCounter decrement = 7;
+  PatternFlowEthernetEtherTypeCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -9706,7 +9706,7 @@ message PatternFlowEthernetPfcQueueMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -9743,10 +9743,10 @@ message PatternFlowEthernetPfcQueue {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetPfcQueueCounter increment = 5;
+  PatternFlowEthernetPfcQueueCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowEthernetPfcQueueCounter decrement = 6;
+  PatternFlowEthernetPfcQueueCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -9778,7 +9778,7 @@ message PatternFlowVlanPriorityMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -9815,10 +9815,10 @@ message PatternFlowVlanPriority {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowVlanPriorityCounter increment = 5;
+  PatternFlowVlanPriorityCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowVlanPriorityCounter decrement = 6;
+  PatternFlowVlanPriorityCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -9850,7 +9850,7 @@ message PatternFlowVlanCfiMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -9887,10 +9887,10 @@ message PatternFlowVlanCfi {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowVlanCfiCounter increment = 5;
+  PatternFlowVlanCfiCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowVlanCfiCounter decrement = 6;
+  PatternFlowVlanCfiCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -9922,7 +9922,7 @@ message PatternFlowVlanIdMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -9959,10 +9959,10 @@ message PatternFlowVlanId {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowVlanIdCounter increment = 5;
+  PatternFlowVlanIdCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowVlanIdCounter decrement = 6;
+  PatternFlowVlanIdCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -9994,7 +9994,7 @@ message PatternFlowVlanTpidMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10031,10 +10031,10 @@ message PatternFlowVlanTpid {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowVlanTpidCounter increment = 5;
+  PatternFlowVlanTpidCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowVlanTpidCounter decrement = 6;
+  PatternFlowVlanTpidCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10066,7 +10066,7 @@ message PatternFlowVxlanFlagsMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10105,10 +10105,10 @@ message PatternFlowVxlanFlags {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowVxlanFlagsCounter increment = 5;
+  PatternFlowVxlanFlagsCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowVxlanFlagsCounter decrement = 6;
+  PatternFlowVxlanFlagsCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10140,7 +10140,7 @@ message PatternFlowVxlanReserved0MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10177,10 +10177,10 @@ message PatternFlowVxlanReserved0 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowVxlanReserved0Counter increment = 5;
+  PatternFlowVxlanReserved0Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowVxlanReserved0Counter decrement = 6;
+  PatternFlowVxlanReserved0Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10212,7 +10212,7 @@ message PatternFlowVxlanVniMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10256,10 +10256,10 @@ message PatternFlowVxlanVni {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowVxlanVniCounter increment = 6;
+  PatternFlowVxlanVniCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowVxlanVniCounter decrement = 7;
+  PatternFlowVxlanVniCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10291,7 +10291,7 @@ message PatternFlowVxlanReserved1MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10328,10 +10328,10 @@ message PatternFlowVxlanReserved1 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowVxlanReserved1Counter increment = 5;
+  PatternFlowVxlanReserved1Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowVxlanReserved1Counter decrement = 6;
+  PatternFlowVxlanReserved1Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10363,7 +10363,7 @@ message PatternFlowIpv4VersionMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10400,10 +10400,10 @@ message PatternFlowIpv4Version {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4VersionCounter increment = 5;
+  PatternFlowIpv4VersionCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4VersionCounter decrement = 6;
+  PatternFlowIpv4VersionCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10435,7 +10435,7 @@ message PatternFlowIpv4HeaderLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10479,10 +10479,10 @@ message PatternFlowIpv4HeaderLength {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowIpv4HeaderLengthCounter increment = 6;
+  PatternFlowIpv4HeaderLengthCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowIpv4HeaderLengthCounter decrement = 7;
+  PatternFlowIpv4HeaderLengthCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10514,7 +10514,7 @@ message PatternFlowIpv4TotalLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10558,10 +10558,10 @@ message PatternFlowIpv4TotalLength {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowIpv4TotalLengthCounter increment = 6;
+  PatternFlowIpv4TotalLengthCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowIpv4TotalLengthCounter decrement = 7;
+  PatternFlowIpv4TotalLengthCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10593,7 +10593,7 @@ message PatternFlowIpv4IdentificationMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10630,10 +10630,10 @@ message PatternFlowIpv4Identification {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4IdentificationCounter increment = 5;
+  PatternFlowIpv4IdentificationCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4IdentificationCounter decrement = 6;
+  PatternFlowIpv4IdentificationCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10665,7 +10665,7 @@ message PatternFlowIpv4ReservedMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10702,10 +10702,10 @@ message PatternFlowIpv4Reserved {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4ReservedCounter increment = 5;
+  PatternFlowIpv4ReservedCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4ReservedCounter decrement = 6;
+  PatternFlowIpv4ReservedCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10737,7 +10737,7 @@ message PatternFlowIpv4DontFragmentMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10775,10 +10775,10 @@ message PatternFlowIpv4DontFragment {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4DontFragmentCounter increment = 5;
+  PatternFlowIpv4DontFragmentCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4DontFragmentCounter decrement = 6;
+  PatternFlowIpv4DontFragmentCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10810,7 +10810,7 @@ message PatternFlowIpv4MoreFragmentsMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10847,10 +10847,10 @@ message PatternFlowIpv4MoreFragments {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4MoreFragmentsCounter increment = 5;
+  PatternFlowIpv4MoreFragmentsCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4MoreFragmentsCounter decrement = 6;
+  PatternFlowIpv4MoreFragmentsCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10882,7 +10882,7 @@ message PatternFlowIpv4FragmentOffsetMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10919,10 +10919,10 @@ message PatternFlowIpv4FragmentOffset {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4FragmentOffsetCounter increment = 5;
+  PatternFlowIpv4FragmentOffsetCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4FragmentOffsetCounter decrement = 6;
+  PatternFlowIpv4FragmentOffsetCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -10954,7 +10954,7 @@ message PatternFlowIpv4TimeToLiveMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -10991,10 +10991,10 @@ message PatternFlowIpv4TimeToLive {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TimeToLiveCounter increment = 5;
+  PatternFlowIpv4TimeToLiveCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4TimeToLiveCounter decrement = 6;
+  PatternFlowIpv4TimeToLiveCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11026,7 +11026,7 @@ message PatternFlowIpv4ProtocolMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11070,10 +11070,10 @@ message PatternFlowIpv4Protocol {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowIpv4ProtocolCounter increment = 6;
+  PatternFlowIpv4ProtocolCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowIpv4ProtocolCounter decrement = 7;
+  PatternFlowIpv4ProtocolCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11134,7 +11134,7 @@ message PatternFlowIpv4SrcMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11171,10 +11171,10 @@ message PatternFlowIpv4Src {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4SrcCounter increment = 5;
+  PatternFlowIpv4SrcCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4SrcCounter decrement = 6;
+  PatternFlowIpv4SrcCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11206,7 +11206,7 @@ message PatternFlowIpv4DstMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11243,10 +11243,10 @@ message PatternFlowIpv4Dst {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4DstCounter increment = 5;
+  PatternFlowIpv4DstCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4DstCounter decrement = 6;
+  PatternFlowIpv4DstCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11278,7 +11278,7 @@ message PatternFlowIpv4PriorityRawMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11315,10 +11315,10 @@ message PatternFlowIpv4PriorityRaw {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4PriorityRawCounter increment = 5;
+  PatternFlowIpv4PriorityRawCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4PriorityRawCounter decrement = 6;
+  PatternFlowIpv4PriorityRawCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11350,7 +11350,7 @@ message PatternFlowIpv4DscpPhbMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11387,10 +11387,10 @@ message PatternFlowIpv4DscpPhb {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4DscpPhbCounter increment = 5;
+  PatternFlowIpv4DscpPhbCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4DscpPhbCounter decrement = 6;
+  PatternFlowIpv4DscpPhbCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11422,7 +11422,7 @@ message PatternFlowIpv4DscpEcnMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11459,10 +11459,10 @@ message PatternFlowIpv4DscpEcn {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4DscpEcnCounter increment = 5;
+  PatternFlowIpv4DscpEcnCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4DscpEcnCounter decrement = 6;
+  PatternFlowIpv4DscpEcnCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11494,7 +11494,7 @@ message PatternFlowIpv4TosPrecedenceMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11531,10 +11531,10 @@ message PatternFlowIpv4TosPrecedence {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TosPrecedenceCounter increment = 5;
+  PatternFlowIpv4TosPrecedenceCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4TosPrecedenceCounter decrement = 6;
+  PatternFlowIpv4TosPrecedenceCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11566,7 +11566,7 @@ message PatternFlowIpv4TosDelayMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11603,10 +11603,10 @@ message PatternFlowIpv4TosDelay {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TosDelayCounter increment = 5;
+  PatternFlowIpv4TosDelayCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4TosDelayCounter decrement = 6;
+  PatternFlowIpv4TosDelayCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11638,7 +11638,7 @@ message PatternFlowIpv4TosThroughputMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11675,10 +11675,10 @@ message PatternFlowIpv4TosThroughput {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TosThroughputCounter increment = 5;
+  PatternFlowIpv4TosThroughputCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4TosThroughputCounter decrement = 6;
+  PatternFlowIpv4TosThroughputCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11710,7 +11710,7 @@ message PatternFlowIpv4TosReliabilityMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11747,10 +11747,10 @@ message PatternFlowIpv4TosReliability {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TosReliabilityCounter increment = 5;
+  PatternFlowIpv4TosReliabilityCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4TosReliabilityCounter decrement = 6;
+  PatternFlowIpv4TosReliabilityCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11782,7 +11782,7 @@ message PatternFlowIpv4TosMonetaryMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11819,10 +11819,10 @@ message PatternFlowIpv4TosMonetary {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TosMonetaryCounter increment = 5;
+  PatternFlowIpv4TosMonetaryCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4TosMonetaryCounter decrement = 6;
+  PatternFlowIpv4TosMonetaryCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11854,7 +11854,7 @@ message PatternFlowIpv4TosUnusedMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11891,10 +11891,10 @@ message PatternFlowIpv4TosUnused {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv4TosUnusedCounter increment = 5;
+  PatternFlowIpv4TosUnusedCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv4TosUnusedCounter decrement = 6;
+  PatternFlowIpv4TosUnusedCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11926,7 +11926,7 @@ message PatternFlowIpv6VersionMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -11963,10 +11963,10 @@ message PatternFlowIpv6Version {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv6VersionCounter increment = 5;
+  PatternFlowIpv6VersionCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv6VersionCounter decrement = 6;
+  PatternFlowIpv6VersionCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -11998,7 +11998,7 @@ message PatternFlowIpv6TrafficClassMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12035,10 +12035,10 @@ message PatternFlowIpv6TrafficClass {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv6TrafficClassCounter increment = 5;
+  PatternFlowIpv6TrafficClassCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv6TrafficClassCounter decrement = 6;
+  PatternFlowIpv6TrafficClassCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12070,7 +12070,7 @@ message PatternFlowIpv6FlowLabelMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12107,10 +12107,10 @@ message PatternFlowIpv6FlowLabel {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv6FlowLabelCounter increment = 5;
+  PatternFlowIpv6FlowLabelCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv6FlowLabelCounter decrement = 6;
+  PatternFlowIpv6FlowLabelCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12142,7 +12142,7 @@ message PatternFlowIpv6PayloadLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12186,10 +12186,10 @@ message PatternFlowIpv6PayloadLength {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowIpv6PayloadLengthCounter increment = 6;
+  PatternFlowIpv6PayloadLengthCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowIpv6PayloadLengthCounter decrement = 7;
+  PatternFlowIpv6PayloadLengthCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12221,7 +12221,7 @@ message PatternFlowIpv6NextHeaderMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12265,10 +12265,10 @@ message PatternFlowIpv6NextHeader {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowIpv6NextHeaderCounter increment = 6;
+  PatternFlowIpv6NextHeaderCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowIpv6NextHeaderCounter decrement = 7;
+  PatternFlowIpv6NextHeaderCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12300,7 +12300,7 @@ message PatternFlowIpv6HopLimitMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12337,10 +12337,10 @@ message PatternFlowIpv6HopLimit {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv6HopLimitCounter increment = 5;
+  PatternFlowIpv6HopLimitCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv6HopLimitCounter decrement = 6;
+  PatternFlowIpv6HopLimitCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12372,7 +12372,7 @@ message PatternFlowIpv6SrcMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12409,10 +12409,10 @@ message PatternFlowIpv6Src {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv6SrcCounter increment = 5;
+  PatternFlowIpv6SrcCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv6SrcCounter decrement = 6;
+  PatternFlowIpv6SrcCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12444,7 +12444,7 @@ message PatternFlowIpv6DstMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12481,10 +12481,10 @@ message PatternFlowIpv6Dst {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowIpv6DstCounter increment = 5;
+  PatternFlowIpv6DstCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIpv6DstCounter decrement = 6;
+  PatternFlowIpv6DstCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12516,7 +12516,7 @@ message PatternFlowPfcPauseDstMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12553,10 +12553,10 @@ message PatternFlowPfcPauseDst {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPauseDstCounter increment = 5;
+  PatternFlowPfcPauseDstCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPauseDstCounter decrement = 6;
+  PatternFlowPfcPauseDstCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12588,7 +12588,7 @@ message PatternFlowPfcPauseSrcMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12625,10 +12625,10 @@ message PatternFlowPfcPauseSrc {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPauseSrcCounter increment = 5;
+  PatternFlowPfcPauseSrcCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPauseSrcCounter decrement = 6;
+  PatternFlowPfcPauseSrcCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12660,7 +12660,7 @@ message PatternFlowPfcPauseEtherTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12697,10 +12697,10 @@ message PatternFlowPfcPauseEtherType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPauseEtherTypeCounter increment = 5;
+  PatternFlowPfcPauseEtherTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPauseEtherTypeCounter decrement = 6;
+  PatternFlowPfcPauseEtherTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12732,7 +12732,7 @@ message PatternFlowPfcPauseControlOpCodeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12769,10 +12769,10 @@ message PatternFlowPfcPauseControlOpCode {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPauseControlOpCodeCounter increment = 5;
+  PatternFlowPfcPauseControlOpCodeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPauseControlOpCodeCounter decrement = 6;
+  PatternFlowPfcPauseControlOpCodeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12804,7 +12804,7 @@ message PatternFlowPfcPauseClassEnableVectorMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12841,10 +12841,10 @@ message PatternFlowPfcPauseClassEnableVector {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPauseClassEnableVectorCounter increment = 5;
+  PatternFlowPfcPauseClassEnableVectorCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPauseClassEnableVectorCounter decrement = 6;
+  PatternFlowPfcPauseClassEnableVectorCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12876,7 +12876,7 @@ message PatternFlowPfcPausePauseClass0MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12913,10 +12913,10 @@ message PatternFlowPfcPausePauseClass0 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass0Counter increment = 5;
+  PatternFlowPfcPausePauseClass0Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass0Counter decrement = 6;
+  PatternFlowPfcPausePauseClass0Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -12948,7 +12948,7 @@ message PatternFlowPfcPausePauseClass1MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -12985,10 +12985,10 @@ message PatternFlowPfcPausePauseClass1 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass1Counter increment = 5;
+  PatternFlowPfcPausePauseClass1Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass1Counter decrement = 6;
+  PatternFlowPfcPausePauseClass1Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13020,7 +13020,7 @@ message PatternFlowPfcPausePauseClass2MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13057,10 +13057,10 @@ message PatternFlowPfcPausePauseClass2 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass2Counter increment = 5;
+  PatternFlowPfcPausePauseClass2Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass2Counter decrement = 6;
+  PatternFlowPfcPausePauseClass2Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13092,7 +13092,7 @@ message PatternFlowPfcPausePauseClass3MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13129,10 +13129,10 @@ message PatternFlowPfcPausePauseClass3 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass3Counter increment = 5;
+  PatternFlowPfcPausePauseClass3Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass3Counter decrement = 6;
+  PatternFlowPfcPausePauseClass3Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13164,7 +13164,7 @@ message PatternFlowPfcPausePauseClass4MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13201,10 +13201,10 @@ message PatternFlowPfcPausePauseClass4 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass4Counter increment = 5;
+  PatternFlowPfcPausePauseClass4Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass4Counter decrement = 6;
+  PatternFlowPfcPausePauseClass4Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13236,7 +13236,7 @@ message PatternFlowPfcPausePauseClass5MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13273,10 +13273,10 @@ message PatternFlowPfcPausePauseClass5 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass5Counter increment = 5;
+  PatternFlowPfcPausePauseClass5Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass5Counter decrement = 6;
+  PatternFlowPfcPausePauseClass5Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13308,7 +13308,7 @@ message PatternFlowPfcPausePauseClass6MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13345,10 +13345,10 @@ message PatternFlowPfcPausePauseClass6 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass6Counter increment = 5;
+  PatternFlowPfcPausePauseClass6Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass6Counter decrement = 6;
+  PatternFlowPfcPausePauseClass6Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13380,7 +13380,7 @@ message PatternFlowPfcPausePauseClass7MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13417,10 +13417,10 @@ message PatternFlowPfcPausePauseClass7 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass7Counter increment = 5;
+  PatternFlowPfcPausePauseClass7Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPfcPausePauseClass7Counter decrement = 6;
+  PatternFlowPfcPausePauseClass7Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13452,7 +13452,7 @@ message PatternFlowEthernetPauseDstMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13489,10 +13489,10 @@ message PatternFlowEthernetPauseDst {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseDstCounter increment = 5;
+  PatternFlowEthernetPauseDstCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseDstCounter decrement = 6;
+  PatternFlowEthernetPauseDstCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13524,7 +13524,7 @@ message PatternFlowEthernetPauseSrcMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13561,10 +13561,10 @@ message PatternFlowEthernetPauseSrc {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseSrcCounter increment = 5;
+  PatternFlowEthernetPauseSrcCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseSrcCounter decrement = 6;
+  PatternFlowEthernetPauseSrcCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13596,7 +13596,7 @@ message PatternFlowEthernetPauseEtherTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13633,10 +13633,10 @@ message PatternFlowEthernetPauseEtherType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseEtherTypeCounter increment = 5;
+  PatternFlowEthernetPauseEtherTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseEtherTypeCounter decrement = 6;
+  PatternFlowEthernetPauseEtherTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13668,7 +13668,7 @@ message PatternFlowEthernetPauseControlOpCodeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13705,10 +13705,10 @@ message PatternFlowEthernetPauseControlOpCode {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseControlOpCodeCounter increment = 5;
+  PatternFlowEthernetPauseControlOpCodeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseControlOpCodeCounter decrement = 6;
+  PatternFlowEthernetPauseControlOpCodeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13740,7 +13740,7 @@ message PatternFlowEthernetPauseTimeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13777,10 +13777,10 @@ message PatternFlowEthernetPauseTime {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseTimeCounter increment = 5;
+  PatternFlowEthernetPauseTimeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowEthernetPauseTimeCounter decrement = 6;
+  PatternFlowEthernetPauseTimeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13812,7 +13812,7 @@ message PatternFlowTcpSrcPortMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13849,10 +13849,10 @@ message PatternFlowTcpSrcPort {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpSrcPortCounter increment = 5;
+  PatternFlowTcpSrcPortCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpSrcPortCounter decrement = 6;
+  PatternFlowTcpSrcPortCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13884,7 +13884,7 @@ message PatternFlowTcpDstPortMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13921,10 +13921,10 @@ message PatternFlowTcpDstPort {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpDstPortCounter increment = 5;
+  PatternFlowTcpDstPortCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpDstPortCounter decrement = 6;
+  PatternFlowTcpDstPortCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -13956,7 +13956,7 @@ message PatternFlowTcpSeqNumMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -13993,10 +13993,10 @@ message PatternFlowTcpSeqNum {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpSeqNumCounter increment = 5;
+  PatternFlowTcpSeqNumCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpSeqNumCounter decrement = 6;
+  PatternFlowTcpSeqNumCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14028,7 +14028,7 @@ message PatternFlowTcpAckNumMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14065,10 +14065,10 @@ message PatternFlowTcpAckNum {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpAckNumCounter increment = 5;
+  PatternFlowTcpAckNumCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpAckNumCounter decrement = 6;
+  PatternFlowTcpAckNumCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14100,7 +14100,7 @@ message PatternFlowTcpDataOffsetMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14137,10 +14137,10 @@ message PatternFlowTcpDataOffset {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpDataOffsetCounter increment = 5;
+  PatternFlowTcpDataOffsetCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpDataOffsetCounter decrement = 6;
+  PatternFlowTcpDataOffsetCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14172,7 +14172,7 @@ message PatternFlowTcpEcnNsMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14209,10 +14209,10 @@ message PatternFlowTcpEcnNs {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpEcnNsCounter increment = 5;
+  PatternFlowTcpEcnNsCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpEcnNsCounter decrement = 6;
+  PatternFlowTcpEcnNsCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14244,7 +14244,7 @@ message PatternFlowTcpEcnCwrMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14281,10 +14281,10 @@ message PatternFlowTcpEcnCwr {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpEcnCwrCounter increment = 5;
+  PatternFlowTcpEcnCwrCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpEcnCwrCounter decrement = 6;
+  PatternFlowTcpEcnCwrCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14316,7 +14316,7 @@ message PatternFlowTcpEcnEchoMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14354,10 +14354,10 @@ message PatternFlowTcpEcnEcho {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpEcnEchoCounter increment = 5;
+  PatternFlowTcpEcnEchoCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpEcnEchoCounter decrement = 6;
+  PatternFlowTcpEcnEchoCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14389,7 +14389,7 @@ message PatternFlowTcpCtlUrgMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14426,10 +14426,10 @@ message PatternFlowTcpCtlUrg {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpCtlUrgCounter increment = 5;
+  PatternFlowTcpCtlUrgCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpCtlUrgCounter decrement = 6;
+  PatternFlowTcpCtlUrgCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14461,7 +14461,7 @@ message PatternFlowTcpCtlAckMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14498,10 +14498,10 @@ message PatternFlowTcpCtlAck {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpCtlAckCounter increment = 5;
+  PatternFlowTcpCtlAckCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpCtlAckCounter decrement = 6;
+  PatternFlowTcpCtlAckCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14533,7 +14533,7 @@ message PatternFlowTcpCtlPshMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14570,10 +14570,10 @@ message PatternFlowTcpCtlPsh {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpCtlPshCounter increment = 5;
+  PatternFlowTcpCtlPshCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpCtlPshCounter decrement = 6;
+  PatternFlowTcpCtlPshCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14605,7 +14605,7 @@ message PatternFlowTcpCtlRstMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14642,10 +14642,10 @@ message PatternFlowTcpCtlRst {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpCtlRstCounter increment = 5;
+  PatternFlowTcpCtlRstCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpCtlRstCounter decrement = 6;
+  PatternFlowTcpCtlRstCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14677,7 +14677,7 @@ message PatternFlowTcpCtlSynMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14714,10 +14714,10 @@ message PatternFlowTcpCtlSyn {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpCtlSynCounter increment = 5;
+  PatternFlowTcpCtlSynCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpCtlSynCounter decrement = 6;
+  PatternFlowTcpCtlSynCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14749,7 +14749,7 @@ message PatternFlowTcpCtlFinMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14786,10 +14786,10 @@ message PatternFlowTcpCtlFin {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpCtlFinCounter increment = 5;
+  PatternFlowTcpCtlFinCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpCtlFinCounter decrement = 6;
+  PatternFlowTcpCtlFinCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14821,7 +14821,7 @@ message PatternFlowTcpWindowMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14858,10 +14858,10 @@ message PatternFlowTcpWindow {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowTcpWindowCounter increment = 5;
+  PatternFlowTcpWindowCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowTcpWindowCounter decrement = 6;
+  PatternFlowTcpWindowCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14893,7 +14893,7 @@ message PatternFlowUdpSrcPortMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -14930,10 +14930,10 @@ message PatternFlowUdpSrcPort {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowUdpSrcPortCounter increment = 5;
+  PatternFlowUdpSrcPortCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowUdpSrcPortCounter decrement = 6;
+  PatternFlowUdpSrcPortCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -14965,7 +14965,7 @@ message PatternFlowUdpDstPortMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15002,10 +15002,10 @@ message PatternFlowUdpDstPort {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowUdpDstPortCounter increment = 5;
+  PatternFlowUdpDstPortCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowUdpDstPortCounter decrement = 6;
+  PatternFlowUdpDstPortCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15037,7 +15037,7 @@ message PatternFlowUdpLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15074,10 +15074,10 @@ message PatternFlowUdpLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowUdpLengthCounter increment = 5;
+  PatternFlowUdpLengthCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowUdpLengthCounter decrement = 6;
+  PatternFlowUdpLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15138,7 +15138,7 @@ message PatternFlowGreChecksumPresentMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15175,10 +15175,10 @@ message PatternFlowGreChecksumPresent {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGreChecksumPresentCounter increment = 5;
+  PatternFlowGreChecksumPresentCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGreChecksumPresentCounter decrement = 6;
+  PatternFlowGreChecksumPresentCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15210,7 +15210,7 @@ message PatternFlowGreReserved0MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15247,10 +15247,10 @@ message PatternFlowGreReserved0 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGreReserved0Counter increment = 5;
+  PatternFlowGreReserved0Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGreReserved0Counter decrement = 6;
+  PatternFlowGreReserved0Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15282,7 +15282,7 @@ message PatternFlowGreVersionMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15319,10 +15319,10 @@ message PatternFlowGreVersion {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGreVersionCounter increment = 5;
+  PatternFlowGreVersionCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGreVersionCounter decrement = 6;
+  PatternFlowGreVersionCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15354,7 +15354,7 @@ message PatternFlowGreProtocolMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15391,10 +15391,10 @@ message PatternFlowGreProtocol {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGreProtocolCounter increment = 5;
+  PatternFlowGreProtocolCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGreProtocolCounter decrement = 6;
+  PatternFlowGreProtocolCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15456,7 +15456,7 @@ message PatternFlowGreReserved1MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15493,10 +15493,10 @@ message PatternFlowGreReserved1 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGreReserved1Counter increment = 5;
+  PatternFlowGreReserved1Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGreReserved1Counter decrement = 6;
+  PatternFlowGreReserved1Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15528,7 +15528,7 @@ message PatternFlowGtpv1VersionMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15565,10 +15565,10 @@ message PatternFlowGtpv1Version {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1VersionCounter increment = 5;
+  PatternFlowGtpv1VersionCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1VersionCounter decrement = 6;
+  PatternFlowGtpv1VersionCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15600,7 +15600,7 @@ message PatternFlowGtpv1ProtocolTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15637,10 +15637,10 @@ message PatternFlowGtpv1ProtocolType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1ProtocolTypeCounter increment = 5;
+  PatternFlowGtpv1ProtocolTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1ProtocolTypeCounter decrement = 6;
+  PatternFlowGtpv1ProtocolTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15672,7 +15672,7 @@ message PatternFlowGtpv1ReservedMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15709,10 +15709,10 @@ message PatternFlowGtpv1Reserved {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1ReservedCounter increment = 5;
+  PatternFlowGtpv1ReservedCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1ReservedCounter decrement = 6;
+  PatternFlowGtpv1ReservedCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15744,7 +15744,7 @@ message PatternFlowGtpv1EFlagMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15781,10 +15781,10 @@ message PatternFlowGtpv1EFlag {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1EFlagCounter increment = 5;
+  PatternFlowGtpv1EFlagCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1EFlagCounter decrement = 6;
+  PatternFlowGtpv1EFlagCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15816,7 +15816,7 @@ message PatternFlowGtpv1SFlagMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15853,10 +15853,10 @@ message PatternFlowGtpv1SFlag {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1SFlagCounter increment = 5;
+  PatternFlowGtpv1SFlagCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1SFlagCounter decrement = 6;
+  PatternFlowGtpv1SFlagCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15888,7 +15888,7 @@ message PatternFlowGtpv1PnFlagMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15925,10 +15925,10 @@ message PatternFlowGtpv1PnFlag {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1PnFlagCounter increment = 5;
+  PatternFlowGtpv1PnFlagCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1PnFlagCounter decrement = 6;
+  PatternFlowGtpv1PnFlagCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -15960,7 +15960,7 @@ message PatternFlowGtpv1MessageTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -15998,10 +15998,10 @@ message PatternFlowGtpv1MessageType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1MessageTypeCounter increment = 5;
+  PatternFlowGtpv1MessageTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1MessageTypeCounter decrement = 6;
+  PatternFlowGtpv1MessageTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16033,7 +16033,7 @@ message PatternFlowGtpv1MessageLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16071,10 +16071,10 @@ message PatternFlowGtpv1MessageLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1MessageLengthCounter increment = 5;
+  PatternFlowGtpv1MessageLengthCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1MessageLengthCounter decrement = 6;
+  PatternFlowGtpv1MessageLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16106,7 +16106,7 @@ message PatternFlowGtpv1TeidMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16143,10 +16143,10 @@ message PatternFlowGtpv1Teid {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1TeidCounter increment = 5;
+  PatternFlowGtpv1TeidCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1TeidCounter decrement = 6;
+  PatternFlowGtpv1TeidCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16178,7 +16178,7 @@ message PatternFlowGtpv1SquenceNumberMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16216,10 +16216,10 @@ message PatternFlowGtpv1SquenceNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1SquenceNumberCounter increment = 5;
+  PatternFlowGtpv1SquenceNumberCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1SquenceNumberCounter decrement = 6;
+  PatternFlowGtpv1SquenceNumberCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16251,7 +16251,7 @@ message PatternFlowGtpv1NPduNumberMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16289,10 +16289,10 @@ message PatternFlowGtpv1NPduNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1NPduNumberCounter increment = 5;
+  PatternFlowGtpv1NPduNumberCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1NPduNumberCounter decrement = 6;
+  PatternFlowGtpv1NPduNumberCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16324,7 +16324,7 @@ message PatternFlowGtpv1NextExtensionHeaderTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16362,10 +16362,10 @@ message PatternFlowGtpv1NextExtensionHeaderType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv1NextExtensionHeaderTypeCounter increment = 5;
+  PatternFlowGtpv1NextExtensionHeaderTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv1NextExtensionHeaderTypeCounter decrement = 6;
+  PatternFlowGtpv1NextExtensionHeaderTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16397,7 +16397,7 @@ message PatternFlowGtpExtensionExtensionLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16436,10 +16436,10 @@ message PatternFlowGtpExtensionExtensionLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpExtensionExtensionLengthCounter increment = 5;
+  PatternFlowGtpExtensionExtensionLengthCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpExtensionExtensionLengthCounter decrement = 6;
+  PatternFlowGtpExtensionExtensionLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16471,7 +16471,7 @@ message PatternFlowGtpExtensionContentsMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16508,10 +16508,10 @@ message PatternFlowGtpExtensionContents {
   repeated uint64 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpExtensionContentsCounter increment = 5;
+  PatternFlowGtpExtensionContentsCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpExtensionContentsCounter decrement = 6;
+  PatternFlowGtpExtensionContentsCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16543,7 +16543,7 @@ message PatternFlowGtpExtensionNextExtensionHeaderMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16581,10 +16581,10 @@ message PatternFlowGtpExtensionNextExtensionHeader {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpExtensionNextExtensionHeaderCounter increment = 5;
+  PatternFlowGtpExtensionNextExtensionHeaderCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpExtensionNextExtensionHeaderCounter decrement = 6;
+  PatternFlowGtpExtensionNextExtensionHeaderCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16616,7 +16616,7 @@ message PatternFlowGtpv2VersionMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16653,10 +16653,10 @@ message PatternFlowGtpv2Version {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2VersionCounter increment = 5;
+  PatternFlowGtpv2VersionCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2VersionCounter decrement = 6;
+  PatternFlowGtpv2VersionCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16688,7 +16688,7 @@ message PatternFlowGtpv2PiggybackingFlagMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16726,10 +16726,10 @@ message PatternFlowGtpv2PiggybackingFlag {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2PiggybackingFlagCounter increment = 5;
+  PatternFlowGtpv2PiggybackingFlagCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2PiggybackingFlagCounter decrement = 6;
+  PatternFlowGtpv2PiggybackingFlagCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16761,7 +16761,7 @@ message PatternFlowGtpv2TeidFlagMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16800,10 +16800,10 @@ message PatternFlowGtpv2TeidFlag {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2TeidFlagCounter increment = 5;
+  PatternFlowGtpv2TeidFlagCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2TeidFlagCounter decrement = 6;
+  PatternFlowGtpv2TeidFlagCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16835,7 +16835,7 @@ message PatternFlowGtpv2Spare1MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16872,10 +16872,10 @@ message PatternFlowGtpv2Spare1 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2Spare1Counter increment = 5;
+  PatternFlowGtpv2Spare1Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2Spare1Counter decrement = 6;
+  PatternFlowGtpv2Spare1Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16907,7 +16907,7 @@ message PatternFlowGtpv2MessageTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -16945,10 +16945,10 @@ message PatternFlowGtpv2MessageType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2MessageTypeCounter increment = 5;
+  PatternFlowGtpv2MessageTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2MessageTypeCounter decrement = 6;
+  PatternFlowGtpv2MessageTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -16980,7 +16980,7 @@ message PatternFlowGtpv2MessageLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17018,10 +17018,10 @@ message PatternFlowGtpv2MessageLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2MessageLengthCounter increment = 5;
+  PatternFlowGtpv2MessageLengthCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2MessageLengthCounter decrement = 6;
+  PatternFlowGtpv2MessageLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17053,7 +17053,7 @@ message PatternFlowGtpv2TeidMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17091,10 +17091,10 @@ message PatternFlowGtpv2Teid {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2TeidCounter increment = 5;
+  PatternFlowGtpv2TeidCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2TeidCounter decrement = 6;
+  PatternFlowGtpv2TeidCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17126,7 +17126,7 @@ message PatternFlowGtpv2SequenceNumberMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17163,10 +17163,10 @@ message PatternFlowGtpv2SequenceNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2SequenceNumberCounter increment = 5;
+  PatternFlowGtpv2SequenceNumberCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2SequenceNumberCounter decrement = 6;
+  PatternFlowGtpv2SequenceNumberCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17198,7 +17198,7 @@ message PatternFlowGtpv2Spare2MetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17235,10 +17235,10 @@ message PatternFlowGtpv2Spare2 {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowGtpv2Spare2Counter increment = 5;
+  PatternFlowGtpv2Spare2Counter increment = 5;
 
   // Description missing in models
-  optional PatternFlowGtpv2Spare2Counter decrement = 6;
+  PatternFlowGtpv2Spare2Counter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17270,7 +17270,7 @@ message PatternFlowArpHardwareTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17307,10 +17307,10 @@ message PatternFlowArpHardwareType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowArpHardwareTypeCounter increment = 5;
+  PatternFlowArpHardwareTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpHardwareTypeCounter decrement = 6;
+  PatternFlowArpHardwareTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17342,7 +17342,7 @@ message PatternFlowArpProtocolTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17379,10 +17379,10 @@ message PatternFlowArpProtocolType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowArpProtocolTypeCounter increment = 5;
+  PatternFlowArpProtocolTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpProtocolTypeCounter decrement = 6;
+  PatternFlowArpProtocolTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17414,7 +17414,7 @@ message PatternFlowArpHardwareLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17451,10 +17451,10 @@ message PatternFlowArpHardwareLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowArpHardwareLengthCounter increment = 5;
+  PatternFlowArpHardwareLengthCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpHardwareLengthCounter decrement = 6;
+  PatternFlowArpHardwareLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17486,7 +17486,7 @@ message PatternFlowArpProtocolLengthMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17523,10 +17523,10 @@ message PatternFlowArpProtocolLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowArpProtocolLengthCounter increment = 5;
+  PatternFlowArpProtocolLengthCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpProtocolLengthCounter decrement = 6;
+  PatternFlowArpProtocolLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17558,7 +17558,7 @@ message PatternFlowArpOperationMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17595,10 +17595,10 @@ message PatternFlowArpOperation {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowArpOperationCounter increment = 5;
+  PatternFlowArpOperationCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpOperationCounter decrement = 6;
+  PatternFlowArpOperationCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17630,7 +17630,7 @@ message PatternFlowArpSenderHardwareAddrMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17667,10 +17667,10 @@ message PatternFlowArpSenderHardwareAddr {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowArpSenderHardwareAddrCounter increment = 5;
+  PatternFlowArpSenderHardwareAddrCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpSenderHardwareAddrCounter decrement = 6;
+  PatternFlowArpSenderHardwareAddrCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17702,7 +17702,7 @@ message PatternFlowArpSenderProtocolAddrMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17739,10 +17739,10 @@ message PatternFlowArpSenderProtocolAddr {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowArpSenderProtocolAddrCounter increment = 5;
+  PatternFlowArpSenderProtocolAddrCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpSenderProtocolAddrCounter decrement = 6;
+  PatternFlowArpSenderProtocolAddrCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17774,7 +17774,7 @@ message PatternFlowArpTargetHardwareAddrMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17811,10 +17811,10 @@ message PatternFlowArpTargetHardwareAddr {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowArpTargetHardwareAddrCounter increment = 5;
+  PatternFlowArpTargetHardwareAddrCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpTargetHardwareAddrCounter decrement = 6;
+  PatternFlowArpTargetHardwareAddrCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17846,7 +17846,7 @@ message PatternFlowArpTargetProtocolAddrMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17883,10 +17883,10 @@ message PatternFlowArpTargetProtocolAddr {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowArpTargetProtocolAddrCounter increment = 5;
+  PatternFlowArpTargetProtocolAddrCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowArpTargetProtocolAddrCounter decrement = 6;
+  PatternFlowArpTargetProtocolAddrCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17918,7 +17918,7 @@ message PatternFlowIcmpEchoTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -17955,10 +17955,10 @@ message PatternFlowIcmpEchoType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoTypeCounter increment = 5;
+  PatternFlowIcmpEchoTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoTypeCounter decrement = 6;
+  PatternFlowIcmpEchoTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -17990,7 +17990,7 @@ message PatternFlowIcmpEchoCodeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18027,10 +18027,10 @@ message PatternFlowIcmpEchoCode {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoCodeCounter increment = 5;
+  PatternFlowIcmpEchoCodeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoCodeCounter decrement = 6;
+  PatternFlowIcmpEchoCodeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18091,7 +18091,7 @@ message PatternFlowIcmpEchoIdentifierMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18128,10 +18128,10 @@ message PatternFlowIcmpEchoIdentifier {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoIdentifierCounter increment = 5;
+  PatternFlowIcmpEchoIdentifierCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoIdentifierCounter decrement = 6;
+  PatternFlowIcmpEchoIdentifierCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18163,7 +18163,7 @@ message PatternFlowIcmpEchoSequenceNumberMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18200,10 +18200,10 @@ message PatternFlowIcmpEchoSequenceNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoSequenceNumberCounter increment = 5;
+  PatternFlowIcmpEchoSequenceNumberCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpEchoSequenceNumberCounter decrement = 6;
+  PatternFlowIcmpEchoSequenceNumberCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18264,7 +18264,7 @@ message PatternFlowIcmpNextFieldsIdentifierMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18301,10 +18301,10 @@ message PatternFlowIcmpNextFieldsIdentifier {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpNextFieldsIdentifierCounter increment = 5;
+  PatternFlowIcmpNextFieldsIdentifierCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpNextFieldsIdentifierCounter decrement = 6;
+  PatternFlowIcmpNextFieldsIdentifierCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18336,7 +18336,7 @@ message PatternFlowIcmpNextFieldsSequenceNumberMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18373,10 +18373,10 @@ message PatternFlowIcmpNextFieldsSequenceNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpNextFieldsSequenceNumberCounter increment = 5;
+  PatternFlowIcmpNextFieldsSequenceNumberCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpNextFieldsSequenceNumberCounter decrement = 6;
+  PatternFlowIcmpNextFieldsSequenceNumberCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18408,7 +18408,7 @@ message PatternFlowIcmpv6EchoTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18445,10 +18445,10 @@ message PatternFlowIcmpv6EchoType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoTypeCounter increment = 5;
+  PatternFlowIcmpv6EchoTypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoTypeCounter decrement = 6;
+  PatternFlowIcmpv6EchoTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18480,7 +18480,7 @@ message PatternFlowIcmpv6EchoCodeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18517,10 +18517,10 @@ message PatternFlowIcmpv6EchoCode {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoCodeCounter increment = 5;
+  PatternFlowIcmpv6EchoCodeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoCodeCounter decrement = 6;
+  PatternFlowIcmpv6EchoCodeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18552,7 +18552,7 @@ message PatternFlowIcmpv6EchoIdentifierMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18589,10 +18589,10 @@ message PatternFlowIcmpv6EchoIdentifier {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoIdentifierCounter increment = 5;
+  PatternFlowIcmpv6EchoIdentifierCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoIdentifierCounter decrement = 6;
+  PatternFlowIcmpv6EchoIdentifierCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18624,7 +18624,7 @@ message PatternFlowIcmpv6EchoSequenceNumberMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18661,10 +18661,10 @@ message PatternFlowIcmpv6EchoSequenceNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoSequenceNumberCounter increment = 5;
+  PatternFlowIcmpv6EchoSequenceNumberCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIcmpv6EchoSequenceNumberCounter decrement = 6;
+  PatternFlowIcmpv6EchoSequenceNumberCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18754,7 +18754,7 @@ message PatternFlowPppAddressMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18791,10 +18791,10 @@ message PatternFlowPppAddress {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPppAddressCounter increment = 5;
+  PatternFlowPppAddressCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPppAddressCounter decrement = 6;
+  PatternFlowPppAddressCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18826,7 +18826,7 @@ message PatternFlowPppControlMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18863,10 +18863,10 @@ message PatternFlowPppControl {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowPppControlCounter increment = 5;
+  PatternFlowPppControlCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowPppControlCounter decrement = 6;
+  PatternFlowPppControlCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18898,7 +18898,7 @@ message PatternFlowPppProtocolTypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -18942,10 +18942,10 @@ message PatternFlowPppProtocolType {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowPppProtocolTypeCounter increment = 6;
+  PatternFlowPppProtocolTypeCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowPppProtocolTypeCounter decrement = 7;
+  PatternFlowPppProtocolTypeCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -18977,7 +18977,7 @@ message PatternFlowIgmpv1VersionMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -19014,10 +19014,10 @@ message PatternFlowIgmpv1Version {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIgmpv1VersionCounter increment = 5;
+  PatternFlowIgmpv1VersionCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIgmpv1VersionCounter decrement = 6;
+  PatternFlowIgmpv1VersionCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -19049,7 +19049,7 @@ message PatternFlowIgmpv1TypeMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -19086,10 +19086,10 @@ message PatternFlowIgmpv1Type {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIgmpv1TypeCounter increment = 5;
+  PatternFlowIgmpv1TypeCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIgmpv1TypeCounter decrement = 6;
+  PatternFlowIgmpv1TypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -19121,7 +19121,7 @@ message PatternFlowIgmpv1UnusedMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -19158,10 +19158,10 @@ message PatternFlowIgmpv1Unused {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowIgmpv1UnusedCounter increment = 5;
+  PatternFlowIgmpv1UnusedCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIgmpv1UnusedCounter decrement = 6;
+  PatternFlowIgmpv1UnusedCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -19222,7 +19222,7 @@ message PatternFlowIgmpv1GroupAddressMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -19259,10 +19259,10 @@ message PatternFlowIgmpv1GroupAddress {
   repeated string values = 3;
 
   // Description missing in models
-  optional PatternFlowIgmpv1GroupAddressCounter increment = 5;
+  PatternFlowIgmpv1GroupAddressCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowIgmpv1GroupAddressCounter decrement = 6;
+  PatternFlowIgmpv1GroupAddressCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -19294,7 +19294,7 @@ message PatternFlowMplsLabelMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -19338,10 +19338,10 @@ message PatternFlowMplsLabel {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowMplsLabelCounter increment = 6;
+  PatternFlowMplsLabelCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowMplsLabelCounter decrement = 7;
+  PatternFlowMplsLabelCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -19373,7 +19373,7 @@ message PatternFlowMplsTrafficClassMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -19410,10 +19410,10 @@ message PatternFlowMplsTrafficClass {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowMplsTrafficClassCounter increment = 5;
+  PatternFlowMplsTrafficClassCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowMplsTrafficClassCounter decrement = 6;
+  PatternFlowMplsTrafficClassCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -19445,7 +19445,7 @@ message PatternFlowMplsBottomOfStackMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -19489,10 +19489,10 @@ message PatternFlowMplsBottomOfStack {
   optional uint32 auto = 4;
 
   // Description missing in models
-  optional PatternFlowMplsBottomOfStackCounter increment = 6;
+  PatternFlowMplsBottomOfStackCounter increment = 6;
 
   // Description missing in models
-  optional PatternFlowMplsBottomOfStackCounter decrement = 7;
+  PatternFlowMplsBottomOfStackCounter decrement = 7;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
@@ -19524,7 +19524,7 @@ message PatternFlowMplsTimeToLiveMetricTag {
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
   // required = true
-  string name = 1;
+  optional string name = 1;
 
   // Offset in bits relative to start of corresponding header field
   // default = 0
@@ -19561,10 +19561,10 @@ message PatternFlowMplsTimeToLive {
   repeated uint32 values = 3;
 
   // Description missing in models
-  optional PatternFlowMplsTimeToLiveCounter increment = 5;
+  PatternFlowMplsTimeToLiveCounter increment = 5;
 
   // Description missing in models
-  optional PatternFlowMplsTimeToLiveCounter decrement = 6;
+  PatternFlowMplsTimeToLiveCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6673,6 +6673,7 @@ message StateProtocol {
       route = 2;
       lacp = 3;
       bgp = 4;
+      isis = 5;
     }
   }
   // Description missing in models
@@ -6929,7 +6930,10 @@ message StateProtocolBgpPeers {
       down = 2;
     }
   }
-  // The desired state of BGP peer.
+  // The desired state of BGP peer. If the desired state is 'up', underlying IP interface(s)
+  // would be brought up automatically (if not already up) and the associated BGP peers
+  // would start advertising routes. If the desired state is 'down', the associated BGP
+  // peers would stop advertising routes.
   // required = true
   optional State.Enum state = 2;
 }
@@ -6969,7 +6973,9 @@ message StateProtocolIsisRouters {
       down = 2;
     }
   }
-  // The desired state of ISIS router.
+  // The desired state of ISIS router. If the desired state is 'up', the associated ISIS
+  // routers would start advertising routes. If the desired state is 'down', the associated
+  // ISIS routers would stop advertising routes.
   // required = true
   optional State.Enum state = 2;
 }

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6652,6 +6652,7 @@ message StateProtocol {
       all = 1;
       route = 2;
       lacp = 3;
+      bgp = 4;
     }
   }
   // Description missing in models
@@ -6666,6 +6667,9 @@ message StateProtocol {
 
   // Description missing in models
   StateProtocolLacp lacp = 4;
+
+  // Description missing in models
+  StateProtocolBgp bgp = 5;
 }
 
 // Sets the link of configured ports.
@@ -6835,6 +6839,46 @@ message StateProtocolLacpAdmin {
   // The LACP Member admin state. 'up' will send LACPDUs with 'sync' flag set on selected
   // member ports. 'down' will send LACPDUs with 'sync' flag unset on selected member
   // ports.
+  // required = true
+  optional State.Enum state = 2;
+}
+
+// Sets state of configured BGP
+message StateProtocolBgp {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      session = 1;
+    }
+  }
+  // Description missing in models
+  // required = true
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  StateProtocolBgpSession session = 2;
+}
+
+// Sets session state of configured BGP peers
+message StateProtocolBgpSession {
+
+  // The names of BGP peers for which the state has to be applied. An empty or null list
+  // will control all BGP peers.
+  // 
+  // x-constraint:
+  // - /components/schemas/Port/properties/name
+  // 
+  repeated string peer_names = 1;
+
+  message State {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // The BGP peer session state.
   // required = true
   optional State.Enum state = 2;
 }

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -112,15 +112,15 @@ components:
         choice:
           type: string
           x-enum:
-            session:
+            peers:
               x-field-uid: 1
           x-field-uid: 1
-        session:
-          $ref: '#/components/schemas/State.Protocol.Bgp.Session'
+        peers:
+          $ref: '#/components/schemas/State.Protocol.Bgp.Peers'
           x-field-uid: 2
-    State.Protocol.Bgp.Session:
+    State.Protocol.Bgp.Peers:
       description: >-
-        Sets session state of configured BGP peers
+        Sets state of configured BGP peers
       required:
         - state
       properties:
@@ -136,7 +136,7 @@ components:
           x-field-uid: 1
         state:
           description: >-
-            The BGP peer session state.
+            The desired state of BGP peer.
           type: string
           x-field-uid: 2
           x-enum:

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -169,8 +169,8 @@ components:
         state:
           description: >-
             The desired state of BGP peer.
-            If the desired state is 'up', underlying IP interface(s) would be brought up automatically (if not already up) and the associated BGP peers would start advertising routes.
-            If the desired state is 'down', the associated BGP peers would stop advertising routes. 
+            If the desired state is 'up', underlying IP interface(s) would be brought up automatically (if not already up), would attempt to bring up the BGP session(s) and advertise route(s), if configured.
+            If the desired state is 'down', BGP session(s) would be brought down. 
           type: string
           x-field-uid: 2
           x-enum:
@@ -213,8 +213,8 @@ components:
         state:
           description: >-
             The desired state of ISIS router.
-            If the desired state is 'up', the associated ISIS routers would start advertising routes.
-            If the desired state is 'down', the associated ISIS routers would stop advertising routes. 
+            If the desired state is 'up', would attempt to bring up the ISIS session(s) with respective peer(s) and advertise route(s), if configured.
+            If the desired state is 'down', would bring down ISIS session(s) with respective peer(s). 
           type: string
           x-field-uid: 2
           x-enum:

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -104,7 +104,7 @@ components:
               x-field-uid: 2
     State.Protocol.Bgp:
       description: >-
-        Sets state of configured BGP
+        Sets state of configured BGP peers.
       type: object
       required:
         - choice
@@ -120,7 +120,7 @@ components:
           x-field-uid: 2
     State.Protocol.Bgp.Peers:
       description: >-
-        Sets state of configured BGP peers
+        Sets state of configured BGP peers.
       required:
         - state
       properties:

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -132,7 +132,8 @@ components:
           items:
             type: string
           x-constraint:
-          - '/components/schemas/Port/properties/name'
+          - "/components/schemas/Bgp.V4Peer/properties/name"
+          - "/components/schemas/Bgp.V6Peer/properties/name"
           x-field-uid: 1
         state:
           description: >-

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -169,6 +169,8 @@ components:
         state:
           description: >-
             The desired state of BGP peer.
+            If the desired state is 'up', underlying IP interface(s) would be brought up automatically (if not already up) and the associated BGP peers would start advertising routes.
+            If the desired state is 'down', the associated BGP peers would stop advertising routes. 
           type: string
           x-field-uid: 2
           x-enum:
@@ -211,6 +213,8 @@ components:
         state:
           description: >-
             The desired state of ISIS router.
+            If the desired state is 'up', the associated ISIS routers would start advertising routes.
+            If the desired state is 'down', the associated ISIS routers would stop advertising routes. 
           type: string
           x-field-uid: 2
           x-enum:

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -102,3 +102,45 @@ components:
               x-field-uid: 1
             down:
               x-field-uid: 2
+    State.Protocol.Bgp:
+      description: >-
+        Sets state of configured BGP
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            session:
+              x-field-uid: 1
+          x-field-uid: 1
+        session:
+          $ref: '#/components/schemas/State.Protocol.Bgp.Session'
+          x-field-uid: 2
+    State.Protocol.Bgp.Session:
+      description: >-
+        Sets session state of configured BGP peers
+      required:
+        - state
+      properties:
+        peer_names:
+          description: >-
+            The names of BGP peers for which the state has to be applied.
+            An empty or null list will control all BGP peers.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Port/properties/name'
+          x-field-uid: 1
+        state:
+          description: >-
+            The BGP peer session state.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -70,10 +70,15 @@ components:
           x-enum:
             admin:
               x-field-uid: 1
+            member_ports:
+              x-field-uid: 2
           x-field-uid: 1
         admin:
           $ref: '#/components/schemas/State.Protocol.Lacp.Admin'
           x-field-uid: 2
+        member_ports:
+          $ref: '#/components/schemas/State.Protocol.Lacp.MemberPorts'
+          x-field-uid: 3
     State.Protocol.Lacp.Admin:
       description: >-
         Sets admin state of LACP configured on LAG members
@@ -95,6 +100,32 @@ components:
             The LACP Member admin state.
             'up' will send LACPDUs with 'sync' flag set on selected member ports.
             'down' will send LACPDUs with 'sync' flag unset on selected member ports.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+    State.Protocol.Lacp.MemberPorts:
+      description: >-
+        Sets state of LACP member ports configured on LAG.
+      required:
+        - state
+      properties:
+        lag_member_names:
+          description: >-
+            The names of LAG members (ports) for which the state has to be applied.
+            An empty or null list will control all LAG members.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Port/properties/name'
+          x-field-uid: 1
+        state:
+          description: >-
+            The desired LACP member port state.
           type: string
           x-field-uid: 2
           x-enum:
@@ -138,6 +169,48 @@ components:
         state:
           description: >-
             The desired state of BGP peer.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+    State.Protocol.Isis:
+      description: >-
+        Sets state of configured ISIS routers.
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            routers:
+              x-field-uid: 1
+          x-field-uid: 1
+        routers:
+          $ref: '#/components/schemas/State.Protocol.Isis.Routers'
+          x-field-uid: 2
+    State.Protocol.Isis.Routers:
+      description: >-
+        Sets state of configured ISIS routers.
+      required:
+        - state
+      properties:
+        router_names:
+          description: >-
+            The names of ISIS routers for which the state has to be applied.
+            An empty or null list will control all ISIS routers.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - "/components/schemas/Device.IsisRouter/properties/name"
+          x-field-uid: 1
+        state:
+          description: >-
+            The desired state of ISIS router.
           type: string
           x-field-uid: 2
           x-enum:

--- a/control/state.yaml
+++ b/control/state.yaml
@@ -85,6 +85,8 @@ components:
               x-field-uid: 2
             lacp:
               x-field-uid: 3
+            bgp:
+              x-field-uid: 4
           x-field-uid: 1
         all:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.All'
@@ -95,3 +97,6 @@ components:
         lacp:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.Lacp'
           x-field-uid: 4
+        bgp:
+          $ref: './protocol.yaml#/components/schemas/State.Protocol.Bgp'
+          x-field-uid: 5

--- a/control/state.yaml
+++ b/control/state.yaml
@@ -100,3 +100,6 @@ components:
         bgp:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.Bgp'
           x-field-uid: 5
+        isis:
+          $ref: './protocol.yaml#/components/schemas/State.Protocol.Isis'
+          x-field-uid: 6

--- a/control/state.yaml
+++ b/control/state.yaml
@@ -87,6 +87,8 @@ components:
               x-field-uid: 3
             bgp:
               x-field-uid: 4
+            isis:
+              x-field-uid: 5
           x-field-uid: 1
         all:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.All'


### PR DESCRIPTION
Check documentation: [here](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-fly-controlstate/artifacts/openapi.yaml&nocors#tag/Control/operation/set_control_state)

### use-case
mentioned [here](https://github.com/open-traffic-generator/featureprofiles/blob/main/feature/experimental/bgp/ate_tests/bgp_long_lived_graceful_restart/bgp_long_lived_graceful_restart_test.go#L976)
- configure one bgp peer
- start protocols (expectation: 1st bgp peer will be up)
- add 5 more bgp peers (expectation: all 6 bgp peers will be up)
- remove 5 newly added bgp peers (expectation: only 1st bgp peer will be up)

### proposal
- configure all bgp peers in the original config
- instead of starting all protocols, bring up/down bgp peers selectively during start protocol
- If the desired state of a set of BGP peers is 'up', underlying IP interface(s) would be brought up automatically (if not already up) and the associated BGP peers would start advertising routes. If the desired state of a set of BGP peers is 'down', the associated BGP peers would stop advertising routes.

**Example**:

```go
        api := gosnappi.NewApi()
	config := gosnappi.NewConfig()

	// add port
	p1 := config.Ports().Add().SetName("p1").SetLocation("eth1")

	// add device
	d1 := config.Devices().Add().SetName("d1")

	// add Ethernet
	d1Eth1 := d1.Ethernets().
		Add().
		SetName("d1Eth").
		SetMac("00:00:01:01:01:01").
		SetMtu(1500)

	d1Eth1.Connection().SetChoice("port_name").SetPortName(p1.Name())

	// add IPv4
	d1Eth1.
		Ipv4Addresses().
		Add().
		SetName("p1d1ipv4").
		SetAddress("1.1.1.1").
		SetGateway("1.1.1.2").
		SetPrefix(24)

	d1Bgp := d1.Bgp().SetRouterId("1.1.1.1")
	d1BgpIpv4Interface := d1Bgp.Ipv4Interfaces().Add().SetIpv4Name("p1d1ipv4")

	// Add 6 bgp peers
	for i := 1; i <= 6; i++ {
		d1BgpIpv4Interface.Peers().Add().
			SetName(fmt.Sprintf("Peer%d", i)).
			SetPeerAddress("1.1.1.2")

		// other bgp peer and route configurations...
	}

	// set config
	api.SetConfig(config)

	// Start protocol with 1st peer
	start := api.NewControlState()
	start.Protocol().Bgp().Peers().
		SetPeerNames([]string{"Peer1"}).
		SetState(gosnappi.StateProtocolBgpPeersState.UP)

	api.SetControlState(start)

	// Peer-names for last 5 peers (peer names are globally unique)
	peerNames := []string{}
	for i := 2; i <= 6; i++ {
		peerNames = append(peerNames, fmt.Sprintf("Peer%d", i))
	}

	// Start last 5 peers
	add5 := api.NewControlState()
	add5.Protocol().Bgp().Peers().
		SetPeerNames(peerNames).
		SetState(gosnappi.StateProtocolBgpPeersState.UP)

	api.SetControlState(add5)

	// Stop last 5 peers
	remove5 := api.NewControlState()
	remove5.Protocol().Bgp().Peers().
		SetPeerNames(peerNames).
		SetState(gosnappi.StateProtocolBgpPeersState.DOWN)

	api.SetControlState(remove5)
```
**Comments**:
- it is a clean approach in line with current OTG model workflow of managing control plane attributes post set_config.
- item in `peer_names` can uniquely identify a bgp peer across config 
	- as property `name` for `Bgp.V4Peer`/`Bgp.V6Peer` is globally unique
- current workflow/design of set_control_state allows atomic changes; hence if any future use-case requires,
	- more than one attribute change in same config-node (e.g. devices/bgp) or in any child of it,
		- further addition in set_control_state would be needed (e.g. under set_control_state/protocol/bgp) for those attributes
	- more than one attribute change across config-nodes (e.g. devices/bgp and devices/isis)
		- further addition in set_control_state would be needed (e.g. under set_control_state/protocol/bgp and/or set_control_state/protocol/isis)
- note: to get hands on with script including this change please use gosnappi through `go get github.com/open-traffic-generator/snappi/gosnappi@dev-fly-controlstate`