### PR TITLE
Exposing the configuration for the BGP passive mode

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3452,6 +3452,14 @@ components:
             The value to be used as a secret MD5 key for authentication. If not configured, MD5 authentication will not be enabled.
           type: string
           x-field-uid: 5
+        passive_mode:
+          description: "If enabled then the BGP Finite State Machine will passively\
+            \ wait \nfor the remote BGP peer to establish the BGP TCP connection.\
+            \ \nIf the passive mode is true, BGP peer will wait for the remote BGP\
+            \ peer \nto issue an Open request before an Open message is sent."
+          type: boolean
+          default: false
+          x-field-uid: 6
     Bgp.Capability:
       description: |-
         Configuration for BGP capability settings.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3453,10 +3453,9 @@ components:
           type: string
           x-field-uid: 5
         passive_mode:
-          description: "If enabled then the BGP Finite State Machine will passively\
-            \ wait \nfor the remote BGP peer to establish the BGP TCP connection.\
-            \ \nIf the passive mode is true, BGP peer will wait for the remote BGP\
-            \ peer \nto issue an Open request before an Open message is sent."
+          description: |-
+            If set to true, the local BGP peer will wait for the remote peer to initiate the BGP session
+            by establishing the TCP connection, rather than initiating sessions from the local peer.
           type: boolean
           default: false
           x-field-uid: 6

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -2359,10 +2359,10 @@ message BgpAdvanced {
   // authentication will not be enabled.
   optional string md5_key = 5;
 
-  // If enabled then the BGP Finite State Machine will passively wait
-  // for the remote BGP peer to establish the BGP TCP connection.
-  // If the passive mode is true, BGP peer will wait for the remote BGP peer
-  // to issue an Open request before an Open message is sent.
+  // If set to true, the local BGP peer will wait for the remote peer to initiate the
+  // BGP session
+  // by establishing the TCP connection, rather than initiating sessions from the local
+  // peer.
   // default = False
   optional bool passive_mode = 6;
 }

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -2358,6 +2358,13 @@ message BgpAdvanced {
   // The value to be used as a secret MD5 key for authentication. If not configured, MD5
   // authentication will not be enabled.
   optional string md5_key = 5;
+
+  // If enabled then the BGP Finite State Machine will passively wait
+  // for the remote BGP peer to establish the BGP TCP connection.
+  // If the passive mode is true, BGP peer will wait for the remote BGP peer
+  // to issue an Open request before an Open message is sent.
+  // default = False
+  optional bool passive_mode = 6;
 }
 
 // Configuration for BGP capability settings.

--- a/device/bgp/bgpadvanced.yaml
+++ b/device/bgp/bgpadvanced.yaml
@@ -45,3 +45,13 @@ components:
             If not configured, MD5 authentication will not be enabled.
           type: string
           x-field-uid: 5
+        passive_mode:
+          description: |-
+            If enabled then the BGP Finite State Machine will passively wait 
+            for the remote BGP peer to establish the BGP TCP connection. 
+            If the passive mode is true, BGP peer will wait for the remote BGP peer 
+            to issue an Open request before an Open message is sent.
+          type: boolean
+          default: false
+          x-field-uid: 6
+        

--- a/device/bgp/bgpadvanced.yaml
+++ b/device/bgp/bgpadvanced.yaml
@@ -47,10 +47,8 @@ components:
           x-field-uid: 5
         passive_mode:
           description: |-
-            If enabled then the BGP Finite State Machine will passively wait 
-            for the remote BGP peer to establish the BGP TCP connection. 
-            If the passive mode is true, BGP peer will wait for the remote BGP peer 
-            to issue an Open request before an Open message is sent.
+            If set to true, the local BGP peer will wait for the remote peer to initiate the BGP session
+            by establishing the TCP connection, rather than initiating sessions from the local peer.
           type: boolean
           default: false
           x-field-uid: 6


### PR DESCRIPTION
https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/bgp-passive-mode/artifacts/openapi.yaml&nocors
This PR is for a sub-part of [RT-1.9: BGP Transport Parameters test](https://github.com/openconfig/featureprofiles/blob/bfe41d0d3231c3404ad993ae54ba159c46a703b2/feature/bgp/transport_tests/README.md#rt-19-bgp-transport-parameters-test).

Exposed passive_mode under BGP peer advanced configuration.
If set to true, the local BGP peer will wait for the remote peer to initiate the BGP session by establishing the TCP connection, rather than initiating sessions from the local peer.

Configuration snippet:
```
bgpIpv4Interface := device.Bgp().Ipv4Interfaces().
                            Add().
                            SetIpv4Name(ipv4Name)
bgpPeer := bgpIpv4Interface.Peers().
                    Add().
                    SetAsNumber(uint32(ixiaAs)).
                    SetAsType(gosnappi.BgpV4PeerAsType.IBGP).
                    SetPeerAddress(peerRemoteIp).
                    SetName(peerName)

**bgpPeer.Advanced().SetPassiveMode(true)**
```