### PR TITLE
IP options in IPv4 header

### DIFF
--- a/api/info.yaml
+++ b/api/info.yaml
@@ -8,7 +8,7 @@ info:
     Contributions can be made in the following ways:
     - [open an issue](https://github.com/open-traffic-generator/models/issues) in the models repository
     - [fork the models repository](https://github.com/open-traffic-generator/models) and submit a PR
-  version: 0.13.1
+  version: 0.13.2
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7333,29 +7333,29 @@ components:
       type: object
       properties:
         type:
-          $ref: '#/components/schemas/Flow.Ipv4Options.Type'
+          $ref: '#/components/schemas/Flow.Ipv4Options.Custom.Type'
           x-field-uid: 1
         length:
-          $ref: '#/components/schemas/Flow.Ipv4Options.Length'
+          $ref: '#/components/schemas/Flow.Ipv4Options.Custom.Length'
           x-field-uid: 2
         value:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value'
-    Flow.Ipv4Options.Type:
+    Flow.Ipv4Options.Custom.Type:
       description: |-
         Type options for custom options.
       type: object
       properties:
         copied_flag:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.CopiedFlag'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.CopiedFlag'
         option_class:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionClass'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.OptionClass'
         option_number:
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionNumber'
-    Flow.Ipv4Options.Length:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.OptionNumber'
+    Flow.Ipv4Options.Custom.Length:
       description: "Length for custom options. The length of all IP options should\
         \ not exceed 40 bytes. "
       type: object
@@ -16105,7 +16105,7 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value.Counter'
           x-field-uid: 6
-    Pattern.Flow.Ipv4Options.Type.CopiedFlag.Counter:
+    Pattern.Flow.Ipv4Options.Custom.Type.CopiedFlag.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -16131,7 +16131,7 @@ components:
       x-constants:
         not_copied: 0
         copied: 1
-    Pattern.Flow.Ipv4Options.Type.CopiedFlag:
+    Pattern.Flow.Ipv4Options.Custom.Type.CopiedFlag:
       description: |-
         This flag indicates this option is copied to all fragments on fragmentations.
       type: object
@@ -16170,15 +16170,15 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.CopiedFlag.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.CopiedFlag.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.CopiedFlag.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.CopiedFlag.Counter'
           x-field-uid: 6
       x-constants:
         not_copied: 0
         copied: 1
-    Pattern.Flow.Ipv4Options.Type.OptionClass.Counter:
+    Pattern.Flow.Ipv4Options.Custom.Type.OptionClass.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -16205,7 +16205,7 @@ components:
         control: 0
         reserved: 3
         debugging_measurement: 2
-    Pattern.Flow.Ipv4Options.Type.OptionClass:
+    Pattern.Flow.Ipv4Options.Custom.Type.OptionClass:
       description: |-
         Option class [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
       type: object
@@ -16244,16 +16244,16 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionClass.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.OptionClass.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionClass.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.OptionClass.Counter'
           x-field-uid: 6
       x-constants:
         control: 0
         reserved: 3
         debugging_measurement: 2
-    Pattern.Flow.Ipv4Options.Type.OptionNumber.Counter:
+    Pattern.Flow.Ipv4Options.Custom.Type.OptionNumber.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -16276,7 +16276,7 @@ components:
           default: 1
           format: uint32
           maximum: 31
-    Pattern.Flow.Ipv4Options.Type.OptionNumber:
+    Pattern.Flow.Ipv4Options.Custom.Type.OptionNumber:
       description: |-
         Option Number [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
       type: object
@@ -16315,10 +16315,10 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionNumber.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.OptionNumber.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionNumber.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.OptionNumber.Counter'
           x-field-uid: 6
     Pattern.Flow.Ipv4.Priority.Raw.Counter:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 0.13.1
+  version: 0.13.2
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7285,7 +7285,9 @@ components:
           x-field-uid: 14
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Dst'
         options:
-          $ref: '#/components/schemas/Flow.Ipv4.Options'
+          type: array
+          items:
+            $ref: '#/components/schemas/Flow.Ipv4.Options'
           x-field-uid: 15
     Flow.Ipv4.Options:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7351,12 +7351,12 @@ components:
           x-field-uid: 2
         value:
           description: |-
-            Value of the option field should not excced 38 bytes since maximum 40 bytes can be added as options in IPv4 header. For type and length requires 2 bytes, so max of 38 bytes are expected. Maximum length of this attribute is 76 (38 * 2 hex character per byte).
+            Value of the option field should not excced 38 bytes since maximum 40 bytes can be added as options in IPv4 header. For type and length requires 2 bytes, hence maximum of 38 bytes are expected. Maximum length of this attribute is 76 (38 * 2 hex character per byte).
           type: string
           format: hex
           minLength: 0
           maxLength: 76
-          default: '00000000'
+          default: '0000'
           x-field-uid: 3
     Flow.Ipv4Options.Custom.Type:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7289,7 +7289,7 @@ components:
           x-field-uid: 15
     Flow.Ipv4.Options:
       description: |-
-        IP options for Router Alert Options (RFC 2113) and custom TLV
+        IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram.  It is encoded as a series of type, length and value attributes.  The IP header length MUST be increased to accomoddate the extra bytes needed to encode the IP options. Currently IP options supported are: 1. router_alert Option allows devices to intercept packets not addressed to them directly as defined in RFC2113. 2. custom option is provided for to be able to configure user defined IP options as needed.
       type: object
       properties:
         choice:
@@ -7304,15 +7304,12 @@ components:
           enum:
           - router_alert
           - custom
-        router_alert:
-          x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Options.RouterAlert'
         custom:
           $ref: '#/components/schemas/Flow.Ipv4.Custom'
           x-field-uid: 3
     Flow.Ipv4.Custom:
       description: |-
-        IP options for custom TLV fields
+        User defined IP options to be appended to the IPv4 header.
       type: object
       properties:
         type:
@@ -15836,110 +15833,6 @@ components:
           items:
             $ref: '#/components/schemas/Pattern.Flow.Ipv4.Dst.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Ipv4.Options.RouterAlert.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: uint32
-          maximum: 65535
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 65535
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 65535
-    Pattern.Flow.Ipv4.Options.RouterAlert.MetricTag:
-      description: |-
-        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-      type: object
-      required:
-      - name
-      properties:
-        name:
-          description: |-
-            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-          x-field-uid: 1
-        offset:
-          description: |-
-            Offset in bits relative to start of corresponding header field
-          type: integer
-          format: uint32
-          default: 0
-          maximum: 15
-          x-field-uid: 2
-        length:
-          description: |-
-            Number of bits to track for metrics starting from configured offset of corresponding header field
-          type: integer
-          format: uint32
-          default: 16
-          minimum: 1
-          maximum: 16
-          x-field-uid: 3
-    Pattern.Flow.Ipv4.Options.RouterAlert:
-      description: |-
-        Router Alert Option can intercept packets not addressed to them directly
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: uint32
-          maximum: 65535
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 65535
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Options.RouterAlert.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Options.RouterAlert.Counter'
-          x-field-uid: 6
-        metric_tags:
-          description: |-
-            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-          type: array
-          items:
-            $ref: '#/components/schemas/Pattern.Flow.Ipv4.Options.RouterAlert.MetricTag'
-          x-field-uid: 7
     Pattern.Flow.Ipv4.Custom.Length.Counter:
       description: |-
         integer counter pattern
@@ -15963,36 +15856,6 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.Ipv4.Custom.Length.MetricTag:
-      description: |-
-        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-      type: object
-      required:
-      - name
-      properties:
-        name:
-          description: |-
-            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-          x-field-uid: 1
-        offset:
-          description: |-
-            Offset in bits relative to start of corresponding header field
-          type: integer
-          format: uint32
-          default: 0
-          maximum: 7
-          x-field-uid: 2
-        length:
-          description: |-
-            Number of bits to track for metrics starting from configured offset of corresponding header field
-          type: integer
-          format: uint32
-          default: 8
-          minimum: 1
-          maximum: 8
-          x-field-uid: 3
     Pattern.Flow.Ipv4.Custom.Length:
       description: |-
         Length of the option field
@@ -16037,13 +15900,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Length.Counter'
           x-field-uid: 6
-        metric_tags:
-          description: |-
-            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-          type: array
-          items:
-            $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Length.MetricTag'
-          x-field-uid: 7
     Pattern.Flow.Ipv4.Custom.Value.Counter:
       description: |-
         integer counter pattern
@@ -16067,36 +15923,6 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Ipv4.Custom.Value.MetricTag:
-      description: |-
-        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-      type: object
-      required:
-      - name
-      properties:
-        name:
-          description: |-
-            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-          x-field-uid: 1
-        offset:
-          description: |-
-            Offset in bits relative to start of corresponding header field
-          type: integer
-          format: uint32
-          default: 0
-          maximum: 15
-          x-field-uid: 2
-        length:
-          description: |-
-            Number of bits to track for metrics starting from configured offset of corresponding header field
-          type: integer
-          format: uint32
-          default: 16
-          minimum: 1
-          maximum: 16
-          x-field-uid: 3
     Pattern.Flow.Ipv4.Custom.Value:
       description: |-
         Length of the option field
@@ -16141,13 +15967,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Value.Counter'
           x-field-uid: 6
-        metric_tags:
-          description: |-
-            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-          type: array
-          items:
-            $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Value.MetricTag'
-          x-field-uid: 7
     Pattern.Flow.Ipv4.Type.CopiedFlag.Counter:
       description: |-
         integer counter pattern
@@ -16174,36 +15993,6 @@ components:
       x-constants:
         not_copied: 0
         copied: 1
-    Pattern.Flow.Ipv4.Type.CopiedFlag.MetricTag:
-      description: |-
-        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-      type: object
-      required:
-      - name
-      properties:
-        name:
-          description: |-
-            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-          x-field-uid: 1
-        offset:
-          description: |-
-            Offset in bits relative to start of corresponding header field
-          type: integer
-          format: uint32
-          default: 0
-          maximum: 0
-          x-field-uid: 2
-        length:
-          description: |-
-            Number of bits to track for metrics starting from configured offset of corresponding header field
-          type: integer
-          format: uint32
-          default: 1
-          minimum: 1
-          maximum: 1
-          x-field-uid: 3
     Pattern.Flow.Ipv4.Type.CopiedFlag:
       description: |-
         This flag indicates this option is copied to all fragments on fragmentations
@@ -16248,13 +16037,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.CopiedFlag.Counter'
           x-field-uid: 6
-        metric_tags:
-          description: |-
-            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-          type: array
-          items:
-            $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.CopiedFlag.MetricTag'
-          x-field-uid: 7
       x-constants:
         not_copied: 0
         copied: 1
@@ -16285,36 +16067,6 @@ components:
         control: 0
         reserved: 3
         debugging_measurement: 2
-    Pattern.Flow.Ipv4.Type.OptionClass.MetricTag:
-      description: |-
-        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-      type: object
-      required:
-      - name
-      properties:
-        name:
-          description: |-
-            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-          x-field-uid: 1
-        offset:
-          description: |-
-            Offset in bits relative to start of corresponding header field
-          type: integer
-          format: uint32
-          default: 0
-          maximum: 1
-          x-field-uid: 2
-        length:
-          description: |-
-            Number of bits to track for metrics starting from configured offset of corresponding header field
-          type: integer
-          format: uint32
-          default: 2
-          minimum: 1
-          maximum: 2
-          x-field-uid: 3
     Pattern.Flow.Ipv4.Type.OptionClass:
       description: |-
         Option class
@@ -16359,13 +16111,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionClass.Counter'
           x-field-uid: 6
-        metric_tags:
-          description: |-
-            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-          type: array
-          items:
-            $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionClass.MetricTag'
-          x-field-uid: 7
       x-constants:
         control: 0
         reserved: 3
@@ -16393,36 +16138,6 @@ components:
           default: 1
           format: uint32
           maximum: 31
-    Pattern.Flow.Ipv4.Type.OptionNumber.MetricTag:
-      description: |-
-        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-      type: object
-      required:
-      - name
-      properties:
-        name:
-          description: |-
-            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
-          type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
-          x-field-uid: 1
-        offset:
-          description: |-
-            Offset in bits relative to start of corresponding header field
-          type: integer
-          format: uint32
-          default: 0
-          maximum: 4
-          x-field-uid: 2
-        length:
-          description: |-
-            Number of bits to track for metrics starting from configured offset of corresponding header field
-          type: integer
-          format: uint32
-          default: 5
-          minimum: 1
-          maximum: 5
-          x-field-uid: 3
     Pattern.Flow.Ipv4.Type.OptionNumber:
       description: |-
         Option Number
@@ -16467,13 +16182,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionNumber.Counter'
           x-field-uid: 6
-        metric_tags:
-          description: |-
-            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
-          type: array
-          items:
-            $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionNumber.MetricTag'
-          x-field-uid: 7
     Pattern.Flow.Ipv4.Priority.Raw.Counter:
       description: |-
         integer counter pattern

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7309,7 +7309,7 @@ components:
           x-field-uid: 15
     Flow.Ipv4.Options:
       description: |-
-        IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram.  It is encoded as a series of type, length and value attributes.  The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options. Currently IP options supported are: 1. router_alert Option allows devices to intercept packets not addressed to them directly as defined in RFC2113. 2. custom option is provided for to be able to configure user defined IP options as needed.
+        IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram.  It is encoded as a series of type, length and value attributes.  The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options. Currently IP options supported are: 1. router_alert option allows devices to intercept packets not addressed to them directly as defined in RFC2113. 2. custom option is provided to configure user defined IP options as needed.
       type: object
       properties:
         choice:
@@ -7343,7 +7343,7 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Value'
     Flow.Ipv4.Type:
       description: |-
-        Type options for custom TLV field in Options
+        Type options for custom options.
       type: object
       properties:
         copied_flag:
@@ -16169,7 +16169,7 @@ components:
         copied: 1
     Pattern.Flow.Ipv4.Type.CopiedFlag:
       description: |-
-        This flag indicates this option is copied to all fragments on fragmentations
+        This flag indicates this option is copied to all fragments on fragmentations.
       type: object
       properties:
         choice:
@@ -16243,7 +16243,7 @@ components:
         debugging_measurement: 2
     Pattern.Flow.Ipv4.Type.OptionClass:
       description: |-
-        Option class
+        Option class.
       type: object
       properties:
         choice:
@@ -16314,7 +16314,7 @@ components:
           maximum: 31
     Pattern.Flow.Ipv4.Type.OptionNumber:
       description: |-
-        Option Number
+        Option Number [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7309,7 +7309,7 @@ components:
           x-field-uid: 15
     Flow.Ipv4.Options:
       description: |-
-        IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram.  It is encoded as a series of type, length and value attributes.  The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options. Currently IP options supported are: 1. router_alert option allows devices to intercept packets not addressed to them directly as defined in RFC2113. 2. custom option is provided to configure user defined IP options as needed.
+        IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram.  It is encoded as a series of type, length and value attributes.  The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options. Currently IP options supported are: 1. router_alert option allows devices to intercept packets not addressed to them directly as defined in RFC2113. 2. custom option is provided to configure user defined IP options as needed. The sum of all added custom options length SHOULD not exceed 40 bytes.
       type: object
       properties:
         choice:
@@ -7336,8 +7336,8 @@ components:
           $ref: '#/components/schemas/Flow.Ipv4Options.Type'
           x-field-uid: 1
         length:
+          $ref: '#/components/schemas/Flow.Ipv4Options.Length'
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Length'
         value:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value'
@@ -7355,6 +7355,37 @@ components:
         option_number:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionNumber'
+    Flow.Ipv4Options.Length:
+      description: "Length for custom options. The length of all IP options should\
+        \ not exceed 40 bytes. "
+      type: object
+      properties:
+        choice:
+          description: |-
+            auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        auto:
+          description: |-
+            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+          type: string
+          format: hex
+          default: '00000000'
+          x-field-uid: 2
+        value:
+          type: string
+          format: hex
+          default: '00000000'
+          x-field-uid: 3
     Flow.Ipv4.Priority:
       description: |-
         A container for ipv4 raw, tos, dscp ip priorities.
@@ -16007,73 +16038,6 @@ components:
           items:
             $ref: '#/components/schemas/Pattern.Flow.Ipv4.Dst.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Ipv4Options.Custom.Length.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 4
-          format: uint32
-          maximum: 255
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 255
-    Pattern.Flow.Ipv4Options.Custom.Length:
-      description: |-
-        Length of the option field
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 4
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 4
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Length.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Length.Counter'
-          x-field-uid: 6
     Pattern.Flow.Ipv4Options.Custom.Value.Counter:
       description: |-
         integer counter pattern
@@ -16099,7 +16063,7 @@ components:
           maximum: 65535
     Pattern.Flow.Ipv4Options.Custom.Value:
       description: |-
-        Length of the option field
+        Value of the option field
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7286,6 +7286,7 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Dst'
         options:
           type: array
+          minItems: 0
           items:
             $ref: '#/components/schemas/Flow.Ipv4.Options'
           x-field-uid: 15

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7325,36 +7325,36 @@ components:
           - router_alert
           - custom
         custom:
-          $ref: '#/components/schemas/Flow.Ipv4.Custom'
+          $ref: '#/components/schemas/Flow.Ipv4Options.Custom'
           x-field-uid: 3
-    Flow.Ipv4.Custom:
+    Flow.Ipv4Options.Custom:
       description: |-
         User defined IP options to be appended to the IPv4 header.
       type: object
       properties:
         type:
-          $ref: '#/components/schemas/Flow.Ipv4.Type'
+          $ref: '#/components/schemas/Flow.Ipv4Options.Type'
           x-field-uid: 1
         length:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Length'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Length'
         value:
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Value'
-    Flow.Ipv4.Type:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value'
+    Flow.Ipv4Options.Type:
       description: |-
         Type options for custom options.
       type: object
       properties:
         copied_flag:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.CopiedFlag'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.CopiedFlag'
         option_class:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionClass'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionClass'
         option_number:
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionNumber'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionNumber'
     Flow.Ipv4.Priority:
       description: |-
         A container for ipv4 raw, tos, dscp ip priorities.
@@ -16007,7 +16007,7 @@ components:
           items:
             $ref: '#/components/schemas/Pattern.Flow.Ipv4.Dst.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Ipv4.Custom.Length.Counter:
+    Pattern.Flow.Ipv4Options.Custom.Length.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -16030,7 +16030,7 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.Ipv4.Custom.Length:
+    Pattern.Flow.Ipv4Options.Custom.Length:
       description: |-
         Length of the option field
       type: object
@@ -16069,12 +16069,12 @@ components:
           default:
           - 4
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Length.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Length.Counter'
           x-field-uid: 6
-    Pattern.Flow.Ipv4.Custom.Value.Counter:
+    Pattern.Flow.Ipv4Options.Custom.Value.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -16097,7 +16097,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Ipv4.Custom.Value:
+    Pattern.Flow.Ipv4Options.Custom.Value:
       description: |-
         Length of the option field
       type: object
@@ -16136,12 +16136,12 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Value.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Custom.Value.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value.Counter'
           x-field-uid: 6
-    Pattern.Flow.Ipv4.Type.CopiedFlag.Counter:
+    Pattern.Flow.Ipv4Options.Type.CopiedFlag.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -16167,7 +16167,7 @@ components:
       x-constants:
         not_copied: 0
         copied: 1
-    Pattern.Flow.Ipv4.Type.CopiedFlag:
+    Pattern.Flow.Ipv4Options.Type.CopiedFlag:
       description: |-
         This flag indicates this option is copied to all fragments on fragmentations.
       type: object
@@ -16206,15 +16206,15 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.CopiedFlag.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.CopiedFlag.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.CopiedFlag.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.CopiedFlag.Counter'
           x-field-uid: 6
       x-constants:
         not_copied: 0
         copied: 1
-    Pattern.Flow.Ipv4.Type.OptionClass.Counter:
+    Pattern.Flow.Ipv4Options.Type.OptionClass.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -16241,9 +16241,9 @@ components:
         control: 0
         reserved: 3
         debugging_measurement: 2
-    Pattern.Flow.Ipv4.Type.OptionClass:
+    Pattern.Flow.Ipv4Options.Type.OptionClass:
       description: |-
-        Option class.
+        Option class [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
       type: object
       properties:
         choice:
@@ -16280,16 +16280,16 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionClass.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionClass.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionClass.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionClass.Counter'
           x-field-uid: 6
       x-constants:
         control: 0
         reserved: 3
         debugging_measurement: 2
-    Pattern.Flow.Ipv4.Type.OptionNumber.Counter:
+    Pattern.Flow.Ipv4Options.Type.OptionNumber.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -16312,7 +16312,7 @@ components:
           default: 1
           format: uint32
           maximum: 31
-    Pattern.Flow.Ipv4.Type.OptionNumber:
+    Pattern.Flow.Ipv4Options.Type.OptionNumber:
       description: |-
         Option Number [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
       type: object
@@ -16351,10 +16351,10 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionNumber.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionNumber.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4.Type.OptionNumber.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Type.OptionNumber.Counter'
           x-field-uid: 6
     Pattern.Flow.Ipv4.Priority.Raw.Counter:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7337,7 +7337,7 @@ components:
           - custom
         custom:
           $ref: '#/components/schemas/Flow.Ipv4Options.Custom'
-          x-field-uid: 3
+          x-field-uid: 2
     Flow.Ipv4Options.Custom:
       description: |-
         User defined IP options to be appended to the IPv4 header.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7308,8 +7308,19 @@ components:
             $ref: '#/components/schemas/Flow.Ipv4.Options'
           x-field-uid: 15
     Flow.Ipv4.Options:
-      description: |-
-        IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram.  It is encoded as a series of type, length and value attributes.  The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options. Currently IP options supported are: 1. router_alert option allows devices to intercept packets not addressed to them directly as defined in RFC2113. 2. custom option is provided to configure user defined IP options as needed. The sum of all added custom options length SHOULD not exceed 40 bytes.
+      description: "IPv4 options are optional extensions for the IPv4 header that\
+        \ can be utilised to provide additional information about the IPv4 datagram.\
+        \  It is encoded as a series of type, length and value attributes.  The IP\
+        \ header length MUST be increased to accommodate the extra bytes needed to\
+        \ encode the IP options. The length of the all options included to a IPv4\
+        \ header should not exceed 40 bytes since IPv4 Header length (4 bits) can\
+        \ at max specify 15 4-word octets for a total of 60 bytes which includes 20\
+        \ bytes needed for mandatory attributes of the IPv4 header. If the user adds\
+        \ multiples IPv4 options that exceeds 40 bytes and specify header length as\
+        \ \"auto\", implementation should throw error. Currently IP options supported\
+        \ are: 1. router_alert option allows devices to intercept packets not addressed\
+        \ to them directly as defined in RFC2113. 2. custom option is provided to\
+        \ configure user defined IP options as needed. "
       type: object
       properties:
         choice:
@@ -7339,8 +7350,14 @@ components:
           $ref: '#/components/schemas/Flow.Ipv4Options.Custom.Length'
           x-field-uid: 2
         value:
+          description: |-
+            Value of the option field should not excced 38 bytes since maximum 40 bytes can be added as options in IPv4 header. For type and length requires 2 bytes, so max of 38 bytes are expected. Maximum length of this attribute is 76 (38 * 2 hex character per byte).
+          type: string
+          format: hex
+          minLength: 0
+          maxLength: 76
+          default: '00000000'
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value'
     Flow.Ipv4Options.Custom.Type:
       description: |-
         Type options for custom options.
@@ -7356,8 +7373,8 @@ components:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.OptionNumber'
     Flow.Ipv4Options.Custom.Length:
-      description: "Length for custom options. The length of all IP options should\
-        \ not exceed 40 bytes. "
+      description: |-
+        Length for custom options.
       type: object
       properties:
         choice:
@@ -7377,14 +7394,14 @@ components:
         auto:
           description: |-
             The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
-          type: string
-          format: hex
-          default: '00000000'
+          type: integer
+          format: uint32
+          default: 0
           x-field-uid: 2
         value:
-          type: string
-          format: hex
-          default: '00000000'
+          type: integer
+          format: uint32
+          default: 0
           x-field-uid: 3
     Flow.Ipv4.Priority:
       description: |-
@@ -16038,73 +16055,6 @@ components:
           items:
             $ref: '#/components/schemas/Pattern.Flow.Ipv4.Dst.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Ipv4Options.Custom.Value.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: uint32
-          maximum: 65535
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 65535
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 65535
-    Pattern.Flow.Ipv4Options.Custom.Value:
-      description: |-
-        Value of the option field
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: uint32
-          maximum: 65535
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 65535
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Value.Counter'
-          x-field-uid: 6
     Pattern.Flow.Ipv4Options.Custom.Type.CopiedFlag.Counter:
       description: |-
         integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5396,10 +5396,10 @@ message FlowIpv4OptionsCustom {
   FlowIpv4OptionsCustomLength length = 2;
 
   // Value of the option field should not excced 38 bytes since maximum 40 bytes can be
-  // added as options in IPv4 header. For type and length requires 2 bytes, so max of
-  // 38 bytes are expected. Maximum length of this attribute is 76 (38 * 2 hex character
+  // added as options in IPv4 header. For type and length requires 2 bytes, hence maximum
+  // of 38 bytes are expected. Maximum length of this attribute is 76 (38 * 2 hex character
   // per byte).
-  // default = 00000000
+  // default = 0000
   optional string value = 3;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5346,7 +5346,7 @@ message FlowIpv4 {
   PatternFlowIpv4Dst dst = 14;
 
   // Description missing in models
-  FlowIpv4Options options = 15;
+  repeated FlowIpv4Options options = 15;
 }
 
 // IPv4 options are optional extensions for the IPv4 header that can be utilised to

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5364,7 +5364,8 @@ message FlowIpv4 {
 // accommodate the extra bytes needed to encode the IP options. Currently IP options
 // supported are: 1. router_alert option allows devices to intercept packets not addressed
 // to them directly as defined in RFC2113. 2. custom option is provided to configure
-// user defined IP options as needed.
+// user defined IP options as needed. The sum of all added custom options length SHOULD
+// not exceed 40 bytes.
 message FlowIpv4Options {
 
   message Choice {
@@ -5389,7 +5390,7 @@ message FlowIpv4OptionsCustom {
   FlowIpv4OptionsType type = 1;
 
   // Description missing in models
-  PatternFlowIpv4OptionsCustomLength length = 2;
+  FlowIpv4OptionsLength length = 2;
 
   // Description missing in models
   PatternFlowIpv4OptionsCustomValue value = 3;
@@ -5406,6 +5407,31 @@ message FlowIpv4OptionsType {
 
   // Description missing in models
   PatternFlowIpv4OptionsTypeOptionNumber option_number = 3;
+}
+
+// Length for custom options. The length of all IP options should not exceed 40 bytes.
+// 
+message FlowIpv4OptionsLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // The OTG implementation can provide a system generated value for this property. If
+  // the OTG is unable to generate a value the default value must be used.
+  // default = 00000000
+  optional string auto = 2;
+
+  // Description missing in models
+  // default = 00000000
+  optional string value = 3;
 }
 
 // A container for ipv4 raw, tos, dscp ip priorities.
@@ -11459,53 +11485,6 @@ message PatternFlowIpv4Dst {
 }
 
 // integer counter pattern
-message PatternFlowIpv4OptionsCustomLengthCounter {
-
-  // Description missing in models
-  // default = 4
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Length of the option field
-message PatternFlowIpv4OptionsCustomLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 4
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [4]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowIpv4OptionsCustomLengthCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowIpv4OptionsCustomLengthCounter decrement = 6;
-}
-
-// integer counter pattern
 message PatternFlowIpv4OptionsCustomValueCounter {
 
   // Description missing in models
@@ -11521,7 +11500,7 @@ message PatternFlowIpv4OptionsCustomValueCounter {
   optional uint32 count = 3;
 }
 
-// Length of the option field
+// Value of the option field
 message PatternFlowIpv4OptionsCustomValue {
 
   message Choice {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 0.13.1
+/* Open Traffic Generator API 0.13.2
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5361,11 +5361,14 @@ message FlowIpv4 {
 // IPv4 options are optional extensions for the IPv4 header that can be utilised to
 // provide additional information about the IPv4 datagram.  It is encoded as a series
 // of type, length and value attributes.  The IP header length MUST be increased to
-// accommodate the extra bytes needed to encode the IP options. Currently IP options
-// supported are: 1. router_alert option allows devices to intercept packets not addressed
-// to them directly as defined in RFC2113. 2. custom option is provided to configure
-// user defined IP options as needed. The sum of all added custom options length SHOULD
-// not exceed 40 bytes.
+// accommodate the extra bytes needed to encode the IP options. The length of the all
+// options included to a IPv4 header should not exceed 40 bytes since IPv4 Header length
+// (4 bits) can at max specify 15 4-word octets for a total of 60 bytes which includes
+// 20 bytes needed for mandatory attributes of the IPv4 header. If the user adds multiples
+// IPv4 options that exceeds 40 bytes and specify header length as auto, implementation
+// should throw error. Currently IP options supported are: 1. router_alert option allows
+// devices to intercept packets not addressed to them directly as defined in RFC2113.
+// 2. custom option is provided to configure user defined IP options as needed.
 message FlowIpv4Options {
 
   message Choice {
@@ -5392,8 +5395,12 @@ message FlowIpv4OptionsCustom {
   // Description missing in models
   FlowIpv4OptionsCustomLength length = 2;
 
-  // Description missing in models
-  PatternFlowIpv4OptionsCustomValue value = 3;
+  // Value of the option field should not excced 38 bytes since maximum 40 bytes can be
+  // added as options in IPv4 header. For type and length requires 2 bytes, so max of
+  // 38 bytes are expected. Maximum length of this attribute is 76 (38 * 2 hex character
+  // per byte).
+  // default = 00000000
+  optional string value = 3;
 }
 
 // Type options for custom options.
@@ -5409,8 +5416,7 @@ message FlowIpv4OptionsCustomType {
   PatternFlowIpv4OptionsCustomTypeOptionNumber option_number = 3;
 }
 
-// Length for custom options. The length of all IP options should not exceed 40 bytes.
-// 
+// Length for custom options.
 message FlowIpv4OptionsCustomLength {
 
   message Choice {
@@ -5426,12 +5432,12 @@ message FlowIpv4OptionsCustomLength {
 
   // The OTG implementation can provide a system generated value for this property. If
   // the OTG is unable to generate a value the default value must be used.
-  // default = 00000000
-  optional string auto = 2;
+  // default = 0
+  optional uint32 auto = 2;
 
   // Description missing in models
-  // default = 00000000
-  optional string value = 3;
+  // default = 0
+  optional uint32 value = 3;
 }
 
 // A container for ipv4 raw, tos, dscp ip priorities.
@@ -11482,53 +11488,6 @@ message PatternFlowIpv4Dst {
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
   repeated PatternFlowIpv4DstMetricTag metric_tags = 7;
-}
-
-// integer counter pattern
-message PatternFlowIpv4OptionsCustomValueCounter {
-
-  // Description missing in models
-  // default = 0
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Value of the option field
-message PatternFlowIpv4OptionsCustomValue {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowIpv4OptionsCustomValueCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowIpv4OptionsCustomValueCounter decrement = 6;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5362,9 +5362,9 @@ message FlowIpv4 {
 // provide additional information about the IPv4 datagram.  It is encoded as a series
 // of type, length and value attributes.  The IP header length MUST be increased to
 // accommodate the extra bytes needed to encode the IP options. Currently IP options
-// supported are: 1. router_alert Option allows devices to intercept packets not addressed
-// to them directly as defined in RFC2113. 2. custom option is provided for to be able
-// to configure user defined IP options as needed.
+// supported are: 1. router_alert option allows devices to intercept packets not addressed
+// to them directly as defined in RFC2113. 2. custom option is provided to configure
+// user defined IP options as needed.
 message FlowIpv4Options {
 
   message Choice {
@@ -5395,7 +5395,7 @@ message FlowIpv4Custom {
   PatternFlowIpv4CustomValue value = 3;
 }
 
-// Type options for custom TLV field in Options
+// Type options for custom options.
 message FlowIpv4Type {
 
   // Description missing in models
@@ -11568,7 +11568,7 @@ message PatternFlowIpv4TypeCopiedFlagCounter {
   optional uint32 count = 3;
 }
 
-// This flag indicates this option is copied to all fragments on fragmentations
+// This flag indicates this option is copied to all fragments on fragmentations.
 message PatternFlowIpv4TypeCopiedFlag {
 
   message Choice {
@@ -11615,7 +11615,7 @@ message PatternFlowIpv4TypeOptionClassCounter {
   optional uint32 count = 3;
 }
 
-// Option class
+// Option class.
 message PatternFlowIpv4TypeOptionClass {
 
   message Choice {
@@ -11662,7 +11662,7 @@ message PatternFlowIpv4TypeOptionNumberCounter {
   optional uint32 count = 3;
 }
 
-// Option Number
+// Option Number [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
 message PatternFlowIpv4TypeOptionNumber {
 
   message Choice {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5383,7 +5383,7 @@ message FlowIpv4Options {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  FlowIpv4OptionsCustom custom = 3;
+  FlowIpv4OptionsCustom custom = 2;
 }
 
 // User defined IP options to be appended to the IPv4 header.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5387,31 +5387,31 @@ message FlowIpv4Options {
 message FlowIpv4OptionsCustom {
 
   // Description missing in models
-  FlowIpv4OptionsType type = 1;
+  FlowIpv4OptionsCustomType type = 1;
 
   // Description missing in models
-  FlowIpv4OptionsLength length = 2;
+  FlowIpv4OptionsCustomLength length = 2;
 
   // Description missing in models
   PatternFlowIpv4OptionsCustomValue value = 3;
 }
 
 // Type options for custom options.
-message FlowIpv4OptionsType {
+message FlowIpv4OptionsCustomType {
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeCopiedFlag copied_flag = 1;
+  PatternFlowIpv4OptionsCustomTypeCopiedFlag copied_flag = 1;
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeOptionClass option_class = 2;
+  PatternFlowIpv4OptionsCustomTypeOptionClass option_class = 2;
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeOptionNumber option_number = 3;
+  PatternFlowIpv4OptionsCustomTypeOptionNumber option_number = 3;
 }
 
 // Length for custom options. The length of all IP options should not exceed 40 bytes.
 // 
-message FlowIpv4OptionsLength {
+message FlowIpv4OptionsCustomLength {
 
   message Choice {
     enum Enum {
@@ -11532,7 +11532,7 @@ message PatternFlowIpv4OptionsCustomValue {
 }
 
 // integer counter pattern
-message PatternFlowIpv4OptionsTypeCopiedFlagCounter {
+message PatternFlowIpv4OptionsCustomTypeCopiedFlagCounter {
 
   // Description missing in models
   // default = 0
@@ -11548,7 +11548,7 @@ message PatternFlowIpv4OptionsTypeCopiedFlagCounter {
 }
 
 // This flag indicates this option is copied to all fragments on fragmentations.
-message PatternFlowIpv4OptionsTypeCopiedFlag {
+message PatternFlowIpv4OptionsCustomTypeCopiedFlag {
 
   message Choice {
     enum Enum {
@@ -11572,14 +11572,14 @@ message PatternFlowIpv4OptionsTypeCopiedFlag {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeCopiedFlagCounter increment = 5;
+  PatternFlowIpv4OptionsCustomTypeCopiedFlagCounter increment = 5;
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeCopiedFlagCounter decrement = 6;
+  PatternFlowIpv4OptionsCustomTypeCopiedFlagCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowIpv4OptionsTypeOptionClassCounter {
+message PatternFlowIpv4OptionsCustomTypeOptionClassCounter {
 
   // Description missing in models
   // default = 0
@@ -11595,7 +11595,7 @@ message PatternFlowIpv4OptionsTypeOptionClassCounter {
 }
 
 // Option class [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
-message PatternFlowIpv4OptionsTypeOptionClass {
+message PatternFlowIpv4OptionsCustomTypeOptionClass {
 
   message Choice {
     enum Enum {
@@ -11619,14 +11619,14 @@ message PatternFlowIpv4OptionsTypeOptionClass {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeOptionClassCounter increment = 5;
+  PatternFlowIpv4OptionsCustomTypeOptionClassCounter increment = 5;
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeOptionClassCounter decrement = 6;
+  PatternFlowIpv4OptionsCustomTypeOptionClassCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowIpv4OptionsTypeOptionNumberCounter {
+message PatternFlowIpv4OptionsCustomTypeOptionNumberCounter {
 
   // Description missing in models
   // default = 0
@@ -11642,7 +11642,7 @@ message PatternFlowIpv4OptionsTypeOptionNumberCounter {
 }
 
 // Option Number [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
-message PatternFlowIpv4OptionsTypeOptionNumber {
+message PatternFlowIpv4OptionsCustomTypeOptionNumber {
 
   message Choice {
     enum Enum {
@@ -11666,10 +11666,10 @@ message PatternFlowIpv4OptionsTypeOptionNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeOptionNumberCounter increment = 5;
+  PatternFlowIpv4OptionsCustomTypeOptionNumberCounter increment = 5;
 
   // Description missing in models
-  PatternFlowIpv4OptionsTypeOptionNumberCounter decrement = 6;
+  PatternFlowIpv4OptionsCustomTypeOptionNumberCounter decrement = 6;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5379,33 +5379,33 @@ message FlowIpv4Options {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  FlowIpv4Custom custom = 3;
+  FlowIpv4OptionsCustom custom = 3;
 }
 
 // User defined IP options to be appended to the IPv4 header.
-message FlowIpv4Custom {
+message FlowIpv4OptionsCustom {
 
   // Description missing in models
-  FlowIpv4Type type = 1;
+  FlowIpv4OptionsType type = 1;
 
   // Description missing in models
-  PatternFlowIpv4CustomLength length = 2;
+  PatternFlowIpv4OptionsCustomLength length = 2;
 
   // Description missing in models
-  PatternFlowIpv4CustomValue value = 3;
+  PatternFlowIpv4OptionsCustomValue value = 3;
 }
 
 // Type options for custom options.
-message FlowIpv4Type {
+message FlowIpv4OptionsType {
 
   // Description missing in models
-  PatternFlowIpv4TypeCopiedFlag copied_flag = 1;
+  PatternFlowIpv4OptionsTypeCopiedFlag copied_flag = 1;
 
   // Description missing in models
-  PatternFlowIpv4TypeOptionClass option_class = 2;
+  PatternFlowIpv4OptionsTypeOptionClass option_class = 2;
 
   // Description missing in models
-  PatternFlowIpv4TypeOptionNumber option_number = 3;
+  PatternFlowIpv4OptionsTypeOptionNumber option_number = 3;
 }
 
 // A container for ipv4 raw, tos, dscp ip priorities.
@@ -11459,7 +11459,7 @@ message PatternFlowIpv4Dst {
 }
 
 // integer counter pattern
-message PatternFlowIpv4CustomLengthCounter {
+message PatternFlowIpv4OptionsCustomLengthCounter {
 
   // Description missing in models
   // default = 4
@@ -11475,7 +11475,7 @@ message PatternFlowIpv4CustomLengthCounter {
 }
 
 // Length of the option field
-message PatternFlowIpv4CustomLength {
+message PatternFlowIpv4OptionsCustomLength {
 
   message Choice {
     enum Enum {
@@ -11499,14 +11499,14 @@ message PatternFlowIpv4CustomLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowIpv4CustomLengthCounter increment = 5;
+  PatternFlowIpv4OptionsCustomLengthCounter increment = 5;
 
   // Description missing in models
-  PatternFlowIpv4CustomLengthCounter decrement = 6;
+  PatternFlowIpv4OptionsCustomLengthCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowIpv4CustomValueCounter {
+message PatternFlowIpv4OptionsCustomValueCounter {
 
   // Description missing in models
   // default = 0
@@ -11522,7 +11522,7 @@ message PatternFlowIpv4CustomValueCounter {
 }
 
 // Length of the option field
-message PatternFlowIpv4CustomValue {
+message PatternFlowIpv4OptionsCustomValue {
 
   message Choice {
     enum Enum {
@@ -11546,14 +11546,14 @@ message PatternFlowIpv4CustomValue {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowIpv4CustomValueCounter increment = 5;
+  PatternFlowIpv4OptionsCustomValueCounter increment = 5;
 
   // Description missing in models
-  PatternFlowIpv4CustomValueCounter decrement = 6;
+  PatternFlowIpv4OptionsCustomValueCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowIpv4TypeCopiedFlagCounter {
+message PatternFlowIpv4OptionsTypeCopiedFlagCounter {
 
   // Description missing in models
   // default = 0
@@ -11569,7 +11569,7 @@ message PatternFlowIpv4TypeCopiedFlagCounter {
 }
 
 // This flag indicates this option is copied to all fragments on fragmentations.
-message PatternFlowIpv4TypeCopiedFlag {
+message PatternFlowIpv4OptionsTypeCopiedFlag {
 
   message Choice {
     enum Enum {
@@ -11593,14 +11593,14 @@ message PatternFlowIpv4TypeCopiedFlag {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowIpv4TypeCopiedFlagCounter increment = 5;
+  PatternFlowIpv4OptionsTypeCopiedFlagCounter increment = 5;
 
   // Description missing in models
-  PatternFlowIpv4TypeCopiedFlagCounter decrement = 6;
+  PatternFlowIpv4OptionsTypeCopiedFlagCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowIpv4TypeOptionClassCounter {
+message PatternFlowIpv4OptionsTypeOptionClassCounter {
 
   // Description missing in models
   // default = 0
@@ -11615,8 +11615,8 @@ message PatternFlowIpv4TypeOptionClassCounter {
   optional uint32 count = 3;
 }
 
-// Option class.
-message PatternFlowIpv4TypeOptionClass {
+// Option class [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
+message PatternFlowIpv4OptionsTypeOptionClass {
 
   message Choice {
     enum Enum {
@@ -11640,14 +11640,14 @@ message PatternFlowIpv4TypeOptionClass {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowIpv4TypeOptionClassCounter increment = 5;
+  PatternFlowIpv4OptionsTypeOptionClassCounter increment = 5;
 
   // Description missing in models
-  PatternFlowIpv4TypeOptionClassCounter decrement = 6;
+  PatternFlowIpv4OptionsTypeOptionClassCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowIpv4TypeOptionNumberCounter {
+message PatternFlowIpv4OptionsTypeOptionNumberCounter {
 
   // Description missing in models
   // default = 0
@@ -11663,7 +11663,7 @@ message PatternFlowIpv4TypeOptionNumberCounter {
 }
 
 // Option Number [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
-message PatternFlowIpv4TypeOptionNumber {
+message PatternFlowIpv4OptionsTypeOptionNumber {
 
   message Choice {
     enum Enum {
@@ -11687,10 +11687,10 @@ message PatternFlowIpv4TypeOptionNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowIpv4TypeOptionNumberCounter increment = 5;
+  PatternFlowIpv4OptionsTypeOptionNumberCounter increment = 5;
 
   // Description missing in models
-  PatternFlowIpv4TypeOptionNumberCounter decrement = 6;
+  PatternFlowIpv4OptionsTypeOptionNumberCounter decrement = 6;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5349,7 +5349,13 @@ message FlowIpv4 {
   FlowIpv4Options options = 15;
 }
 
-// IP options for Router Alert Options (RFC 2113) and custom TLV
+// IPv4 options are optional extensions for the IPv4 header that can be utilised to
+// provide additional information about the IPv4 datagram.  It is encoded as a series
+// of type, length and value attributes.  The IP header length MUST be increased to
+// accomoddate the extra bytes needed to encode the IP options. Currently IP options
+// supported are: 1. router_alert Option allows devices to intercept packets not addressed
+// to them directly as defined in RFC2113. 2. custom option is provided for to be able
+// to configure user defined IP options as needed.
 message FlowIpv4Options {
 
   message Choice {
@@ -5364,13 +5370,10 @@ message FlowIpv4Options {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  PatternFlowIpv4OptionsRouterAlert router_alert = 2;
-
-  // Description missing in models
   FlowIpv4Custom custom = 3;
 }
 
-// IP options for custom TLV fields
+// User defined IP options to be appended to the IPv4 header.
 message FlowIpv4Custom {
 
   // Description missing in models
@@ -11325,78 +11328,6 @@ message PatternFlowIpv4Dst {
 }
 
 // integer counter pattern
-message PatternFlowIpv4OptionsRouterAlertCounter {
-
-  // Description missing in models
-  // default = 0
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Metric tag can be used to enable tracking portion of or all bits in a corresponding
-// header field for metrics per each applicable value. These would appear as tagged
-// metrics in corresponding flow metrics.
-message PatternFlowIpv4OptionsRouterAlertMetricTag {
-
-  // Name used to identify the metrics associated with the values applicable for configured
-  // offset and length inside corresponding header field
-  // required = true
-  optional string name = 1;
-
-  // Offset in bits relative to start of corresponding header field
-  // default = 0
-  optional uint32 offset = 2;
-
-  // Number of bits to track for metrics starting from configured offset of corresponding
-  // header field
-  // default = 16
-  optional uint32 length = 3;
-}
-
-// Router Alert Option can intercept packets not addressed to them directly
-message PatternFlowIpv4OptionsRouterAlert {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowIpv4OptionsRouterAlertCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowIpv4OptionsRouterAlertCounter decrement = 6;
-
-  // One or more metric tags can be used to enable tracking portion of or all bits in
-  // a corresponding header field for metrics per each applicable value. These would appear
-  // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowIpv4OptionsRouterAlertMetricTag metric_tags = 7;
-}
-
-// integer counter pattern
 message PatternFlowIpv4CustomLengthCounter {
 
   // Description missing in models
@@ -11410,26 +11341,6 @@ message PatternFlowIpv4CustomLengthCounter {
   // Description missing in models
   // default = 1
   optional uint32 count = 3;
-}
-
-// Metric tag can be used to enable tracking portion of or all bits in a corresponding
-// header field for metrics per each applicable value. These would appear as tagged
-// metrics in corresponding flow metrics.
-message PatternFlowIpv4CustomLengthMetricTag {
-
-  // Name used to identify the metrics associated with the values applicable for configured
-  // offset and length inside corresponding header field
-  // required = true
-  optional string name = 1;
-
-  // Offset in bits relative to start of corresponding header field
-  // default = 0
-  optional uint32 offset = 2;
-
-  // Number of bits to track for metrics starting from configured offset of corresponding
-  // header field
-  // default = 8
-  optional uint32 length = 3;
 }
 
 // Length of the option field
@@ -11461,11 +11372,6 @@ message PatternFlowIpv4CustomLength {
 
   // Description missing in models
   PatternFlowIpv4CustomLengthCounter decrement = 6;
-
-  // One or more metric tags can be used to enable tracking portion of or all bits in
-  // a corresponding header field for metrics per each applicable value. These would appear
-  // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowIpv4CustomLengthMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
@@ -11482,26 +11388,6 @@ message PatternFlowIpv4CustomValueCounter {
   // Description missing in models
   // default = 1
   optional uint32 count = 3;
-}
-
-// Metric tag can be used to enable tracking portion of or all bits in a corresponding
-// header field for metrics per each applicable value. These would appear as tagged
-// metrics in corresponding flow metrics.
-message PatternFlowIpv4CustomValueMetricTag {
-
-  // Name used to identify the metrics associated with the values applicable for configured
-  // offset and length inside corresponding header field
-  // required = true
-  optional string name = 1;
-
-  // Offset in bits relative to start of corresponding header field
-  // default = 0
-  optional uint32 offset = 2;
-
-  // Number of bits to track for metrics starting from configured offset of corresponding
-  // header field
-  // default = 16
-  optional uint32 length = 3;
 }
 
 // Length of the option field
@@ -11533,11 +11419,6 @@ message PatternFlowIpv4CustomValue {
 
   // Description missing in models
   PatternFlowIpv4CustomValueCounter decrement = 6;
-
-  // One or more metric tags can be used to enable tracking portion of or all bits in
-  // a corresponding header field for metrics per each applicable value. These would appear
-  // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowIpv4CustomValueMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
@@ -11554,26 +11435,6 @@ message PatternFlowIpv4TypeCopiedFlagCounter {
   // Description missing in models
   // default = 1
   optional uint32 count = 3;
-}
-
-// Metric tag can be used to enable tracking portion of or all bits in a corresponding
-// header field for metrics per each applicable value. These would appear as tagged
-// metrics in corresponding flow metrics.
-message PatternFlowIpv4TypeCopiedFlagMetricTag {
-
-  // Name used to identify the metrics associated with the values applicable for configured
-  // offset and length inside corresponding header field
-  // required = true
-  optional string name = 1;
-
-  // Offset in bits relative to start of corresponding header field
-  // default = 0
-  optional uint32 offset = 2;
-
-  // Number of bits to track for metrics starting from configured offset of corresponding
-  // header field
-  // default = 1
-  optional uint32 length = 3;
 }
 
 // This flag indicates this option is copied to all fragments on fragmentations
@@ -11605,11 +11466,6 @@ message PatternFlowIpv4TypeCopiedFlag {
 
   // Description missing in models
   PatternFlowIpv4TypeCopiedFlagCounter decrement = 6;
-
-  // One or more metric tags can be used to enable tracking portion of or all bits in
-  // a corresponding header field for metrics per each applicable value. These would appear
-  // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowIpv4TypeCopiedFlagMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
@@ -11626,26 +11482,6 @@ message PatternFlowIpv4TypeOptionClassCounter {
   // Description missing in models
   // default = 1
   optional uint32 count = 3;
-}
-
-// Metric tag can be used to enable tracking portion of or all bits in a corresponding
-// header field for metrics per each applicable value. These would appear as tagged
-// metrics in corresponding flow metrics.
-message PatternFlowIpv4TypeOptionClassMetricTag {
-
-  // Name used to identify the metrics associated with the values applicable for configured
-  // offset and length inside corresponding header field
-  // required = true
-  optional string name = 1;
-
-  // Offset in bits relative to start of corresponding header field
-  // default = 0
-  optional uint32 offset = 2;
-
-  // Number of bits to track for metrics starting from configured offset of corresponding
-  // header field
-  // default = 2
-  optional uint32 length = 3;
 }
 
 // Option class
@@ -11677,11 +11513,6 @@ message PatternFlowIpv4TypeOptionClass {
 
   // Description missing in models
   PatternFlowIpv4TypeOptionClassCounter decrement = 6;
-
-  // One or more metric tags can be used to enable tracking portion of or all bits in
-  // a corresponding header field for metrics per each applicable value. These would appear
-  // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowIpv4TypeOptionClassMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
@@ -11698,26 +11529,6 @@ message PatternFlowIpv4TypeOptionNumberCounter {
   // Description missing in models
   // default = 1
   optional uint32 count = 3;
-}
-
-// Metric tag can be used to enable tracking portion of or all bits in a corresponding
-// header field for metrics per each applicable value. These would appear as tagged
-// metrics in corresponding flow metrics.
-message PatternFlowIpv4TypeOptionNumberMetricTag {
-
-  // Name used to identify the metrics associated with the values applicable for configured
-  // offset and length inside corresponding header field
-  // required = true
-  optional string name = 1;
-
-  // Offset in bits relative to start of corresponding header field
-  // default = 0
-  optional uint32 offset = 2;
-
-  // Number of bits to track for metrics starting from configured offset of corresponding
-  // header field
-  // default = 5
-  optional uint32 length = 3;
 }
 
 // Option Number
@@ -11749,11 +11560,6 @@ message PatternFlowIpv4TypeOptionNumber {
 
   // Description missing in models
   PatternFlowIpv4TypeOptionNumberCounter decrement = 6;
-
-  // One or more metric tags can be used to enable tracking portion of or all bits in
-  // a corresponding header field for metrics per each applicable value. These would appear
-  // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowIpv4TypeOptionNumberMetricTag metric_tags = 7;
 }
 
 // integer counter pattern

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -151,7 +151,7 @@ components:
               x-field-uid: 2
         custom:
           $ref: '#/components/schemas/Flow.Ipv4Options.Custom'
-          x-field-uid: 3
+          x-field-uid: 2
     Flow.Ipv4Options.Custom:
       description: >-
         User defined IP options to be appended to the IPv4 header.

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -122,6 +122,101 @@ components:
             default: 0.0.0.0
             features: [count, metric_tags]
           x-field-uid: 14
+        options:
+          $ref: '#/components/schemas/Flow.Ipv4.Options'
+          x-field-uid: 15
+    Flow.Ipv4.Options:
+      description: >-
+        IP options for Router Alert Options (RFC 2113) and custom TLV
+      type: object
+      properties:
+        choice:
+          type: string
+          default: router_alert
+          x-field-uid: 1
+          x-enum:
+            router_alert:
+              x-field-uid: 1
+            custom:
+              x-field-uid: 2
+        router_alert:
+          x-field-pattern:
+            description: >-
+              Router Alert Option can intercept packets not addressed to them directly
+            format: integer
+            length: 16
+            default: 0
+            features: [count, metric_tags]
+          x-field-uid: 2
+        custom:
+          $ref: '#/components/schemas/Flow.Ipv4.Custom'
+          x-field-uid: 3
+    Flow.Ipv4.Custom:
+      description: >-
+        IP options for custom TLV fields
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/Flow.Ipv4.Type'
+          x-field-uid: 1
+        length:
+          x-field-pattern:
+            description: >-
+              Length of the option field
+            format: integer
+            length: 8
+            default: 4
+            features: [count, metric_tags]
+          x-field-uid: 2
+        value:
+          x-field-pattern:
+            description: >-
+              Length of the option field
+            format: integer
+            length: 16
+            default: 0
+            features: [count, metric_tags]
+          x-field-uid: 3
+    Flow.Ipv4.Type:
+      description: >-
+        Type options for custom TLV field in Options
+      type: object
+      properties:
+        copied_flag:
+          x-field-pattern:
+            x-constants:
+              not_copied: 0
+              copied: 1
+            description: >-
+              This flag indicates this option is copied to all fragments on fragmentations
+            format: integer
+            length: 1
+            default: 0
+            features: [count, metric_tags]
+          x-field-uid: 1
+        option_class:
+          x-field-pattern:
+            x-constants:
+              control: 0
+              reserved: 1
+              debugging_measurement: 2
+              reserved: 3
+            description: >-
+              Option class
+            format: integer
+            length: 2
+            default: 0
+            features: [count, metric_tags]
+          x-field-uid: 2
+        option_number:
+          x-field-pattern:
+            description: >-
+              Option Number
+            format: integer
+            length: 5
+            default: 0
+            features: [count, metric_tags]
+          x-field-uid: 3
     Flow.Ipv4.Priority:
       description: >-
         A container for ipv4 raw, tos, dscp ip priorities.

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -133,9 +133,11 @@ components:
         IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram. 
         It is encoded as a series of type, length and value attributes. 
         The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options.
+        The length of the all options included to a IPv4 header should not exceed 40 bytes since IPv4 Header length (4 bits) can at max specify 15 4-word octets for a total of 60 bytes which includes 20 bytes needed for mandatory attributes of the IPv4 header.
+        If the user adds multiples IPv4 options that exceeds 40 bytes and specify header length as "auto", implementation should throw error.
         Currently IP options supported are:
         1. router_alert option allows devices to intercept packets not addressed to them directly as defined in RFC2113.
-        2. custom option is provided to configure user defined IP options as needed. The sum of all added custom options length SHOULD not exceed 40 bytes.
+        2. custom option is provided to configure user defined IP options as needed. 
       type: object
       properties:
         choice:
@@ -162,13 +164,15 @@ components:
           $ref: '#/components/schemas/Flow.Ipv4Options.Custom.Length'
           x-field-uid: 2
         value:
-          x-field-pattern:
-            description: >-
-              Value of the option field
-            format: integer
-            length: 16
-            default: 0
-            features: [count]
+          description: >-
+            Value of the option field should not excced 38 bytes since maximum 40 bytes can be added as options in IPv4 header.
+            For type and length requires 2 bytes, so max of 38 bytes are expected.
+            Maximum length of this attribute is 76 (38 * 2 hex character per byte).
+          type: string
+          format: hex
+          minLength: 0
+          maxLength: 76
+          default: '00000000'
           x-field-uid: 3
     Flow.Ipv4Options.Custom.Type:
       description: >-
@@ -212,7 +216,7 @@ components:
           x-field-uid: 3
     Flow.Ipv4Options.Custom.Length:
       description: >-
-        Length for custom options. The length of all IP options should not exceed 40 bytes. 
+        Length for custom options.
       type: object
       properties:
         choice:
@@ -229,14 +233,14 @@ components:
           description: >-
             The OTG implementation can provide a system generated value for this property.
             If the OTG is unable to generate a value the default value must be used.
-          type: string
-          format: hex
-          default: '00000000'
+          type: integer
+          format: uint32
+          default: 0
           x-field-uid: 2
         value:
-          type: string
-          format: hex
-          default: '00000000'
+          type: integer
+          format: uint32
+          default: 0
           x-field-uid: 3
     Flow.Ipv4.Priority:
       description: >-

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -156,10 +156,10 @@ components:
       type: object
       properties:
         type:
-          $ref: '#/components/schemas/Flow.Ipv4Options.Type'
+          $ref: '#/components/schemas/Flow.Ipv4Options.Custom.Type'
           x-field-uid: 1
         length:
-          $ref: '#/components/schemas/Flow.Ipv4Options.Length'
+          $ref: '#/components/schemas/Flow.Ipv4Options.Custom.Length'
           x-field-uid: 2
         value:
           x-field-pattern:
@@ -170,7 +170,7 @@ components:
             default: 0
             features: [count]
           x-field-uid: 3
-    Flow.Ipv4Options.Type:
+    Flow.Ipv4Options.Custom.Type:
       description: >-
         Type options for custom options.
       type: object
@@ -210,7 +210,7 @@ components:
             default: 0
             features: [count]
           x-field-uid: 3
-    Flow.Ipv4Options.Length:
+    Flow.Ipv4Options.Custom.Length:
       description: >-
         Length for custom options. The length of all IP options should not exceed 40 bytes. 
       type: object

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -166,13 +166,13 @@ components:
         value:
           description: >-
             Value of the option field should not excced 38 bytes since maximum 40 bytes can be added as options in IPv4 header.
-            For type and length requires 2 bytes, so max of 38 bytes are expected.
+            For type and length requires 2 bytes, hence maximum of 38 bytes are expected.
             Maximum length of this attribute is 76 (38 * 2 hex character per byte).
           type: string
           format: hex
           minLength: 0
           maxLength: 76
-          default: '00000000'
+          default: '0000'
           x-field-uid: 3
     Flow.Ipv4Options.Custom.Type:
       description: >-

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -135,7 +135,7 @@ components:
         The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options.
         Currently IP options supported are:
         1. router_alert option allows devices to intercept packets not addressed to them directly as defined in RFC2113.
-        2. custom option is provided to configure user defined IP options as needed.
+        2. custom option is provided to configure user defined IP options as needed. The sum of all added custom options length SHOULD not exceed 40 bytes.
       type: object
       properties:
         choice:
@@ -159,18 +159,12 @@ components:
           $ref: '#/components/schemas/Flow.Ipv4Options.Type'
           x-field-uid: 1
         length:
-          x-field-pattern:
-            description: >-
-              Length of the option field
-            format: integer
-            length: 8
-            default: 4
-            features: [count]
+          $ref: '#/components/schemas/Flow.Ipv4Options.Length'
           x-field-uid: 2
         value:
           x-field-pattern:
             description: >-
-              Length of the option field
+              Value of the option field
             format: integer
             length: 16
             default: 0
@@ -215,6 +209,34 @@ components:
             length: 5
             default: 0
             features: [count]
+          x-field-uid: 3
+    Flow.Ipv4Options.Length:
+      description: >-
+        Length for custom options. The length of all IP options should not exceed 40 bytes. 
+      type: object
+      properties:
+        choice:
+          description: auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+        auto:
+          description: >-
+            The OTG implementation can provide a system generated value for this property.
+            If the OTG is unable to generate a value the default value must be used.
+          type: string
+          format: hex
+          default: '00000000'
+          x-field-uid: 2
+        value:
+          type: string
+          format: hex
+          default: '00000000'
           x-field-uid: 3
     Flow.Ipv4.Priority:
       description: >-

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -129,7 +129,7 @@ components:
       description: >-
         IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram. 
         It is encoded as a series of type, length and value attributes. 
-        The IP header length MUST be increased to accomoddate the extra bytes needed to encode the IP options.
+        The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options.
         Currently IP options supported are:
         1. router_alert Option allows devices to intercept packets not addressed to them directly as defined in RFC2113.
         2. custom option is provided for to be able to configure user defined IP options as needed.

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -148,15 +148,15 @@ components:
             custom:
               x-field-uid: 2
         custom:
-          $ref: '#/components/schemas/Flow.Ipv4.Custom'
+          $ref: '#/components/schemas/Flow.Ipv4Options.Custom'
           x-field-uid: 3
-    Flow.Ipv4.Custom:
+    Flow.Ipv4Options.Custom:
       description: >-
         User defined IP options to be appended to the IPv4 header.
       type: object
       properties:
         type:
-          $ref: '#/components/schemas/Flow.Ipv4.Type'
+          $ref: '#/components/schemas/Flow.Ipv4Options.Type'
           x-field-uid: 1
         length:
           x-field-pattern:
@@ -176,7 +176,7 @@ components:
             default: 0
             features: [count]
           x-field-uid: 3
-    Flow.Ipv4.Type:
+    Flow.Ipv4Options.Type:
       description: >-
         Type options for custom options.
       type: object
@@ -201,7 +201,7 @@ components:
               debugging_measurement: 2
               reserved: 3
             description: >-
-              Option class.
+              Option class [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
             format: integer
             length: 2
             default: 0

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -127,7 +127,12 @@ components:
           x-field-uid: 15
     Flow.Ipv4.Options:
       description: >-
-        IP options for Router Alert Options (RFC 2113) and custom TLV
+        IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram. 
+        It is encoded as a series of type, length and value attributes. 
+        The IP header length MUST be increased to accomoddate the extra bytes needed to encode the IP options.
+        Currently IP options supported are:
+        1. router_alert Option allows devices to intercept packets not addressed to them directly as defined in RFC2113.
+        2. custom option is provided for to be able to configure user defined IP options as needed.
       type: object
       properties:
         choice:
@@ -139,21 +144,12 @@ components:
               x-field-uid: 1
             custom:
               x-field-uid: 2
-        router_alert:
-          x-field-pattern:
-            description: >-
-              Router Alert Option can intercept packets not addressed to them directly
-            format: integer
-            length: 16
-            default: 0
-            features: [count, metric_tags]
-          x-field-uid: 2
         custom:
           $ref: '#/components/schemas/Flow.Ipv4.Custom'
           x-field-uid: 3
     Flow.Ipv4.Custom:
       description: >-
-        IP options for custom TLV fields
+        User defined IP options to be appended to the IPv4 header.
       type: object
       properties:
         type:
@@ -166,7 +162,7 @@ components:
             format: integer
             length: 8
             default: 4
-            features: [count, metric_tags]
+            features: [count]
           x-field-uid: 2
         value:
           x-field-pattern:
@@ -175,7 +171,7 @@ components:
             format: integer
             length: 16
             default: 0
-            features: [count, metric_tags]
+            features: [count]
           x-field-uid: 3
     Flow.Ipv4.Type:
       description: >-
@@ -192,7 +188,7 @@ components:
             format: integer
             length: 1
             default: 0
-            features: [count, metric_tags]
+            features: [count]
           x-field-uid: 1
         option_class:
           x-field-pattern:
@@ -206,7 +202,7 @@ components:
             format: integer
             length: 2
             default: 0
-            features: [count, metric_tags]
+            features: [count]
           x-field-uid: 2
         option_number:
           x-field-pattern:
@@ -215,7 +211,7 @@ components:
             format: integer
             length: 5
             default: 0
-            features: [count, metric_tags]
+            features: [count]
           x-field-uid: 3
     Flow.Ipv4.Priority:
       description: >-

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -134,8 +134,8 @@ components:
         It is encoded as a series of type, length and value attributes. 
         The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options.
         Currently IP options supported are:
-        1. router_alert Option allows devices to intercept packets not addressed to them directly as defined in RFC2113.
-        2. custom option is provided for to be able to configure user defined IP options as needed.
+        1. router_alert option allows devices to intercept packets not addressed to them directly as defined in RFC2113.
+        2. custom option is provided to configure user defined IP options as needed.
       type: object
       properties:
         choice:
@@ -178,7 +178,7 @@ components:
           x-field-uid: 3
     Flow.Ipv4.Type:
       description: >-
-        Type options for custom TLV field in Options
+        Type options for custom options.
       type: object
       properties:
         copied_flag:
@@ -187,7 +187,7 @@ components:
               not_copied: 0
               copied: 1
             description: >-
-              This flag indicates this option is copied to all fragments on fragmentations
+              This flag indicates this option is copied to all fragments on fragmentations.
             format: integer
             length: 1
             default: 0
@@ -201,7 +201,7 @@ components:
               debugging_measurement: 2
               reserved: 3
             description: >-
-              Option class
+              Option class.
             format: integer
             length: 2
             default: 0
@@ -210,7 +210,7 @@ components:
         option_number:
           x-field-pattern:
             description: >-
-              Option Number
+              Option Number [Ref:https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1].
             format: integer
             length: 5
             default: 0

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -123,7 +123,9 @@ components:
             features: [count, metric_tags]
           x-field-uid: 14
         options:
-          $ref: '#/components/schemas/Flow.Ipv4.Options'
+          type: array
+          items:
+            $ref: '#/components/schemas/Flow.Ipv4.Options'
           x-field-uid: 15
     Flow.Ipv4.Options:
       description: >-

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -124,6 +124,7 @@ components:
           x-field-uid: 14
         options:
           type: array
+          minItems: 0
           items:
             $ref: '#/components/schemas/Flow.Ipv4.Options'
           x-field-uid: 15


### PR DESCRIPTION
ReDocly link: 
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-ip-options/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config)

( New object at : set_config/flows/packet/ipv4/options )

[IPv4 RFC: RFC791](https://datatracker.ietf.org/doc/html/rfc791)
[Router Alert Option RFC: RFC2113](https://datatracker.ietf.org/doc/html/rfc2113)
[IPv4 Options parameters](https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-1)

Objective:  IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram. It is encoded as a series of type, length and value attributes. The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options. 
Currently IP options supported are: 
1. router_alert Option allows devices to intercept packets not addressed to them directly as defined in RFC2113. 
2. custom option is provided for to be able to configure user defined IP options as needed.
IPv4 Options is an array option objects.
To support RSVP control packet, router alert option is required in IP header.

Sample IPv4 Options (Router Alert and Custom):

```
        srcIP := "10.10.0.1"
	dstIP := "10.10.0.2"

	config := gosnappi.NewConfig()
	// add ports
	p1 := config.Ports().Add().SetName("p1").SetLocation("eth1")
	p2 := config.Ports().Add().SetName("p2").SetLocation("eth2")

	f1 := config.Flows().Items()[0]
	f1.SetName("f1:p1->p2").
		TxRx().Port().SetTxName(p1.Name()).SetRxName(p2.Name())
	f1.Duration().FixedPackets().SetPackets(100)
	f1.Rate().SetPps(10)

	f1.Packet().Add().Ethernet()
	ip := f1.Packet().Add().Ipv4()

	ip.Src().SetChoice("value").SetValue(srcIP)
	ip.Dst().SetChoice("value").SetValue(dstIP)

	// Sample of router_alert option:
	ip.Options().Add().SetChoice("router_alert")

	// Sample of user defined custom TLV options (Stream ID)
	ipOptionCustom := ip.Options().Add().SetChoice("custom")
	ipOptionCustom.Custom().Type().CopiedFlag().SetChoice("value").SetValue(0)
	ipOptionCustom.Custom().Type().OptionClass().SetChoice("value").SetValue(0)
	ipOptionCustom.Custom().Type().OptionNumber().SetChoice("value").SetValue(8)

	ipOptionCustom.Custom().Length().SetChoice("value").SetValue(4)
	ipOptionCustom.Custom().SetValue("0088")
```
