### PR TITLE
On the fly bgp peer add/remove: through UpdateConfig devices/bgp

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8753,20 +8753,25 @@ components:
       description: |-
         Request for updating specific attributes of resources in traffic generator
       type: object
+      required:
+      - choice
       properties:
         choice:
           type: string
           x-enum:
             flows:
               x-field-uid: 1
+            devices:
+              x-field-uid: 2
           x-field-uid: 1
           enum:
           - flows
+          - devices
         flows:
           $ref: '#/components/schemas/Flows.Update'
           x-field-uid: 2
-        protocols:
-          $ref: '#/components/schemas/Protocols.Update'
+        devices:
+          $ref: '#/components/schemas/Devices.Update'
           x-field-uid: 3
     Flows.Update:
       description: |-
@@ -8798,9 +8803,9 @@ components:
           items:
             $ref: '#/components/schemas/Flow'
           x-field-uid: 2
-    Protocols.Update:
+    Devices.Update:
       description: |-
-        Protocols for which update properties would be initiated.
+        Devices for which update properties would be initiated.
       type: object
       required:
       - choice
@@ -8814,11 +8819,11 @@ components:
           enum:
           - bgp
         bgp:
-          $ref: '#/components/schemas/Update.Protocol.Bgp'
+          $ref: '#/components/schemas/Update.Device.Bgp'
           x-field-uid: 2
-    Update.Protocol.Bgp:
+    Update.Device.Bgp:
       description: |-
-        Updates protocol properties of configured BGP
+        Updates properties of configured BGP
       type: object
       required:
       - property_names

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6561,16 +6561,18 @@ message ConfigUpdate {
     enum Enum {
       unspecified = 0;
       flows = 1;
+      devices = 2;
     }
   }
   // Description missing in models
+  // required = true
   optional Choice.Enum choice = 1;
 
   // Description missing in models
   FlowsUpdate flows = 2;
 
   // Description missing in models
-  ProtocolsUpdate protocols = 3;
+  DevicesUpdate devices = 3;
 }
 
 // A container of flows with associated properties to be updated without affecting the
@@ -6591,8 +6593,8 @@ message FlowsUpdate {
   repeated Flow flows = 2;
 }
 
-// Protocols for which update properties would be initiated.
-message ProtocolsUpdate {
+// Devices for which update properties would be initiated.
+message DevicesUpdate {
 
   message Choice {
     enum Enum {
@@ -6605,11 +6607,11 @@ message ProtocolsUpdate {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  UpdateProtocolBgp bgp = 2;
+  UpdateDeviceBgp bgp = 2;
 }
 
-// Updates protocol properties of configured BGP
-message UpdateProtocolBgp {
+// Updates properties of configured BGP
+message UpdateDeviceBgp {
 
   message PropertyNames {
     enum Enum {

--- a/config/device.yaml
+++ b/config/device.yaml
@@ -1,14 +1,14 @@
 openapi: 3.0.3
 info:
-  title: Control protocol models for protocol update
+  title: Control protocol models for devices update
   description: >-
-    All control protocol schemas for protocol update
+    All control protocol schemas for devices update
   version: ^0.0.0
 components:
   schemas:
-    Update.Protocol.Bgp:
+    Update.Device.Bgp:
       description: >-
-        Updates protocol properties of configured BGP
+        Updates properties of configured BGP
       type: object
       required:
         - property_names

--- a/config/protocol.yaml
+++ b/config/protocol.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.3
+info:
+  title: Control protocol models for protocol update
+  description: >-
+    All control protocol schemas for protocol update
+  version: ^0.0.0
+components:
+  schemas:
+    Update.Protocol.Bgp:
+      description: >-
+        Updates protocol properties of configured BGP
+      type: object
+      required:
+        - property_names
+        - bgp
+      properties:
+        property_names:
+          description: >-
+            BGP properties to be updated.
+          type: array
+          items:
+            type: string
+            x-enum:
+              peer_enabled:
+                x-field-uid: 1
+          x-field-uid: 1
+        bgp:
+          description: >-
+            The list of configured BGP peers for which given property will be updated.
+          type: array
+          items:
+            $ref: '#/components/schemas/Device.BgpRouter'
+          x-field-uid: 2

--- a/config/update.yaml
+++ b/config/update.yaml
@@ -14,6 +14,9 @@ components:
         flows:
           $ref: '#/components/schemas/Flows.Update'
           x-field-uid: 2
+        protocols:
+          $ref: '#/components/schemas/Protocols.Update'
+          x-field-uid: 3
     Flows.Update:
       description: >-
         A container of flows with associated properties to be updated without
@@ -41,4 +44,20 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Flow'
+          x-field-uid: 2
+    Protocols.Update:
+      description: >-
+        Protocols for which update properties would be initiated.
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            bgp:
+              x-field-uid: 1
+          x-field-uid: 1
+        bgp:
+          $ref: './protocol.yaml#/components/schemas/Update.Protocol.Bgp'
           x-field-uid: 2

--- a/config/update.yaml
+++ b/config/update.yaml
@@ -4,18 +4,22 @@ components:
       description: >-
         Request for updating specific attributes of resources in traffic generator
       type: object
+      required:
+        - choice
       properties:
         choice:
           type: string
           x-enum:
             flows:
               x-field-uid: 1
+            devices:
+              x-field-uid: 2
           x-field-uid: 1
         flows:
           $ref: '#/components/schemas/Flows.Update'
           x-field-uid: 2
-        protocols:
-          $ref: '#/components/schemas/Protocols.Update'
+        devices:
+          $ref: '#/components/schemas/Devices.Update'
           x-field-uid: 3
     Flows.Update:
       description: >-
@@ -45,9 +49,9 @@ components:
           items:
             $ref: '#/components/schemas/Flow'
           x-field-uid: 2
-    Protocols.Update:
+    Devices.Update:
       description: >-
-        Protocols for which update properties would be initiated.
+        Devices for which update properties would be initiated.
       type: object
       required:
         - choice
@@ -59,5 +63,5 @@ components:
               x-field-uid: 1
           x-field-uid: 1
         bgp:
-          $ref: './protocol.yaml#/components/schemas/Update.Protocol.Bgp'
+          $ref: './device.yaml#/components/schemas/Update.Device.Bgp'
           x-field-uid: 2

--- a/device/bgp/bgpv4.yaml
+++ b/device/bgp/bgpv4.yaml
@@ -69,6 +69,12 @@ components:
         graceful_restart:
           x-include: './bgp.yaml#/components/schemas/Device.Bgp/properties/graceful_restart'
           x-field-uid: 14
+        peer_enabled:
+          description: |-
+            Specifies whether the peer is enabled or not. 
+          type: boolean
+          default: true
+          x-field-uid: 15
     Bgp.V4Interface:
       description: >-
         Configuration for emulated BGPv4 peers and routes on a single IPv4 interface.

--- a/device/bgp/bgpv6.yaml
+++ b/device/bgp/bgpv6.yaml
@@ -72,6 +72,12 @@ components:
         graceful_restart:
           x-include: './bgp.yaml#/components/schemas/Device.Bgp/properties/graceful_restart'
           x-field-uid: 15
+        peer_enabled:
+          description: |-
+            Specifies whether the peer is enabled or not. 
+          type: boolean
+          default: true
+          x-field-uid: 16
     Bgp.V6Interface:
       description: >-
         Configuration for emulated BGPv6 peers and routes on a single IPv6 interface.


### PR DESCRIPTION
Check documentation: [here](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-fly-updatecfg/artifacts/openapi.yaml&nocors#tag/Configuration/operation/update_config)

### use-case
mentioned [here](https://github.com/open-traffic-generator/featureprofiles/blob/main/feature/experimental/bgp/ate_tests/bgp_long_lived_graceful_restart/bgp_long_lived_graceful_restart_test.go#L976)
- configure one bgp peer
- start protocols (expectation: 1st bgp peer will be up)
- add 5 more bgp peers (expectation: all 6 bgp peers will be up)
- remove 5 newly added bgp peers (expectation: only 1st bgp peer will be up)

### proposal
- configure all bgp peers in the original config with 1st peer enabled, rest 5 peers disabled using new `peer_enabled` flag.
- start protocols (only 1st peer will come up)
- update config with rest 5 peers enabled (all 6 peers will come up)
- update config with rest 5 peers disabled again (only 1st bgp peer remains up, rest 5 goes down)

**Example**:
```go
        api := gosnappi.NewApi()
	config := gosnappi.NewConfig()

	d1 := config.Devices().Add().SetName("d1")

	// bgp router, interface(s), peers
	d1Bgp := d1.Bgp()
	d1BgpIpv4Interface := d1Bgp.Ipv4Interfaces().Add()
	peers := d1BgpIpv4Interface.Peers()

	// Add 6 bgp peers (enabled by default) - disable the last 5
	peers.Add().SetName("Peer1")
	for i := 2; i <= 6; i++ {
		peers.Add().SetName(fmt.Sprintf("Peer%d", i)).SetPeerEnabled(false)
	}

	// other bgp internal configurations...

	// set config
	api.SetConfig(config)

	// Start protocols - only 1st peer would be UP
	start := api.NewControlState()
	start.Protocol().All().SetState(gosnappi.StateProtocolAllState.START)
	api.SetControlState(start)

	// Enable the last 5 peers
	for idx, peer := range peers.Items() {
		if idx != 0 {
			peer.SetPeerEnabled(true)
		}
	}

	// config-slice to update, with
	// 1. properties to update
	// 2. config-nodes [Array of objects (Device.BgpRouter) in this case] to update
	// last 5 peer would be UP as well
	upd := api.NewConfigUpdate()
	upd.Devices().Bgp().
		SetPropertyNames([]gosnappi.UpdateDeviceBgpPropertyNamesEnum{gosnappi.UpdateDeviceBgpPropertyNames.PEER_ENABLED}).
		Bgp().Append(d1Bgp)

	api.UpdateConfig(upd)

	// Disable the last 5 peer
	for idx, peer := range peers.Items() {
		if idx != 0 {
			peer.SetPeerEnabled(false)
		}
	}

	// config-slice to update, with
	// 1. properties to update
	// 2. config-nodes [Array of objects (Device.BgpRouter) in this case] to update
	// last 5 peer would go DOWN
	upd = api.NewConfigUpdate()
	upd.Devices().Bgp().
		SetPropertyNames([]gosnappi.UpdateDeviceBgpPropertyNamesEnum{gosnappi.UpdateDeviceBgpPropertyNames.PEER_ENABLED}).
		Bgp().Append(d1Bgp)

	api.UpdateConfig(upd)
```
**Comments**:
- this approach is proposed for future accmodation of use-case where more than one attribute change in same config-node (e.g. devices/bgp) or in any child of it might be required - those attributes could be passed in `property_names` field of update_config/devices/bgp.
- issues with this approach are,
  - attributes (to be changed on the fly) mentioned in `property_names` does not have a path associated. Hence consumer of `update_config` api (controller for ixia-c/keng solution), need to find out each of the mentioned attribute(s) in the provided config-node (e.g. devices/bgp) or in any nested child of same - it would result in a performance hit.
	(note: in similar scenario, looks like, gnmi updates the attributes with key-value pair of `<absolute-path-to-attribute>:<new value>` (reference [here](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md?plain=1#L1245)) but I believe it is not good for UX and hence similar methodology is avoided in OTG model altogether)
  - in reality, there are duplicate attribute-names at different levels of same config-node (e.g. almost all the attributes of `Bgp.V4Peer` and `Bgp.V6Peer` under devices/bgp have same attribute-names) - hence as there is no associated path with the attribute, it might result in some undesired updates.
  - this approach still does not address attribute changes spread across different config-nodes e.g. devices/bgp and devices/isis - which might still need multiple `update_config` api calls.
  - this approach might result in high volume of data-transfer for bulky config-nodes e.g. devices/bgp with 1M routes even though attributes to update might not be associated with routes and is present directly under devices/bgp or in some other child of it.
- a preferred approach to solve the use-case is captured in [this pr](https://github.com/open-traffic-generator/models/pull/337)
- note: to get hands on with script including this change please use gosnappi through `go get github.com/open-traffic-generator/snappi/gosnappi@dev-fly-updatecfg` 