### PR TITLE
Allow BGP to be configured on a non-default TCP port.

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3481,7 +3481,7 @@ components:
           x-field-uid: 6
         listen_port:
           description: |-
-            Set listen transport port number for the local BGP peer.
+            The TCP port number on which to accept BGP connections from the remote peer.
           type: integer
           format: uint32
           default: 179

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3453,14 +3453,13 @@ components:
           type: string
           x-field-uid: 5
         passive_mode:
-          description: "If enabled then the BGP Finite State Machine will passively\
-            \ wait \nfor the remote BGP peer to establish the BGP TCP connection.\
-            \ \nIf the passive mode is true, BGP peer will wait for the remote BGP\
-            \ peer \nto issue an Open request before an Open message is sent."
+          description: |-
+            If set to true, the local BGP peer will wait for the remote peer to initiate the BGP session
+            by establishing the TCP connection, rather than initiating sessions from the local peer.
           type: boolean
           default: false
           x-field-uid: 6
-        local_listen_port:
+        listen_port:
           description: |-
             Set listen transport port number for the local BGP peer.
           type: integer
@@ -3468,6 +3467,15 @@ components:
           default: 179
           maximum: 65535
           x-field-uid: 7
+        neighbor_port:
+          description: |-
+            Destination TCP port number of the BGP peer when initiating a
+            session from the local BGP peer.
+          type: integer
+          format: uint32
+          default: 179
+          maximum: 65535
+          x-field-uid: 8
     Bgp.Capability:
       description: |-
         Configuration for BGP capability settings.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3460,6 +3460,14 @@ components:
           type: boolean
           default: false
           x-field-uid: 6
+        local_listen_port:
+          description: |-
+            Set listen transport port number for the local BGP peer.
+          type: integer
+          format: uint32
+          default: 179
+          maximum: 65535
+          x-field-uid: 7
     Bgp.Capability:
       description: |-
         Configuration for BGP capability settings.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3452,6 +3452,14 @@ components:
             The value to be used as a secret MD5 key for authentication. If not configured, MD5 authentication will not be enabled.
           type: string
           x-field-uid: 5
+        passive_mode:
+          description: "If enabled then the BGP Finite State Machine will passively\
+            \ wait \nfor the remote BGP peer to establish the BGP TCP connection.\
+            \ \nIf the passive mode is true, BGP peer will wait for the remote BGP\
+            \ peer \nto issue an Open request before an Open message is sent."
+          type: boolean
+          default: false
+          x-field-uid: 6
     Bgp.Capability:
       description: |-
         Configuration for BGP capability settings.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -2365,6 +2365,10 @@ message BgpAdvanced {
   // to issue an Open request before an Open message is sent.
   // default = False
   optional bool passive_mode = 6;
+
+  // Set listen transport port number for the local BGP peer.
+  // default = 179
+  optional uint32 local_listen_port = 7;
 }
 
 // Configuration for BGP capability settings.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -2379,7 +2379,7 @@ message BgpAdvanced {
   // default = False
   optional bool passive_mode = 6;
 
-  // Set listen transport port number for the local BGP peer.
+  // The TCP port number on which to accept BGP connections from the remote peer.
   // default = 179
   optional uint32 listen_port = 7;
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -2359,16 +2359,21 @@ message BgpAdvanced {
   // authentication will not be enabled.
   optional string md5_key = 5;
 
-  // If enabled then the BGP Finite State Machine will passively wait
-  // for the remote BGP peer to establish the BGP TCP connection.
-  // If the passive mode is true, BGP peer will wait for the remote BGP peer
-  // to issue an Open request before an Open message is sent.
+  // If set to true, the local BGP peer will wait for the remote peer to initiate the
+  // BGP session
+  // by establishing the TCP connection, rather than initiating sessions from the local
+  // peer.
   // default = False
   optional bool passive_mode = 6;
 
   // Set listen transport port number for the local BGP peer.
   // default = 179
-  optional uint32 local_listen_port = 7;
+  optional uint32 listen_port = 7;
+
+  // Destination TCP port number of the BGP peer when initiating a
+  // session from the local BGP peer.
+  // default = 179
+  optional uint32 neighbor_port = 8;
 }
 
 // Configuration for BGP capability settings.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -2358,6 +2358,13 @@ message BgpAdvanced {
   // The value to be used as a secret MD5 key for authentication. If not configured, MD5
   // authentication will not be enabled.
   optional string md5_key = 5;
+
+  // If enabled then the BGP Finite State Machine will passively wait
+  // for the remote BGP peer to establish the BGP TCP connection.
+  // If the passive mode is true, BGP peer will wait for the remote BGP peer
+  // to issue an Open request before an Open message is sent.
+  // default = False
+  optional bool passive_mode = 6;
 }
 
 // Configuration for BGP capability settings.

--- a/device/bgp/bgpadvanced.yaml
+++ b/device/bgp/bgpadvanced.yaml
@@ -54,7 +54,7 @@ components:
           x-field-uid: 6
         listen_port:
           description: |-
-            Set listen transport port number for the local BGP peer.
+            The TCP port number on which to accept BGP connections from the remote peer.
           type: integer
           format: uint32
           default: 179

--- a/device/bgp/bgpadvanced.yaml
+++ b/device/bgp/bgpadvanced.yaml
@@ -47,14 +47,12 @@ components:
           x-field-uid: 5
         passive_mode:
           description: |-
-            If enabled then the BGP Finite State Machine will passively wait 
-            for the remote BGP peer to establish the BGP TCP connection. 
-            If the passive mode is true, BGP peer will wait for the remote BGP peer 
-            to issue an Open request before an Open message is sent.
+            If set to true, the local BGP peer will wait for the remote peer to initiate the BGP session
+            by establishing the TCP connection, rather than initiating sessions from the local peer.
           type: boolean
           default: false
           x-field-uid: 6
-        local_listen_port:
+        listen_port:
           description: |-
             Set listen transport port number for the local BGP peer.
           type: integer
@@ -62,3 +60,12 @@ components:
           default: 179
           maximum: 65535
           x-field-uid: 7
+        neighbor_port:
+          description: |-
+            Destination TCP port number of the BGP peer when initiating a
+            session from the local BGP peer.
+          type: integer
+          format: uint32
+          default: 179
+          maximum: 65535
+          x-field-uid: 8

--- a/device/bgp/bgpadvanced.yaml
+++ b/device/bgp/bgpadvanced.yaml
@@ -54,4 +54,11 @@ components:
           type: boolean
           default: false
           x-field-uid: 6
-        
+        local_listen_port:
+          description: |-
+            Set listen transport port number for the local BGP peer.
+          type: integer
+          format: uint32
+          default: 179
+          maximum: 65535
+          x-field-uid: 7


### PR DESCRIPTION
https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/bgp-listen-port/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config

This PR is for a sub-part of [RT-1.9: BGP Transport Parameters test](https://github.com/openconfig/featureprofiles/blob/bfe41d0d3231c3404ad993ae54ba159c46a703b2/feature/bgp/transport_tests/README.md#rt-19-bgp-transport-parameters-test).

Exposing BGP listen port number and neighbor port for user to change to non-default port number, say 1800 or 2000, as per need.

Configuration snippet:

bgpIpv4Interface := device.Bgp().Ipv4Interfaces().
                            Add().
                            SetIpv4Name(ipv4Name)
bgpPeer := bgpIpv4Interface.Peers().
                    Add().
                    SetAsNumber(uint32(ixiaAs)).
                    SetAsType(gosnappi.BgpV4PeerAsType.IBGP).
                    SetPeerAddress(peerRemoteIp).
                    SetName(peerName)

**bgpPeer.Advanced().SetListenPort(1800)**
**bgpPeer.Advanced().SetNeighborPort(2000)**