### PR TITLE
RSVP data packet header (path message)

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7871,22 +7871,16 @@ components:
             The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
+          maximum: 65535
           default: 0
           x-field-uid: 2
         value:
           type: integer
           format: uint32
+          maximum: 65535
           default: 0
           x-field-uid: 3
     Flow.RSVP.Message:
-      description: |-
-        RSVP Message type. Currently only "path" message type is supported.
-      type: object
-      properties:
-        message_type:
-          $ref: '#/components/schemas/Flow.RSVP.MessageType'
-          x-field-uid: 1
-    Flow.RSVP.MessageType:
       type: object
       properties:
         choice:
@@ -7903,14 +7897,14 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: |-
-        "path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
+        "path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
       type: object
       properties:
         objects:
           description: |-
-            "path" message required atleast SESSION, RSVP_HOP and TIME_VALUES objects.
+            "path" message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
           type: array
-          minItems: 3
+          minItems: 6
           items:
             $ref: '#/components/schemas/Flow.RSVP.PathObjects'
           x-field-uid: 1
@@ -7920,11 +7914,46 @@ components:
       type: object
       properties:
         length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4, and at least 4.
+          $ref: '#/components/schemas/Flow.RSVPPathObject.Length'
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjects.Length'
         class_num:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClass'
           x-field-uid: 2
+    Flow.RSVPPathObject.Length:
+      type: object
+      properties:
+        choice:
+          description: |-
+            auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        auto:
+          description: |-
+            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          minimum: 4
+          maximum: 65535
+          default: 4
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          minimum: 4
+          maximum: 65535
+          default: 4
+          x-field-uid: 3
     Flow.RSVP.PathObjectsClass:
       description: |-
         The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "path" message type. "path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored in above options.
@@ -8020,25 +8049,25 @@ components:
           enum:
           - lsp_tunnel_ipv4
         lsp_tunnel_ipv4:
-          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionLspTunnelIpv4'
+          $ref: '#/components/schemas/Flow.RSVP.PathSessionLspTunnelIpv4'
           x-field-uid: 2
-    Flow.RSVP.PathObjectsSessionLspTunnelIpv4:
+    Flow.RSVP.PathSessionLspTunnelIpv4:
       description: |-
         Class = SESSION, LSP_TUNNEL_IPv4 C-Type = 7.
       type: object
       properties:
         ipv4_tunnel_end_point_address:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress'
         reserved:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Reserved'
         tunnel_id:
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.TunnelId'
         extended_tunnel_id:
           x-field-uid: 4
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId'
     Flow.RSVP.PathObjectsClassRsvpHop:
       description: |-
         C-Type is specific to a class num.
@@ -8062,19 +8091,19 @@ components:
           enum:
           - ipv4
         ipv4:
-          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRsvpHopIpv4'
+          $ref: '#/components/schemas/Flow.RSVP.PathRsvpHopIpv4'
           x-field-uid: 2
-    Flow.RSVP.PathObjectsClassRsvpHopIpv4:
+    Flow.RSVP.PathRsvpHopIpv4:
       description: |-
         IPv4 RSVP_HOP object: Class = 3, C-Type = 1
       type: object
       properties:
         ipv4_next_previous_hop_address:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress'
         logical_interface_handle:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.LogicalInterfaceHandle'
     Flow.RSVP.PathObjectsClassTimeValues:
       description: |-
         C-Type is specific to a class num.
@@ -8098,16 +8127,16 @@ components:
           enum:
           - type_1_time_value
         type_1_time_value:
-          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassTimeValuesType1'
+          $ref: '#/components/schemas/Flow.RSVP.PathTimeValuesType1'
           x-field-uid: 2
-    Flow.RSVP.PathObjectsClassTimeValuesType1:
+    Flow.RSVP.PathTimeValuesType1:
       description: |-
         TIME_VALUES Object: Class = 5, C-Type = 1
       type: object
       properties:
         refresh_period_r:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathTimeValuesType1.RefreshPeriodR'
     Flow.RSVP.PathObjectsClassExplicitRoute:
       description: |-
         C-Type is specific to a class num.
@@ -8118,7 +8147,7 @@ components:
           x-field-uid: 1
     Flow.RSVP.PathObjectsClassExplicitRouteCType:
       description: |-
-        Object for EXPLICIT_ROUTE class. Currently supported c-type is Type 1 Explicit Route (1).
+        Object for EXPLICIT_ROUTE class and c-type is Type 1 Explicit Route (1).
       type: object
       properties:
         choice:
@@ -8184,10 +8213,12 @@ components:
           x-field-uid: 1
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit'
         length:
-          x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length'
+          description: |-
+            The Length contains the total length of the subobject in bytes,including L ,Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+          $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
+          x-field-uid: 2
         ipv4_address:
-          x-field-uid: 4
+          x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address'
         prefix:
           description: |-
@@ -8197,7 +8228,7 @@ components:
           minimum: 1
           maximum: 32
           default: 32
-          x-field-uid: 5
+          x-field-uid: 4
     Flow.RSVP.PathExplicitRouteType1FourByteASNumber:
       description: |-
         Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: 4-byte AS number, C-Type: 32
@@ -8207,10 +8238,12 @@ components:
           x-field-uid: 1
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit'
         length:
-          x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length'
+          description: |-
+            The Length contains the total length of the subobject in bytes,including L ,Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+          $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
+          x-field-uid: 2
         reserved:
-          x-field-uid: 4
+          x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved'
         as_number:
           description: |-
@@ -8219,7 +8252,38 @@ components:
           format: uint32
           default: 0
           maximum: 65535
-          x-field-uid: 5
+          x-field-uid: 4
+    Flow.RSVPExplicitRoute.Length:
+      type: object
+      properties:
+        choice:
+          description: |-
+            auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        auto:
+          description: |-
+            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 8
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 8
+          x-field-uid: 3
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: |-
         C-Type is specific to a class num.
@@ -8309,8 +8373,10 @@ components:
           maximum: 7
           x-field-uid: 2
         flags:
+          description: |-
+            0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+          $ref: '#/components/schemas/Flow.RSVPLspTunnel.Flag'
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionAttributeLspTunnel.Flags'
         name_length:
           description: "The length of the display string before padding, in bytes.\
             \          "
@@ -8385,8 +8451,10 @@ components:
           maximum: 7
           x-field-uid: 5
         flags:
+          description: |-
+            0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+          $ref: '#/components/schemas/Flow.RSVPLspTunnel.Flag'
           x-field-uid: 6
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionAttributeLspTunnelRa.Flags'
         name_length:
           description: "The length of the display string before padding, in bytes.\
             \          "
@@ -8401,6 +8469,24 @@ components:
           minLength: 0
           maxLength: 254
           x-field-uid: 8
+    Flow.RSVPLspTunnel.Flag:
+      type: object
+      properties:
+        choice:
+          type: string
+          default: local_protection_desired
+          x-enum:
+            local_protection_desired:
+              x-field-uid: 1
+            label_recording_desired:
+              x-field-uid: 2
+            se_style_desired:
+              x-field-uid: 3
+          x-field-uid: 1
+          enum:
+          - local_protection_desired
+          - label_recording_desired
+          - se_style_desired
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: |-
         C-Type is specific to a class num.
@@ -8600,30 +8686,51 @@ components:
       type: object
       properties:
         length:
-          x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length'
+          description: |-
+            The Length contains the total length of the subobject in bytes, including the Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+          $ref: '#/components/schemas/Flow.RSVPRouteRecord.Length'
+          x-field-uid: 1
         ipv4_address:
-          x-field-uid: 3
+          x-field-uid: 2
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address'
         prefix_length:
-          x-field-uid: 4
+          x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.PrefixLength'
         flags:
-          x-field-uid: 5
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Flags'
+          description: |-
+            0x01  local_protection_available, 0x02  local_protection_in_use
+          $ref: '#/components/schemas/Flow.RSVPRecordRouteIPv4.Flag'
+          x-field-uid: 4
+    Flow.RSVPRecordRouteIPv4.Flag:
+      type: object
+      properties:
+        choice:
+          type: string
+          default: local_protection_available
+          x-enum:
+            local_protection_available:
+              x-field-uid: 1
+            local_protection_in_use:
+              x-field-uid: 2
+          x-field-uid: 1
+          enum:
+          - local_protection_available
+          - local_protection_in_use
     Flow.RSVP.PathRecordRouteType1Label:
       description: |-
         Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: Label, C-Type: 3
       type: object
       properties:
         length:
-          x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Length'
+          description: |-
+            The Length contains the total length of the subobject in bytes, including the Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+          $ref: '#/components/schemas/Flow.RSVPRouteRecord.Length'
+          x-field-uid: 1
         flags:
-          x-field-uid: 3
+          x-field-uid: 2
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Flags'
         c_type:
-          x-field-uid: 4
+          x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.CType'
         contents_of_label_obejct:
           description: |-
@@ -8631,7 +8738,38 @@ components:
           type: string
           format: hex
           default: '00'
-          x-field-uid: 5
+          x-field-uid: 4
+    Flow.RSVPRouteRecord.Length:
+      type: object
+      properties:
+        choice:
+          description: |-
+            auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        auto:
+          description: |-
+            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 8
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 8
+          x-field-uid: 3
     Flow.RSVP.PathObjectsCustom:
       type: object
       description: |-
@@ -29168,74 +29306,7 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Rsvp.Reserved.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathObjects.Length.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 4
-          format: uint32
-          maximum: 65535
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 65535
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 65535
-    Pattern.Flow.RSVP.PathObjects.Length:
-      description: "Contains the total length of the object including the object's\
-        \ header, measured in bytes.  Objects must be aligned to 32-bit words. "
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 4
-          format: uint32
-          maximum: 65535
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 65535
-          x-field-uid: 3
-          default:
-          - 4
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjects.Length.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjects.Length.Counter'
-          x-field-uid: 6
-    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter:
+    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter:
       description: |-
         ipv4 counter pattern
       type: object
@@ -29255,7 +29326,7 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress:
+    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress:
       description: |-
         IPv4 address of the egress node for the tunnel.
       type: object
@@ -29292,12 +29363,12 @@ components:
           default:
           - 0.0.0.0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved.Counter:
+    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Reserved.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -29320,7 +29391,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved:
+    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Reserved:
       description: |-
         Reserved field, MUST be zero.
       type: object
@@ -29359,12 +29430,12 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Reserved.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.Reserved.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId.Counter:
+    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.TunnelId.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -29387,7 +29458,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId:
+    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.TunnelId:
       description: |-
         A 16-bit identifier used in the SESSION that remains constant over the life of the tunnel.
       type: object
@@ -29426,12 +29497,12 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.TunnelId.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.TunnelId.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId.Counter:
+    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -29451,7 +29522,7 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId:
+    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId:
       description: |-
         A 32-bit identifier used in the SESSION that remains constant over the life of the tunnel. Normally set to all zeros. Ingress nodes that wish to narrow the scope of a SESSION to the ingress-egress pair may place their IPv4 address here as a globally unique identifier.
       type: object
@@ -29488,12 +29559,12 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter:
+    Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter:
       description: |-
         ipv4 counter pattern
       type: object
@@ -29513,7 +29584,7 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress:
+    Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress:
       description: |-
         The IPv4 address of the interface through which the last RSVP-knowledgeable hop forwarded this message.
       type: object
@@ -29550,12 +29621,12 @@ components:
           default:
           - 0.0.0.0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle.Counter:
+    Pattern.Flow.RSVP.PathRsvpHopIpv4.LogicalInterfaceHandle.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -29575,7 +29646,7 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle:
+    Pattern.Flow.RSVP.PathRsvpHopIpv4.LogicalInterfaceHandle:
       description: |-
         Logical Interface Handle (LIH) is used to distinguish logical outgoing interfaces. A node receiving an LIH in a Path message saves its value and returns it in the HOP objects of subsequent Resv messages sent to the node that originated the LIH. The LIH should be identically zero if there is no logical interface handle.
       type: object
@@ -29612,12 +29683,12 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.LogicalInterfaceHandle.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.LogicalInterfaceHandle.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR.Counter:
+    Pattern.Flow.RSVP.PathTimeValuesType1.RefreshPeriodR.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -29637,7 +29708,7 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR:
+    Pattern.Flow.RSVP.PathTimeValuesType1.RefreshPeriodR:
       description: |-
         The refresh timeout period R used to generate this message;in milliseconds.
       type: object
@@ -29674,10 +29745,10 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathTimeValuesType1.RefreshPeriodR.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathTimeValuesType1.RefreshPeriodR.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit.Counter:
       description: |-
@@ -29745,73 +29816,6 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit.Counter'
-          x-field-uid: 6
-    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 8
-          format: uint32
-          maximum: 127
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 127
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 127
-    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length:
-      description: |-
-        The Length contains the total length of the subobject in bytes,including the Type and Length fields.   The Length is always 8.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 8
-          format: uint32
-          maximum: 127
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 127
-          x-field-uid: 3
-          default:
-          - 8
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address.Counter:
       description: |-
@@ -29941,73 +29945,6 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit.Counter'
-          x-field-uid: 6
-    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 8
-          format: uint32
-          maximum: 255
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 255
-    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length:
-      description: |-
-        The Length contains the total length of the subobject in bytes,including the Type and Length fields.   The Length is always 8.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 8
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 8
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved.Counter:
       description: |-
@@ -30210,78 +30147,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathSessionAttributeLspTunnel.Flags:
-      description: |-
-        0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 1
-      x-constants:
-        local_protection_desired: 1
-        label_recording_desired: 2
-        se_style_desired: 3
-    Pattern.Flow.RSVP.PathSessionAttributeLspTunnelRa.Flags:
-      description: |-
-        0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 1
-      x-constants:
-        local_protection_desired: 1
-        label_recording_desired: 2
-        se_style_desired: 4
     Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Ipv4TunnelSenderAddress.Counter:
       description: |-
         ipv4 counter pattern
@@ -31272,73 +31137,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 8
-          format: uint32
-          maximum: 255
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 255
-    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length:
-      description: |-
-        The Length contains the total length of the subobject in bytes, including the Type and Length fields.  The Length is always 8.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 8
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 8
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length.Counter'
-          x-field-uid: 6
     Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address.Counter:
       description: |-
         ipv4 counter pattern
@@ -31468,108 +31266,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.PrefixLength.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Flags:
-      description: |-
-        0x01  local_protection_available, 0x02  local_protection_in_use
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 1
-      x-constants:
-        local_protection_available: 1
-        local_protection_in_use: 2
-    Pattern.Flow.RSVP.PathRecordRouteType1Label.Length.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 8
-          format: uint32
-          maximum: 255
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 255
-    Pattern.Flow.RSVP.PathRecordRouteType1Label.Length:
-      description: "The Length contains the total length of the subobject in bytes,\
-        \ including the Type and Length fields.  "
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 8
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 8
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Length.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Length.Counter'
-          x-field-uid: 6
     Pattern.Flow.RSVP.PathRecordRouteType1Label.Flags:
       description: |-
         0x01 = Global label. This flag indicates that the label will be understood if received on any interface.
@@ -31602,9 +31298,6 @@ components:
           x-field-uid: 3
           default:
           - 1
-      x-constants:
-        local_protection_available: 1
-        local_protection_in_use: 2
     Pattern.Flow.RSVP.PathRecordRouteType1Label.CType:
       description: |-
         The C-Type of the included Label Object. Copied from the Label object.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7075,12 +7075,10 @@ components:
               x-field-uid: 18
             mpls:
               x-field-uid: 19
-<<<<<<< HEAD
-            rsvp:
-=======
             snmpv2c:
->>>>>>> master
               x-field-uid: 20
+            rsvp:
+              x-field-uid: 21
           enum:
           - custom
           - ethernet
@@ -7101,11 +7099,8 @@ components:
           - ppp
           - igmpv1
           - mpls
-<<<<<<< HEAD
-          - rsvp
-=======
           - snmpv2c
->>>>>>> master
+          - rsvp
         custom:
           $ref: '#/components/schemas/Flow.Custom'
           x-field-uid: 2
@@ -7163,14 +7158,12 @@ components:
         mpls:
           $ref: '#/components/schemas/Flow.Mpls'
           x-field-uid: 20
-<<<<<<< HEAD
-        rsvp:
-          $ref: '#/components/schemas/Flow.Rsvp'
-=======
         snmpv2c:
           $ref: '#/components/schemas/Flow.Snmpv2c'
->>>>>>> master
           x-field-uid: 21
+        rsvp:
+          $ref: '#/components/schemas/Flow.Rsvp'
+          x-field-uid: 22
     Flow.Custom:
       type: object
       description: |-
@@ -7920,7 +7913,327 @@ components:
         time_to_live:
           x-field-uid: 4
           $ref: '#/components/schemas/Pattern.Flow.Mpls.TimeToLive'
-<<<<<<< HEAD
+    Flow.Snmpv2c:
+      description: |-
+        SNMPv2C packet header as defined in RFC1901 and RFC3416.
+      type: object
+      required:
+      - data
+      properties:
+        version:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Version'
+        community:
+          description: |-
+            It is an ASCII based octet string which identifies the SNMP community in which the sender and recipient of this message are located. It should match the read-only or read-write community string configured on the recipient for the PDU to be accepted.
+          type: string
+          maxLength: 10000
+          default: community
+          x-field-uid: 2
+        data:
+          $ref: '#/components/schemas/Flow.Snmpv2c.Data'
+          x-field-uid: 3
+    Flow.Snmpv2c.Data:
+      description: |-
+        This contains the body of the SNMPv2C message.
+
+        - Encoding of subsequent fields follow ASN.1 specification.
+          Refer: http://www.itu.int/ITU-T/asn1/
+      type: object
+      required:
+      - choice
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          x-enum:
+            get_request:
+              x-field-uid: 1
+            get_next_request:
+              x-field-uid: 2
+            response:
+              x-field-uid: 3
+            set_request:
+              x-field-uid: 4
+            get_bulk_request:
+              x-field-uid: 5
+            inform_request:
+              x-field-uid: 6
+            snmpv2_trap:
+              x-field-uid: 7
+            report:
+              x-field-uid: 8
+          enum:
+          - get_request
+          - get_next_request
+          - response
+          - set_request
+          - get_bulk_request
+          - inform_request
+          - snmpv2_trap
+          - report
+        get_request:
+          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
+          x-field-uid: 2
+        get_next_request:
+          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
+          x-field-uid: 3
+        response:
+          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
+          x-field-uid: 4
+        set_request:
+          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
+          x-field-uid: 5
+        get_bulk_request:
+          $ref: '#/components/schemas/Flow.Snmpv2c.BulkPDU'
+          x-field-uid: 6
+        inform_request:
+          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
+          x-field-uid: 7
+        snmpv2_trap:
+          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
+          x-field-uid: 8
+        report:
+          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
+          x-field-uid: 9
+    Flow.Snmpv2c.PDU:
+      description: |-
+        This contains the body of the SNMPv2C PDU.
+      type: object
+      properties:
+        request_id:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.RequestId'
+        error_status:
+          description: |-
+            The SNMP agent places an error code in this field in the response message if an error occurred processing the request.
+          type: string
+          default: no_error
+          x-enum:
+            no_error:
+              x-field-uid: 1
+            too_big:
+              x-field-uid: 2
+            no_such_name:
+              x-field-uid: 3
+            bad_value:
+              x-field-uid: 4
+            read_only:
+              x-field-uid: 5
+            gen_err:
+              x-field-uid: 6
+            no_access:
+              x-field-uid: 7
+            wrong_type:
+              x-field-uid: 8
+            wrong_length:
+              x-field-uid: 9
+            wrong_encoding:
+              x-field-uid: 10
+            wrong_value:
+              x-field-uid: 11
+            no_creation:
+              x-field-uid: 12
+            inconsistent_value:
+              x-field-uid: 13
+            resource_unavailable:
+              x-field-uid: 14
+            commit_failed:
+              x-field-uid: 15
+            undo_failed:
+              x-field-uid: 16
+            authorization_error:
+              x-field-uid: 17
+            not_writable:
+              x-field-uid: 18
+            inconsistent_name:
+              x-field-uid: 19
+          x-field-uid: 2
+          enum:
+          - no_error
+          - too_big
+          - no_such_name
+          - bad_value
+          - read_only
+          - gen_err
+          - no_access
+          - wrong_type
+          - wrong_length
+          - wrong_encoding
+          - wrong_value
+          - no_creation
+          - inconsistent_value
+          - resource_unavailable
+          - commit_failed
+          - undo_failed
+          - authorization_error
+          - not_writable
+          - inconsistent_name
+        error_index:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.ErrorIndex'
+        variable_bindings:
+          description: |-
+            A Sequence of variable_bindings.
+          type: array
+          items:
+            $ref: '#/components/schemas/Flow.Snmpv2c.VariableBinding'
+          x-field-uid: 4
+    Flow.Snmpv2c.BulkPDU:
+      description: |-
+        The purpose of the GetBulkRequest-PDU is to request the transfer of a potentially large amount of data, including, but not limited to, the efficient and rapid retrieval of large tables.
+      type: object
+      properties:
+        request_id:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.RequestId'
+        non_repeaters:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.NonRepeaters'
+        max_repetitions:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions'
+        variable_bindings:
+          description: |-
+            A Sequence of variable_bindings.
+          type: array
+          items:
+            $ref: '#/components/schemas/Flow.Snmpv2c.VariableBinding'
+          x-field-uid: 4
+    Flow.Snmpv2c.VariableBinding:
+      description: |-
+        A Sequence of two fields, an object_identifier and the value for/from that object_identifier.
+      type: object
+      properties:
+        object_identifier:
+          x-field-uid: 1
+          description: "The Object Identifier points to a particular parameter in\
+            \ the SNMP agent. \n- Encoding of this field follows RFC2578(section 3.5)\
+            \ and ASN.1 X.690(section 8.1.3.6) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/\n\
+            - According to BER, the first two numbers of any OID (x.y) are encoded\
+            \ as one value using the formula (40*x)+y. \n  Example, the first two\
+            \ numbers of an SNMP OID 1.3... are encoded as 43 or 0x2B, because (40*1)+3\
+            \ = 43. \n- After the first two numbers are encoded, the subsequent numbers\
+            \ in the OID are each encoded as a byte. \n- However, a special rule is\
+            \ required for large numbers because one byte can only represent a number\
+            \ from 0-127. \n- The rule for large numbers states that only the lower\
+            \ 7 bits in the byte are used for holding the value (0-127). \n- The highest\
+            \ order bit(8th) is used as a flag to indicate that this number spans\
+            \ more than one byte. Therefore, any number over 127 must be encoded using\
+            \ more than one byte. \n  - Example, the number 2680 in the OID '1.3.6.1.4.1.2680.1.2.7.3.2.0'\
+            \ cannot be encoded using a single byte. \n    According to this rule,\
+            \ the number 2680 must be encoded as 0x94 0x78. \n    Since the most significant\
+            \ bit is set in the first byte (0x94), it indicates that number spans\
+            \ to the next byte.\n    Since the most significant bit is not set in\
+            \ the next byte (0x78), it indicates that the number ends at the second\
+            \ byte.\n    The value is derived by appending 7 bits from each of the\
+            \ concatenated bytes i.e (0x14 *128^1) + (0x78 * 128^0) = 2680."
+          type: string
+          format: oid
+          default: '0.1'
+        value:
+          $ref: '#/components/schemas/Flow.Snmpv2c.VariableBindingValue'
+          x-field-uid: 2
+    Flow.Snmpv2c.VariableBindingValue:
+      description: |-
+        The value for the object_identifier as per RFC2578.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: no_value
+          x-field-uid: 1
+          x-enum:
+            no_value:
+              x-field-uid: 1
+            integer_value:
+              x-field-uid: 2
+            string_value:
+              x-field-uid: 3
+            object_identifier_value:
+              x-field-uid: 4
+            ip_address_value:
+              x-field-uid: 5
+            counter_value:
+              x-field-uid: 6
+            timeticks_value:
+              x-field-uid: 7
+            arbitrary_value:
+              x-field-uid: 8
+            big_counter_value:
+              x-field-uid: 9
+            unsigned_integer_value:
+              x-field-uid: 10
+          enum:
+          - no_value
+          - integer_value
+          - string_value
+          - object_identifier_value
+          - ip_address_value
+          - counter_value
+          - timeticks_value
+          - arbitrary_value
+          - big_counter_value
+          - unsigned_integer_value
+        integer_value:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue'
+        string_value:
+          description: |-
+            It contains the hex bytes of the value to be sent.  As of now it is restricted to 5000 bytes.
+          type: string
+          maxLength: 10000
+          default: string
+          x-field-uid: 3
+        object_identifier_value:
+          x-field-uid: 4
+          description: "The Object Identifier points to a particular parameter in\
+            \ the SNMP agent. \n- Encoding of this field follows RFC2578(section 3.5)\
+            \ and ASN.1 X.690(section 8.1.3.6) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/\n\
+            - According to BER, the first two numbers of any OID (x.y) are encoded\
+            \ as one value using the formula (40*x)+y. \n  Example, the first two\
+            \ numbers of an SNMP OID 1.3... are encoded as 43 or 0x2B, because (40*1)+3\
+            \ = 43. \n- After the first two numbers are encoded, the subsequent numbers\
+            \ in the OID are each encoded as a byte. \n- However, a special rule is\
+            \ required for large numbers because one byte can only represent a number\
+            \ from 0-127. \n- The rule for large numbers states that only the lower\
+            \ 7 bits in the byte are used for holding the value (0-127). \n- The highest\
+            \ order bit(8th) is used as a flag to indicate that this number spans\
+            \ more than one byte. Therefore, any number over 127 must be encoded using\
+            \ more than one byte. \n  - Example, the number 2680 in the OID '1.3.6.1.4.1.2680.1.2.7.3.2.0'\
+            \ cannot be encoded using a single byte. \n    According to this rule,\
+            \ the number 2680 must be encoded as 0x94 0x78. \n    Since the most significant\
+            \ bit is set in the first byte (0x94), it indicates that number spans\
+            \ to the next byte.\n    Since the most significant bit is not set in\
+            \ the next byte (0x78), it indicates that the number ends at the second\
+            \ byte.\n    The value is derived by appending 7 bits from each of the\
+            \ concatenated bytes i.e (0x14 *128^1) + (0x78 * 128^0) = 2680."
+          type: string
+          format: oid
+          default: '0.1'
+        ip_address_value:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue'
+        counter_value:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue'
+        timeticks_value:
+          x-field-uid: 7
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue'
+        arbitrary_value:
+          description: |-
+            It contains the hex bytes of the value to be sent.  As of now it is restricted to 5000 bytes.
+          type: string
+          format: hex
+          maxLength: 10000
+          default: '00'
+          x-field-uid: 8
+        big_counter_value:
+          x-field-uid: 9
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue'
+        unsigned_integer_value:
+          x-field-uid: 10
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue'
     Flow.Rsvp:
       description: |-
         RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message type is "Path" with mandatory objects and sub-objects.
@@ -8069,34 +8382,6 @@ components:
     Flow.RSVP.PathObjectsClass:
       description: |-
         The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "Path" message type. "Path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not supported in above options.
-=======
-    Flow.Snmpv2c:
-      description: |-
-        SNMPv2C packet header as defined in RFC1901 and RFC3416.
-      type: object
-      required:
-      - data
-      properties:
-        version:
-          x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Version'
-        community:
-          description: |-
-            It is an ASCII based octet string which identifies the SNMP community in which the sender and recipient of this message are located. It should match the read-only or read-write community string configured on the recipient for the PDU to be accepted.
-          type: string
-          maxLength: 10000
-          default: community
-          x-field-uid: 2
-        data:
-          $ref: '#/components/schemas/Flow.Snmpv2c.Data'
-          x-field-uid: 3
-    Flow.Snmpv2c.Data:
-      description: |-
-        This contains the body of the SNMPv2C message.
-
-        - Encoding of subsequent fields follow ASN.1 specification.
-          Refer: http://www.itu.int/ITU-T/asn1/
->>>>>>> master
       type: object
       required:
       - choice
@@ -8105,7 +8390,6 @@ components:
           type: string
           x-field-uid: 1
           x-enum:
-<<<<<<< HEAD
             session:
               x-field-uid: 1
             rsvp_hop:
@@ -9055,295 +9339,6 @@ components:
           maxLength: 131050
           default: '0000'
           x-field-uid: 3
-=======
-            get_request:
-              x-field-uid: 1
-            get_next_request:
-              x-field-uid: 2
-            response:
-              x-field-uid: 3
-            set_request:
-              x-field-uid: 4
-            get_bulk_request:
-              x-field-uid: 5
-            inform_request:
-              x-field-uid: 6
-            snmpv2_trap:
-              x-field-uid: 7
-            report:
-              x-field-uid: 8
-          enum:
-          - get_request
-          - get_next_request
-          - response
-          - set_request
-          - get_bulk_request
-          - inform_request
-          - snmpv2_trap
-          - report
-        get_request:
-          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
-          x-field-uid: 2
-        get_next_request:
-          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
-          x-field-uid: 3
-        response:
-          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
-          x-field-uid: 4
-        set_request:
-          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
-          x-field-uid: 5
-        get_bulk_request:
-          $ref: '#/components/schemas/Flow.Snmpv2c.BulkPDU'
-          x-field-uid: 6
-        inform_request:
-          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
-          x-field-uid: 7
-        snmpv2_trap:
-          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
-          x-field-uid: 8
-        report:
-          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
-          x-field-uid: 9
-    Flow.Snmpv2c.PDU:
-      description: |-
-        This contains the body of the SNMPv2C PDU.
-      type: object
-      properties:
-        request_id:
-          x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.RequestId'
-        error_status:
-          description: |-
-            The SNMP agent places an error code in this field in the response message if an error occurred processing the request.
-          type: string
-          default: no_error
-          x-enum:
-            no_error:
-              x-field-uid: 1
-            too_big:
-              x-field-uid: 2
-            no_such_name:
-              x-field-uid: 3
-            bad_value:
-              x-field-uid: 4
-            read_only:
-              x-field-uid: 5
-            gen_err:
-              x-field-uid: 6
-            no_access:
-              x-field-uid: 7
-            wrong_type:
-              x-field-uid: 8
-            wrong_length:
-              x-field-uid: 9
-            wrong_encoding:
-              x-field-uid: 10
-            wrong_value:
-              x-field-uid: 11
-            no_creation:
-              x-field-uid: 12
-            inconsistent_value:
-              x-field-uid: 13
-            resource_unavailable:
-              x-field-uid: 14
-            commit_failed:
-              x-field-uid: 15
-            undo_failed:
-              x-field-uid: 16
-            authorization_error:
-              x-field-uid: 17
-            not_writable:
-              x-field-uid: 18
-            inconsistent_name:
-              x-field-uid: 19
-          x-field-uid: 2
-          enum:
-          - no_error
-          - too_big
-          - no_such_name
-          - bad_value
-          - read_only
-          - gen_err
-          - no_access
-          - wrong_type
-          - wrong_length
-          - wrong_encoding
-          - wrong_value
-          - no_creation
-          - inconsistent_value
-          - resource_unavailable
-          - commit_failed
-          - undo_failed
-          - authorization_error
-          - not_writable
-          - inconsistent_name
-        error_index:
-          x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.ErrorIndex'
-        variable_bindings:
-          description: |-
-            A Sequence of variable_bindings.
-          type: array
-          items:
-            $ref: '#/components/schemas/Flow.Snmpv2c.VariableBinding'
-          x-field-uid: 4
-    Flow.Snmpv2c.BulkPDU:
-      description: |-
-        The purpose of the GetBulkRequest-PDU is to request the transfer of a potentially large amount of data, including, but not limited to, the efficient and rapid retrieval of large tables.
-      type: object
-      properties:
-        request_id:
-          x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.RequestId'
-        non_repeaters:
-          x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.NonRepeaters'
-        max_repetitions:
-          x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions'
-        variable_bindings:
-          description: |-
-            A Sequence of variable_bindings.
-          type: array
-          items:
-            $ref: '#/components/schemas/Flow.Snmpv2c.VariableBinding'
-          x-field-uid: 4
-    Flow.Snmpv2c.VariableBinding:
-      description: |-
-        A Sequence of two fields, an object_identifier and the value for/from that object_identifier.
-      type: object
-      properties:
-        object_identifier:
-          x-field-uid: 1
-          description: "The Object Identifier points to a particular parameter in\
-            \ the SNMP agent. \n- Encoding of this field follows RFC2578(section 3.5)\
-            \ and ASN.1 X.690(section 8.1.3.6) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/\n\
-            - According to BER, the first two numbers of any OID (x.y) are encoded\
-            \ as one value using the formula (40*x)+y. \n  Example, the first two\
-            \ numbers of an SNMP OID 1.3... are encoded as 43 or 0x2B, because (40*1)+3\
-            \ = 43. \n- After the first two numbers are encoded, the subsequent numbers\
-            \ in the OID are each encoded as a byte. \n- However, a special rule is\
-            \ required for large numbers because one byte can only represent a number\
-            \ from 0-127. \n- The rule for large numbers states that only the lower\
-            \ 7 bits in the byte are used for holding the value (0-127). \n- The highest\
-            \ order bit(8th) is used as a flag to indicate that this number spans\
-            \ more than one byte. Therefore, any number over 127 must be encoded using\
-            \ more than one byte. \n  - Example, the number 2680 in the OID '1.3.6.1.4.1.2680.1.2.7.3.2.0'\
-            \ cannot be encoded using a single byte. \n    According to this rule,\
-            \ the number 2680 must be encoded as 0x94 0x78. \n    Since the most significant\
-            \ bit is set in the first byte (0x94), it indicates that number spans\
-            \ to the next byte.\n    Since the most significant bit is not set in\
-            \ the next byte (0x78), it indicates that the number ends at the second\
-            \ byte.\n    The value is derived by appending 7 bits from each of the\
-            \ concatenated bytes i.e (0x14 *128^1) + (0x78 * 128^0) = 2680."
-          type: string
-          format: oid
-          default: '0.1'
-        value:
-          $ref: '#/components/schemas/Flow.Snmpv2c.VariableBindingValue'
-          x-field-uid: 2
-    Flow.Snmpv2c.VariableBindingValue:
-      description: |-
-        The value for the object_identifier as per RFC2578.
-      type: object
-      properties:
-        choice:
-          type: string
-          default: no_value
-          x-field-uid: 1
-          x-enum:
-            no_value:
-              x-field-uid: 1
-            integer_value:
-              x-field-uid: 2
-            string_value:
-              x-field-uid: 3
-            object_identifier_value:
-              x-field-uid: 4
-            ip_address_value:
-              x-field-uid: 5
-            counter_value:
-              x-field-uid: 6
-            timeticks_value:
-              x-field-uid: 7
-            arbitrary_value:
-              x-field-uid: 8
-            big_counter_value:
-              x-field-uid: 9
-            unsigned_integer_value:
-              x-field-uid: 10
-          enum:
-          - no_value
-          - integer_value
-          - string_value
-          - object_identifier_value
-          - ip_address_value
-          - counter_value
-          - timeticks_value
-          - arbitrary_value
-          - big_counter_value
-          - unsigned_integer_value
-        integer_value:
-          x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue'
-        string_value:
-          description: |-
-            It contains the hex bytes of the value to be sent.  As of now it is restricted to 5000 bytes.
-          type: string
-          maxLength: 10000
-          default: string
-          x-field-uid: 3
-        object_identifier_value:
-          x-field-uid: 4
-          description: "The Object Identifier points to a particular parameter in\
-            \ the SNMP agent. \n- Encoding of this field follows RFC2578(section 3.5)\
-            \ and ASN.1 X.690(section 8.1.3.6) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/\n\
-            - According to BER, the first two numbers of any OID (x.y) are encoded\
-            \ as one value using the formula (40*x)+y. \n  Example, the first two\
-            \ numbers of an SNMP OID 1.3... are encoded as 43 or 0x2B, because (40*1)+3\
-            \ = 43. \n- After the first two numbers are encoded, the subsequent numbers\
-            \ in the OID are each encoded as a byte. \n- However, a special rule is\
-            \ required for large numbers because one byte can only represent a number\
-            \ from 0-127. \n- The rule for large numbers states that only the lower\
-            \ 7 bits in the byte are used for holding the value (0-127). \n- The highest\
-            \ order bit(8th) is used as a flag to indicate that this number spans\
-            \ more than one byte. Therefore, any number over 127 must be encoded using\
-            \ more than one byte. \n  - Example, the number 2680 in the OID '1.3.6.1.4.1.2680.1.2.7.3.2.0'\
-            \ cannot be encoded using a single byte. \n    According to this rule,\
-            \ the number 2680 must be encoded as 0x94 0x78. \n    Since the most significant\
-            \ bit is set in the first byte (0x94), it indicates that number spans\
-            \ to the next byte.\n    Since the most significant bit is not set in\
-            \ the next byte (0x78), it indicates that the number ends at the second\
-            \ byte.\n    The value is derived by appending 7 bits from each of the\
-            \ concatenated bytes i.e (0x14 *128^1) + (0x78 * 128^0) = 2680."
-          type: string
-          format: oid
-          default: '0.1'
-        ip_address_value:
-          x-field-uid: 5
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue'
-        counter_value:
-          x-field-uid: 6
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue'
-        timeticks_value:
-          x-field-uid: 7
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue'
-        arbitrary_value:
-          description: |-
-            It contains the hex bytes of the value to be sent.  As of now it is restricted to 5000 bytes.
-          type: string
-          format: hex
-          maxLength: 10000
-          default: '00'
-          x-field-uid: 8
-        big_counter_value:
-          x-field-uid: 9
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue'
-        unsigned_integer_value:
-          x-field-uid: 10
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue'
->>>>>>> master
     Flow.Size:
       description: |-
         The frame size which overrides the total length of the packet
@@ -29806,7 +29801,791 @@ components:
           items:
             $ref: '#/components/schemas/Pattern.Flow.Mpls.TimeToLive.MetricTag'
           x-field-uid: 7
-<<<<<<< HEAD
+    Pattern.Flow.Snmpv2c.Version.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Snmpv2c.Version:
+      description: |-
+        Version
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Version.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Version.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.PDU.RequestId.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: int32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: int32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: int32
+    Pattern.Flow.Snmpv2c.PDU.RequestId:
+      description: "Identifies a particular SNMP request. \nThis index is echoed back\
+        \ in the response from the SNMP agent, \nallowing the SNMP manager to match\
+        \ an incoming response to the appropriate request.\n\n- Encoding of this field\
+        \ follows ASN.1 X.690(section 8.3) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/"
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: int32
+        values:
+          type: array
+          items:
+            type: integer
+            format: int32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.RequestId.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.RequestId.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.PDU.ErrorIndex.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Snmpv2c.PDU.ErrorIndex:
+      description: |-
+        When Error Status is non-zero,  this field contains a pointer that specifies which object generated the error.  Always zero in a request.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.ErrorIndex.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.ErrorIndex.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.BulkPDU.RequestId.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: int32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: int32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: int32
+    Pattern.Flow.Snmpv2c.BulkPDU.RequestId:
+      description: "Identifies a particular SNMP request. \nThis index is echoed back\
+        \ in the response from the SNMP agent, \nallowing the SNMP manager to match\
+        \ an incoming response to the appropriate request.\n\n- Encoding of this field\
+        \ follows ASN.1 X.690(section 8.3) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/"
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: int32
+        values:
+          type: array
+          items:
+            type: integer
+            format: int32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.RequestId.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.RequestId.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.BulkPDU.NonRepeaters:
+      description: |-
+        One variable binding in the Response-PDU is requested for the first non_repeaters variable bindings in the GetBulkRequest.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+    Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions:
+      description: |-
+        A maximum of max_repetitions variable bindings are requested in the Response-PDU for each of the remaining variable bindings in the GetBulkRequest after the non_repeaters variable bindings.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: int32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: int32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: int32
+    Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue:
+      description: |-
+        Integer value returned for the requested OID.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: int32
+        values:
+          type: array
+          items:
+            type: integer
+            format: int32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue.Counter:
+      description: |-
+        ipv4 counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 0.0.0.0
+          format: ipv4
+        step:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.1
+          format: ipv4
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue:
+      description: |-
+        IPv4 address returned for the requested OID.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.0
+          format: ipv4
+        values:
+          type: array
+          items:
+            type: string
+            format: ipv4
+          x-field-uid: 3
+          default:
+          - 0.0.0.0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue:
+      description: |-
+        Counter returned for the requested OID.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue:
+      description: |-
+        Timeticks returned for the requested OID.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint64
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint64
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint64
+    Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue:
+      description: |-
+        Big counter returned for the requested OID.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint64
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint64
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue:
+      description: |-
+        Unsigned integer value returned for the requested OID.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv2c.Common.RequestId.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: int32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: int32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: int32
+    Pattern.Flow.Snmpv2c.Common.RequestId:
+      description: "Identifies a particular SNMP request. \nThis index is echoed back\
+        \ in the response from the SNMP agent, \nallowing the SNMP manager to match\
+        \ an incoming response to the appropriate request.\n\n- Encoding of this field\
+        \ follows ASN.1 X.690(section 8.3) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/"
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: int32
+        values:
+          type: array
+          items:
+            type: integer
+            format: int32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Common.RequestId.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Common.RequestId.Counter'
+          x-field-uid: 6
     Pattern.Flow.Rsvp.RsvpChecksum:
       description: |-
         The one's complement of the one's complement sum of the message, with the checksum field replaced by zero for the purpose of computing the checksum.   An all-zero value means that no checksum was transmitted.
@@ -31282,9 +32061,6 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.OverallLength.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader.Counter:
-=======
-    Pattern.Flow.Snmpv2c.Version.Counter:
->>>>>>> master
       description: |-
         integer counter pattern
       type: object
@@ -31307,15 +32083,9 @@ components:
           default: 1
           format: uint32
           maximum: 255
-<<<<<<< HEAD
     Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader:
       description: |-
         Service header, service number - '1' (Generic information) if in a PATH message.
-=======
-    Pattern.Flow.Snmpv2c.Version:
-      description: |-
-        Version
->>>>>>> master
       type: object
       properties:
         choice:
@@ -31352,21 +32122,12 @@ components:
           default:
           - 1
         increment:
-<<<<<<< HEAD
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader.Counter'
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathSenderTspecIntServ.ZeroBit.Counter:
-=======
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Version.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Version.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.PDU.RequestId.Counter:
->>>>>>> master
       description: |-
         integer counter pattern
       type: object
@@ -31375,40 +32136,23 @@ components:
           type: integer
           x-field-uid: 1
           default: 0
-<<<<<<< HEAD
           format: uint32
           maximum: 1
-=======
-          format: int32
->>>>>>> master
         step:
           type: integer
           x-field-uid: 2
           default: 1
-<<<<<<< HEAD
           format: uint32
           maximum: 1
-=======
-          format: int32
->>>>>>> master
         count:
           type: integer
           x-field-uid: 3
           default: 1
-<<<<<<< HEAD
           format: uint32
           maximum: 1
     Pattern.Flow.RSVP.PathSenderTspecIntServ.ZeroBit:
       description: |-
         MUST be 0.
-=======
-          format: int32
-    Pattern.Flow.Snmpv2c.PDU.RequestId:
-      description: "Identifies a particular SNMP request. \nThis index is echoed back\
-        \ in the response from the SNMP agent, \nallowing the SNMP manager to match\
-        \ an incoming response to the appropriate request.\n\n- Encoding of this field\
-        \ follows ASN.1 X.690(section 8.3) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/"
->>>>>>> master
       type: object
       properties:
         choice:
@@ -31433,27 +32177,18 @@ components:
           type: integer
           x-field-uid: 2
           default: 0
-<<<<<<< HEAD
           format: uint32
           maximum: 1
-=======
-          format: int32
->>>>>>> master
         values:
           type: array
           items:
             type: integer
-<<<<<<< HEAD
             format: uint32
             maximum: 1
-=======
-            format: int32
->>>>>>> master
           x-field-uid: 3
           default:
           - 0
         increment:
-<<<<<<< HEAD
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ZeroBit.Counter'
           x-field-uid: 5
         decrement:
@@ -31795,14 +32530,6 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Length.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit.Counter:
-=======
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.RequestId.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.RequestId.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.PDU.ErrorIndex.Counter:
->>>>>>> master
       description: |-
         integer counter pattern
       type: object
@@ -31822,15 +32549,9 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-<<<<<<< HEAD
     Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit:
       description: |-
         The minimum policed unit parameter should generally be set equal to the size of the smallest packet generated by the application.
-=======
-    Pattern.Flow.Snmpv2c.PDU.ErrorIndex:
-      description: |-
-        When Error Status is non-zero,  this field contains a pointer that specifies which object generated the error.  Always zero in a request.
->>>>>>> master
       type: object
       properties:
         choice:
@@ -31865,115 +32586,12 @@ components:
           default:
           - 0
         increment:
-<<<<<<< HEAD
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit.Counter'
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize.Counter:
-=======
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.ErrorIndex.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.PDU.ErrorIndex.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.BulkPDU.RequestId.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: int32
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: int32
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: int32
-    Pattern.Flow.Snmpv2c.BulkPDU.RequestId:
-      description: "Identifies a particular SNMP request. \nThis index is echoed back\
-        \ in the response from the SNMP agent, \nallowing the SNMP manager to match\
-        \ an incoming response to the appropriate request.\n\n- Encoding of this field\
-        \ follows ASN.1 X.690(section 8.3) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/"
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: int32
-        values:
-          type: array
-          items:
-            type: integer
-            format: int32
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.RequestId.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.RequestId.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.BulkPDU.NonRepeaters:
-      description: |-
-        One variable binding in the Response-PDU is requested for the first non_repeaters variable bindings in the GetBulkRequest.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: uint32
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-          x-field-uid: 3
-          default:
-          - 0
-    Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions.Counter:
->>>>>>> master
       description: |-
         integer counter pattern
       type: object
@@ -31993,15 +32611,9 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-<<<<<<< HEAD
     Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize:
       description: |-
         The maximum packet size parameter should be set to the size of the largest packet the application might wish to generate. This value must, by definition, be equal to or larger than the value of The minimum policed unit.
-=======
-    Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions:
-      description: |-
-        A maximum of max_repetitions variable bindings are requested in the Response-PDU for each of the remaining variable bindings in the GetBulkRequest after the non_repeaters variable bindings.
->>>>>>> master
       type: object
       properties:
         choice:
@@ -32036,83 +32648,12 @@ components:
           default:
           - 0
         increment:
-<<<<<<< HEAD
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize.Counter'
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address.Counter:
-=======
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.BulkPDU.MaxRepetitions.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: int32
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: int32
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: int32
-    Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue:
-      description: |-
-        Integer value returned for the requested OID.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: int32
-        values:
-          type: array
-          items:
-            type: integer
-            format: int32
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IntegerValue.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue.Counter:
->>>>>>> master
       description: |-
         ipv4 counter pattern
       type: object
@@ -32132,15 +32673,9 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-<<<<<<< HEAD
     Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address:
       description: |-
         A 32-bit unicast, host address.  Any network-reachable interface address is allowed here. Illegal addresses, such as certain loopback addresses, SHOULD NOT be used.
-=======
-    Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue:
-      description: |-
-        IPv4 address returned for the requested OID.
->>>>>>> master
       type: object
       properties:
         choice:
@@ -32175,7 +32710,6 @@ components:
           default:
           - 0.0.0.0
         increment:
-<<<<<<< HEAD
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address.Counter'
           x-field-uid: 5
         decrement:
@@ -32313,14 +32847,6 @@ components:
           default:
           - 1
     Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter:
-=======
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.IpAddressValue.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue.Counter:
->>>>>>> master
       description: |-
         integer counter pattern
       type: object
@@ -32330,34 +32856,22 @@ components:
           x-field-uid: 1
           default: 0
           format: uint32
-<<<<<<< HEAD
           maximum: 255
-=======
->>>>>>> master
         step:
           type: integer
           x-field-uid: 2
           default: 1
           format: uint32
-<<<<<<< HEAD
           maximum: 255
-=======
->>>>>>> master
         count:
           type: integer
           x-field-uid: 3
           default: 1
           format: uint32
-<<<<<<< HEAD
           maximum: 255
     Pattern.Flow.RSVP.PathObjectsCustom.Type:
       description: |-
         User defined object type.
-=======
-    Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue:
-      description: |-
-        Counter returned for the requested OID.
->>>>>>> master
       type: object
       properties:
         choice:
@@ -32383,284 +32897,21 @@ components:
           x-field-uid: 2
           default: 0
           format: uint32
-<<<<<<< HEAD
           maximum: 255
-=======
->>>>>>> master
         values:
           type: array
           items:
             type: integer
             format: uint32
-<<<<<<< HEAD
             maximum: 255
-=======
->>>>>>> master
           x-field-uid: 3
           default:
           - 0
         increment:
-<<<<<<< HEAD
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter'
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter'
-=======
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.CounterValue.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: uint32
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-    Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue:
-      description: |-
-        Timeticks returned for the requested OID.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: uint32
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.TimeticksValue.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: uint64
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint64
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint64
-    Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue:
-      description: |-
-        Big counter returned for the requested OID.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: uint64
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint64
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.BigCounterValue.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: uint32
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-    Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue:
-      description: |-
-        Unsigned integer value returned for the requested OID.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: uint32
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue.Counter'
-          x-field-uid: 6
-    Pattern.Flow.Snmpv2c.Common.RequestId.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: int32
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: int32
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: int32
-    Pattern.Flow.Snmpv2c.Common.RequestId:
-      description: "Identifies a particular SNMP request. \nThis index is echoed back\
-        \ in the response from the SNMP agent, \nallowing the SNMP manager to match\
-        \ an incoming response to the appropriate request.\n\n- Encoding of this field\
-        \ follows ASN.1 X.690(section 8.3) specification.\n  Refer: http://www.itu.int/ITU-T/asn1/"
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: int32
-        values:
-          type: array
-          items:
-            type: integer
-            format: int32
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Common.RequestId.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.Common.RequestId.Counter'
->>>>>>> master
           x-field-uid: 6
     Version:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7804,8 +7804,49 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.Mpls.TimeToLive'
     Flow.Rsvp:
       description: |-
-        RSVP packet header as defined in RFC2205 and RFC3209.
+        RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message type is "path".
       type: object
+      properties:
+        version:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Version'
+        flag:
+          description: |-
+            Flag, 0x01-0x08: Reserved.
+          type: string
+          default: not_refresh_reduction_capable
+          x-enum:
+            not_refresh_reduction_capable:
+              x-field-uid: 1
+            refresh_reduction_capable:
+              x-field-uid: 2
+          x-field-uid: 2
+          enum:
+          - not_refresh_reduction_capable
+          - refresh_reduction_capable
+        rsvp_checksum:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpChecksum'
+        time_to_live:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.TimeToLive'
+        reserved:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Reserved'
+        rsvp_length:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpLength'
+        message_type:
+          description: |-
+            An 8-bit number that identifies the function of the RSVP message. There are aound 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 . Among Those we are presently supporting "path"(value: 1) and "hello" (value: 20) message type.
+          type: string
+          default: path
+          x-enum:
+            path:
+              x-field-uid: 1
+          x-field-uid: 7
+          enum:
+          - path
     Flow.Size:
       description: |-
         The frame size which overrides the total length of the packet
@@ -28052,6 +28093,325 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Pattern.Flow.Mpls.TimeToLive.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Rsvp.Version.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 15
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 15
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 15
+    Pattern.Flow.Rsvp.Version:
+      description: "Protocol Version number. "
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 15
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 15
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Version.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Version.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Rsvp.RsvpChecksum:
+      description: |-
+        The one's complement of the one's complement sum of the message, with the checksum field replaced by zero for the purpose of computing the checksum.   An all-zero value means that no checksum was transmitted.
+      type: object
+      properties:
+        choice:
+          description: |-
+            The type of checksum
+          type: string
+          x-enum:
+            generated:
+              x-field-uid: 1
+            custom:
+              x-field-uid: 2
+          default: generated
+          x-field-uid: 1
+          enum:
+          - generated
+          - custom
+        generated:
+          description: |-
+            A system generated checksum value
+          type: string
+          x-enum:
+            good:
+              x-field-uid: 1
+            bad:
+              x-field-uid: 2
+          default: good
+          x-field-uid: 2
+          enum:
+          - good
+          - bad
+        custom:
+          description: |-
+            A custom checksum value
+          type: integer
+          format: uint32
+          maximum: 65535
+          x-field-uid: 3
+    Pattern.Flow.Rsvp.TimeToLive.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Rsvp.TimeToLive:
+      description: |-
+        The IP time-to-live(TTL) value with which the message was sent.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.TimeToLive.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.TimeToLive.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Rsvp.Reserved.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Rsvp.Reserved:
+      description: "Reserved "
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Reserved.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Reserved.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Rsvp.RsvpLength.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: auto
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Rsvp.RsvpLength:
+      description: |-
+        The sum of the lengths of the common header and all objects included in the message.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            auto:
+              x-field-uid: 1
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: auto
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - auto
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: auto
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - auto
+        auto:
+          description: |-
+            The OTG implementation can provide a system generated
+            value for this property. If the OTG is unable to generate a value
+            the default value must be used.
+          type: integer
+          x-field-uid: 4
+          default: auto
+          format: uint32
+          maximum: 65535
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpLength.Counter'
+          x-field-uid: 6
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpLength.Counter'
           x-field-uid: 7
     Version:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8065,8 +8065,33 @@ components:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.TunnelId'
         extended_tunnel_id:
+          description: |-
+            A 32-bit identifier used in the SESSION that remains constant over the life of the tunnel. Normally set to all zeros. Ingress nodes that wish to narrow the scope of a SESSION to the ingress-egress pair may place their IPv4 address here as a globally unique identifier.
+          $ref: '#/components/schemas/Flow.RSVP.PathSessionExtTunnelId'
           x-field-uid: 4
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId'
+    Flow.RSVP.PathSessionExtTunnelId:
+      type: object
+      properties:
+        choice:
+          description: |-
+            32 bit integer or IPv4 address.
+          type: string
+          default: as_integer
+          x-field-uid: 1
+          x-enum:
+            as_integer:
+              x-field-uid: 1
+            as_ipv4:
+              x-field-uid: 2
+          enum:
+          - as_integer
+          - as_ipv4
+        as_integer:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionExtTunnelId.AsInteger'
+        as_ipv4:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionExtTunnelId.AsIpv4'
     Flow.RSVP.PathObjectsClassRsvpHop:
       description: |-
         C-Type is specific to a class num.
@@ -29470,7 +29495,7 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.TunnelId.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId.Counter:
+    Pattern.Flow.RSVP.PathSessionExtTunnelId.AsInteger.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -29490,9 +29515,9 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId:
+    Pattern.Flow.RSVP.PathSessionExtTunnelId.AsInteger:
       description: |-
-        A 32-bit identifier used in the SESSION that remains constant over the life of the tunnel. Normally set to all zeros. Ingress nodes that wish to narrow the scope of a SESSION to the ingress-egress pair may place their IPv4 address here as a globally unique identifier.
+        TBD
       type: object
       properties:
         choice:
@@ -29527,10 +29552,72 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionExtTunnelId.AsInteger.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionExtTunnelId.AsInteger.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSessionExtTunnelId.AsIpv4.Counter:
+      description: |-
+        ipv4 counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 0.0.0.0
+          format: ipv4
+        step:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.1
+          format: ipv4
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathSessionExtTunnelId.AsIpv4:
+      description: |-
+        IPv4 address of the egress node for the tunnel.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.0
+          format: ipv4
+        values:
+          type: array
+          items:
+            type: string
+            format: ipv4
+          x-field-uid: 3
+          default:
+          - 0.0.0.0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionExtTunnelId.AsIpv4.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionExtTunnelId.AsIpv4.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4Address.Counter:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7813,17 +7813,8 @@ components:
         flag:
           description: |-
             Flag, 0x01-0x08: Reserved.
-          type: string
-          default: not_refresh_reduction_capable
-          x-enum:
-            not_refresh_reduction_capable:
-              x-field-uid: 1
-            refresh_reduction_capable:
-              x-field-uid: 2
+          $ref: '#/components/schemas/Flow.RSVP.Flag'
           x-field-uid: 2
-          enum:
-          - not_refresh_reduction_capable
-          - refresh_reduction_capable
         rsvp_checksum:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpChecksum'
@@ -7838,15 +7829,165 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpLength'
         message_type:
           description: |-
-            An 8-bit number that identifies the function of the RSVP message. There are aound 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 . Among Those we are presently supporting "path"(value: 1) and "hello" (value: 20) message type.
+            An 8-bit number that identifies the function of the RSVP message. There are aound 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 . Among Those we are presently supporting "path"(value: 1) message type.
+          $ref: '#/components/schemas/Flow.RSVP.Message'
+          x-field-uid: 7
+    Flow.RSVP.Flag:
+      type: object
+      properties:
+        choice:
+          type: string
+          default: not_refresh_reduction_capable
+          x-enum:
+            not_refresh_reduction_capable:
+              x-field-uid: 1
+            refresh_reduction_capable:
+              x-field-uid: 2
+          x-field-uid: 1
+          enum:
+          - not_refresh_reduction_capable
+          - refresh_reduction_capable
+    Flow.RSVP.Message:
+      type: object
+      properties:
+        choice:
           type: string
           default: path
           x-enum:
             path:
               x-field-uid: 1
-          x-field-uid: 7
+          x-field-uid: 1
           enum:
           - path
+        path:
+          $ref: '#/components/schemas/Flow.RSVP.PathMessage'
+          x-field-uid: 2
+    Flow.RSVP.PathMessage:
+      description: |-
+        "path" message required the follwoing list of objects in order: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT ROUTE  5. LABEL_REQUEST 6. SESSION_ATTRIBUTE 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
+      type: object
+      properties:
+        objects:
+          description: |-
+            "path" message required atleast SESSION, RSVP_HOP and TIME_VALUES objects.
+          type: array
+          minItems: 3
+          items:
+            $ref: '#/components/schemas/Flow.RSVP.PathObjects'
+          x-field-uid: 1
+    Flow.RSVP.PathObjects:
+      description: |-
+        Every RSVP object encapsulated in an RSVP message consists of a 32-bit word header and the object's contents.
+      type: object
+      properties:
+        length:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjects.Length'
+        class_num:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClass'
+          x-field-uid: 2
+    Flow.RSVP.PathObjectsClass:
+      description: |-
+        The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "path" message type. "path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21.
+      type: object
+      required:
+      - choice
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          x-enum:
+            session:
+              x-field-uid: 1
+            rsvp_hop:
+              x-field-uid: 2
+            time_values:
+              x-field-uid: 3
+            explicit_route:
+              x-field-uid: 4
+            label_request:
+              x-field-uid: 5
+            session_attribute:
+              x-field-uid: 6
+            sender_template:
+              x-field-uid: 7
+            sender_tspec:
+              x-field-uid: 8
+            record_route:
+              x-field-uid: 9
+          enum:
+          - session
+          - rsvp_hop
+          - time_values
+          - explicit_route
+          - label_request
+          - session_attribute
+          - sender_template
+          - sender_tspec
+          - record_route
+        session:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSession'
+          x-field-uid: 2
+        rsvp_hop:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRsvpHop'
+          x-field-uid: 3
+        time_values:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassTimeValues'
+          x-field-uid: 4
+        explicit_route:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassExplicitRoute'
+          x-field-uid: 5
+        label_request:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassLabelRequest'
+          x-field-uid: 6
+        session_attribute:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSessionAttribute'
+          x-field-uid: 7
+        sender_template:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSenderTemplate'
+          x-field-uid: 8
+        sender_tspec:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSenderTspec'
+          x-field-uid: 9
+        record_route:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRecordRoute'
+          x-field-uid: 10
+    Flow.RSVP.PathObjectsClassSession:
+      description: |-
+        Object for SESSION class.
+      type: object
+    Flow.RSVP.PathObjectsClassRsvpHop:
+      description: |-
+        Object for RSVP_HOP class.
+      type: object
+    Flow.RSVP.PathObjectsClassTimeValues:
+      description: |-
+        Object for TIME_VALUES class.
+      type: object
+    Flow.RSVP.PathObjectsClassExplicitRoute:
+      description: |-
+        Object for EXPLICIT_ROUTE class.
+      type: object
+    Flow.RSVP.PathObjectsClassLabelRequest:
+      description: |-
+        Object for LABEL_REQUEST class.
+      type: object
+    Flow.RSVP.PathObjectsClassSessionAttribute:
+      description: |-
+        Object for SESSION_ATTRIBUTE class.
+      type: object
+    Flow.RSVP.PathObjectsClassSenderTemplate:
+      description: |-
+        Object for SENDER_TEMPLATE class.
+      type: object
+    Flow.RSVP.PathObjectsClassSenderTspec:
+      description: |-
+        Object for SENDER_TSPEC class.
+      type: object
+    Flow.RSVP.PathObjectsClassRecordRoute:
+      description: |-
+        Object for RECORD_ROUTE class.
+      type: object
     Flow.Size:
       description: |-
         The frame size which overrides the total length of the packet
@@ -28413,6 +28554,73 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpLength.Counter'
           x-field-uid: 7
+    Pattern.Flow.RSVP.PathObjects.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 4
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathObjects.Length:
+      description: "Contains the total length of the object including the object's\
+        \ header, measured in bytes.  Objects must be aligned to 32-bit words. "
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 4
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 4
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjects.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjects.Length.Counter'
+          x-field-uid: 6
     Version:
       description: |-
         Version details

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8488,14 +8488,6 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathRecordRouteType1:
       description: |-
-        C-Type of Type 1 Record Route.
-      type: object
-      properties:
-        c_type:
-          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1CType'
-          x-field-uid: 1
-    Flow.RSVP.PathRecordRouteType1CType:
-      description: |-
         Type1 record route has list of subobjects. Currently supported subobjects are IPv4 address(1) and Label(3).
       type: object
       properties:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7804,7 +7804,7 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.Mpls.TimeToLive'
     Flow.Rsvp:
       description: |-
-        RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message type is "path".
+        RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message type is "path" with mandatory objects and sub-objects.
       type: object
       properties:
         version:
@@ -7825,8 +7825,10 @@ components:
           x-field-uid: 5
           $ref: '#/components/schemas/Pattern.Flow.Rsvp.Reserved'
         rsvp_length:
+          description: |-
+            The sum of the lengths of the common header and all objects included in the message.
+          $ref: '#/components/schemas/Flow.RSVP.Length'
           x-field-uid: 6
-          $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpLength'
         message_type:
           description: |-
             An 8-bit number that identifies the function of the RSVP message. There are aound 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 . Among Those we are presently supporting "path"(value: 1) message type.
@@ -7847,7 +7849,44 @@ components:
           enum:
           - not_refresh_reduction_capable
           - refresh_reduction_capable
+    Flow.RSVP.Length:
+      type: object
+      properties:
+        choice:
+          description: |-
+            auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        auto:
+          description: |-
+            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 3
     Flow.RSVP.Message:
+      description: |-
+        RSVP Message type. Currently only "path" message type is supported.
+      type: object
+      properties:
+        message_type:
+          $ref: '#/components/schemas/Flow.RSVP.MessageType'
+          x-field-uid: 1
+    Flow.RSVP.MessageType:
       type: object
       properties:
         choice:
@@ -7864,7 +7903,7 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: |-
-        "path" message required the follwoing list of objects in order: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT ROUTE  5. LABEL_REQUEST 6. SESSION_ATTRIBUTE 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
+        "path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
       type: object
       properties:
         objects:
@@ -29129,86 +29168,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Rsvp.Reserved.Counter'
           x-field-uid: 6
-    Pattern.Flow.Rsvp.RsvpLength.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: auto
-          format: uint32
-          maximum: 65535
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 65535
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 65535
-    Pattern.Flow.Rsvp.RsvpLength:
-      description: |-
-        The sum of the lengths of the common header and all objects included in the message.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            auto:
-              x-field-uid: 1
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: auto
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - auto
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: auto
-          format: uint32
-          maximum: 65535
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 65535
-          x-field-uid: 3
-          default:
-          - auto
-        auto:
-          description: |-
-            The OTG implementation can provide a system generated
-            value for this property. If the OTG is unable to generate a value
-            the default value must be used.
-          type: integer
-          x-field-uid: 4
-          default: auto
-          format: uint32
-          maximum: 65535
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpLength.Counter'
-          x-field-uid: 6
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpLength.Counter'
-          x-field-uid: 7
     Pattern.Flow.RSVP.PathObjects.Length.Counter:
       description: |-
         integer counter pattern

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8230,7 +8230,38 @@ components:
         unsigned_integer_value:
           x-field-uid: 10
           $ref: '#/components/schemas/Pattern.Flow.Snmpv2c.VariableBindingValue.UnsignedIntegerValue'
-<<<<<<< HEAD
+    Flow.Snmpv2c.VariableBindingStringValue:
+      type: object
+      description: |-
+        It contains the raw/ascii string value to be sent.
+      properties:
+        choice:
+          type: string
+          default: ascii
+          x-field-uid: 1
+          x-enum:
+            ascii:
+              x-field-uid: 1
+            raw:
+              x-field-uid: 2
+          enum:
+          - ascii
+          - raw
+        ascii:
+          description: |-
+            It contains the ASCII string to be sent.  As of now it is restricted to 10000 bytes.
+          type: string
+          maxLength: 10000
+          default: ascii
+          x-field-uid: 2
+        raw:
+          description: |-
+            It contains the hex string to be sent.  As of now it is restricted to 10000 bytes.
+          type: string
+          format: hex
+          maxLength: 10000
+          default: '00'
+          x-field-uid: 3
     Flow.Rsvp:
       description: |-
         RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message type is "Path" with mandatory objects and sub-objects.
@@ -9335,39 +9366,6 @@ components:
           minLength: 1
           maxLength: 131050
           default: '0000'
-=======
-    Flow.Snmpv2c.VariableBindingStringValue:
-      type: object
-      description: |-
-        It contains the raw/ascii string value to be sent.
-      properties:
-        choice:
-          type: string
-          default: ascii
-          x-field-uid: 1
-          x-enum:
-            ascii:
-              x-field-uid: 1
-            raw:
-              x-field-uid: 2
-          enum:
-          - ascii
-          - raw
-        ascii:
-          description: |-
-            It contains the ASCII string to be sent.  As of now it is restricted to 10000 bytes.
-          type: string
-          maxLength: 10000
-          default: ascii
-          x-field-uid: 2
-        raw:
-          description: |-
-            It contains the hex string to be sent.  As of now it is restricted to 10000 bytes.
-          type: string
-          format: hex
-          maxLength: 10000
-          default: '00'
->>>>>>> master
           x-field-uid: 3
     Flow.Size:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7912,15 +7912,10 @@ components:
         Every RSVP object encapsulated in an RSVP message consists of a 32-bit word header and the object's contents.
       type: object
       properties:
-        length:
-          description: |-
-            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
-          $ref: '#/components/schemas/Flow.RSVPPathObject.Length'
-          x-field-uid: 1
         class_num:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClass'
-          x-field-uid: 2
-    Flow.RSVPPathObject.Length:
+          x-field-uid: 1
+    Flow.RSVPObject.Length:
       type: object
       properties:
         choice:
@@ -8030,9 +8025,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsSessionCType:
       description: |-
         The body of an object corresponding to the class number and c-type. Currently supported c-type for SESSION object is LSP Tunnel IPv4 (7).
@@ -8072,9 +8072,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsRsvpHopCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsRsvpHopCType:
       description: |-
         Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
@@ -8108,9 +8113,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsTimeValuesCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsTimeValuesCType:
       description: |-
         Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
@@ -8141,9 +8151,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassExplicitRouteCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsClassExplicitRouteCType:
       description: |-
         Object for EXPLICIT_ROUTE class and c-type is Type 1 Explicit Route (1).
@@ -8288,9 +8303,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsLabelRequestCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsLabelRequestCType:
       description: |-
         Object for LABEL_REQUEST class. Currently supported c-type is Without Label Range (1).
@@ -8324,9 +8344,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionAttributeCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsSessionAttributeCType:
       description: |-
         Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
@@ -8491,9 +8516,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSenderTemplateCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsSenderTemplateCType:
       description: |-
         Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
@@ -8530,9 +8560,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSenderTspecCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsSenderTspecCType:
       description: |-
         Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
@@ -8617,9 +8652,14 @@ components:
         C-Type is specific to a class num.
       type: object
       properties:
+        length:
+          description: |-
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsRecordRouteCType'
-          x-field-uid: 1
+          x-field-uid: 2
     Flow.RSVP.PathObjectsRecordRouteCType:
       description: |-
         Object for RECORD_ROUTE class. c-type is Type 1 Route Record (1).
@@ -8780,44 +8820,13 @@ components:
           x-field-uid: 1
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type'
         length:
-          $ref: '#/components/schemas/Flow.RSVP.ObjectOptionsCustom.Length'
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
           x-field-uid: 2
         bytes:
           description: |-
             A custom packet header defined as a string of hex bytes. The string MUST contain sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be discarded. This packet header can be used in multiple places in the packet.
           type: string
           pattern: '^[A-Fa-f0-9: ]+$'
-          x-field-uid: 3
-    Flow.RSVP.ObjectOptionsCustom.Length:
-      description: |-
-        Length for custom options.
-      type: object
-      properties:
-        choice:
-          description: |-
-            auto or configured value.
-          type: string
-          default: auto
-          x-field-uid: 1
-          x-enum:
-            auto:
-              x-field-uid: 1
-            value:
-              x-field-uid: 2
-          enum:
-          - auto
-          - value
-        auto:
-          description: |-
-            OTG will provide a system generated value for this property.  If OTG is unable to generate a value the default value must be used.
-          type: integer
-          format: uint32
-          default: 4
-          x-field-uid: 2
-        value:
-          type: integer
-          format: uint32
-          default: 4
           x-field-uid: 3
     Flow.Size:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8156,6 +8156,14 @@ components:
           x-field-uid: 5
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: |-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsLabelRequestCType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsLabelRequestCType:
+      description: |-
         Object for LABEL_REQUEST class. Currently supported c-type is Without Label Range (1).
       type: object
       properties:
@@ -8183,6 +8191,14 @@ components:
           x-field-uid: 2
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid'
     Flow.RSVP.PathObjectsClassSessionAttribute:
+      description: |-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionAttributeCType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsSessionAttributeCType:
       description: |-
         Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
       type: object
@@ -8321,6 +8337,14 @@ components:
           x-field-uid: 8
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: |-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSenderTemplateCType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsSenderTemplateCType:
+      description: |-
         Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
       type: object
       properties:
@@ -8351,6 +8375,14 @@ components:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.LspId'
     Flow.RSVP.PathObjectsClassSenderTspec:
+      description: |-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSenderTspecCType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsSenderTspecCType:
       description: |-
         Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
       type: object

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7804,7 +7804,7 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.Mpls.TimeToLive'
     Flow.Rsvp:
       description: |-
-        RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message type is "path" with mandatory objects and sub-objects.
+        RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message type is "Path" with mandatory objects and sub-objects.
       type: object
       properties:
         version:
@@ -7831,7 +7831,7 @@ components:
           x-field-uid: 6
         message_type:
           description: |-
-            An 8-bit number that identifies the function of the RSVP message. There are aound 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 . Among Those we are presently supporting "path"(value: 1) message type.
+            An 8-bit number that identifies the function of the RSVP message. There are aound 20 message types defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 . Among these presently supported is "Path"(value: 1) message type.
           $ref: '#/components/schemas/Flow.RSVP.Message'
           x-field-uid: 7
     Flow.RSVP.Flag:
@@ -7868,7 +7868,7 @@ components:
           - value
         auto:
           description: |-
-            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property.  If OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
           maximum: 65535
@@ -7897,12 +7897,12 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: |-
-        "path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
+        "Path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
       type: object
       properties:
         objects:
           description: |-
-            "path" message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
+            "Path" message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
           type: array
           minItems: 6
           items:
@@ -7915,7 +7915,7 @@ components:
       properties:
         length:
           description: |-
-            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4, and at least 4.
+            A 16-bit field containing the total object length in bytes.  Must always be a multiple of 4 or at least 4.
           $ref: '#/components/schemas/Flow.RSVPPathObject.Length'
           x-field-uid: 1
         class_num:
@@ -7940,7 +7940,7 @@ components:
           - value
         auto:
           description: |-
-            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property.  If OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
           minimum: 4
@@ -7956,7 +7956,7 @@ components:
           x-field-uid: 3
     Flow.RSVP.PathObjectsClass:
       description: |-
-        The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "path" message type. "path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored in above options.
+        The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "Path" message type. "Path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored in above options.
       type: object
       required:
       - choice
@@ -8214,7 +8214,7 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit'
         length:
           description: |-
-            The Length contains the total length of the subobject in bytes,including L ,Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+            The Length contains the total length of the subobject in bytes,including L,Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
           $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
           x-field-uid: 2
         ipv4_address:
@@ -8239,7 +8239,7 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit'
         length:
           description: |-
-            The Length contains the total length of the subobject in bytes,including L ,Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+            The Length contains the total length of the subobject in bytes,including L, Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
           $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
           x-field-uid: 2
         reserved:
@@ -8271,8 +8271,8 @@ components:
           - auto
           - value
         auto:
-          description: |-
-            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+          description: "OTG will provide a system generated value for this property.\
+            \  If OTG is unable to generate a value the default value must be used. "
           type: integer
           format: uint32
           maximum: 256
@@ -8374,7 +8374,7 @@ components:
           x-field-uid: 2
         flags:
           description: |-
-            0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+            0x01 Local protection desired, 0x02 Label recording desired, 0x04 SE Style desired
           $ref: '#/components/schemas/Flow.RSVPLspTunnel.Flag'
           x-field-uid: 3
         name_length:
@@ -8425,7 +8425,7 @@ components:
           description: "A 32-bit vector representing a set of attribute filters associated\
             \ with a tunnel all of which must be present for a link to be acceptable.\
             \ A null set (all bits set to zero) automatically passes. The most significant\
-            \ byte in the hex-string is the farthest  to the left in the byte sequence.\
+            \ byte in the hex-string is the farthest to the left in the byte sequence.\
             \  Leading zero bytes in the configured value may be omitted for brevity.\
             \          "
           type: string
@@ -8452,7 +8452,7 @@ components:
           x-field-uid: 5
         flags:
           description: |-
-            0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+            0x01 Local protection desired, 0x02 Label recording desired, 0x04 SE Style desired
           $ref: '#/components/schemas/Flow.RSVPLspTunnel.Flag'
           x-field-uid: 6
         name_length:
@@ -8758,7 +8758,7 @@ components:
           - value
         auto:
           description: |-
-            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property.  If OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
           maximum: 256
@@ -8810,7 +8810,7 @@ components:
           - value
         auto:
           description: |-
-            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property.  If OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
           default: 4
@@ -29091,7 +29091,7 @@ components:
           format: uint32
           maximum: 15
     Pattern.Flow.Rsvp.Version:
-      description: "Protocol Version number. "
+      description: "RSVP Protocol Version. "
       type: object
       properties:
         choice:
@@ -29775,7 +29775,7 @@ components:
           maximum: 1
     Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit:
       description: |-
-        The L bit is an attribute of the subobject.The L bit is set if the subobject represents a loose hop in the explicit route. If the bit is not set, the subobject represents a strict hop in the explicit route.
+        The L bit is an attribute of the subobject. The L bit is set if the subobject represents a loose hop in the explicit route. If the bit is not set, the subobject represents a strict hop in the explicit route.
       type: object
       properties:
         choice:
@@ -29904,7 +29904,7 @@ components:
           maximum: 1
     Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit:
       description: |-
-        The L bit is an attribute of the subobject.The L bit is set if the subobject represents a loose hop in the explicit route. If the bit is not set, the subobject represents a strict hop in the explicit route.
+        The L bit is an attribute of the subobject. The L bit is set if the subobject represents a loose hop in the explicit route. If the bit is not set, the subobject represents a strict hop in the explicit route.
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7956,37 +7956,67 @@ components:
       description: |-
         Object for SESSION class.
       type: object
+      properties:
+        c_type:
+          description: |-
+            Currently supported c-type is LSP Tunnel IPv4 (7).
+          type: string
+          default: lsp_tunnel_ipv4
+          x-enum:
+            lsp_tunnel_ipv4:
+              $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionLspTunnelIpv4'
+              x-field-uid: 1
+          x-field-uid: 1
+          enum:
+          - lsp_tunnel_ipv4
+    Flow.RSVP.PathObjectsSessionLspTunnelIpv4:
+      description: |-
+        Class = SESSION, LSP_TUNNEL_IPv4 C-Type = 7.
+      type: object
+      properties:
+        ipv4_tunnel_end_point_address:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress'
+        reserved:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved'
+        tunnel_id:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId'
+        extended_tunnel_id:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId'
     Flow.RSVP.PathObjectsClassRsvpHop:
       description: |-
-        Object for RSVP_HOP class.
+        Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
       type: object
     Flow.RSVP.PathObjectsClassTimeValues:
       description: |-
-        Object for TIME_VALUES class.
+        Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
       type: object
     Flow.RSVP.PathObjectsClassExplicitRoute:
       description: |-
-        Object for EXPLICIT_ROUTE class.
+        Object for EXPLICIT_ROUTE class. Currently supported c-type is Type 1 Explicit Route (1).
       type: object
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: |-
-        Object for LABEL_REQUEST class.
+        Object for LABEL_REQUEST class. Currently supported c-type is Without Label Range (1).
       type: object
     Flow.RSVP.PathObjectsClassSessionAttribute:
       description: |-
-        Object for SESSION_ATTRIBUTE class.
+        Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
       type: object
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: |-
-        Object for SENDER_TEMPLATE class.
+        Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
       type: object
     Flow.RSVP.PathObjectsClassSenderTspec:
       description: |-
-        Object for SENDER_TSPEC class.
+        Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
       type: object
     Flow.RSVP.PathObjectsClassRecordRoute:
       description: |-
-        Object for RECORD_ROUTE class.
+        Object for RECORD_ROUTE class. Currently supported c-type is Type 1 Route Record (1)
       type: object
     Flow.Size:
       description: |-
@@ -28620,6 +28650,264 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjects.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter:
+      description: |-
+        ipv4 counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 0.0.0.0
+          format: ipv4
+        step:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.1
+          format: ipv4
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress:
+      description: |-
+        IPv4 address of the egress node for the tunnel.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.0
+          format: ipv4
+        values:
+          type: array
+          items:
+            type: string
+            format: ipv4
+          x-field-uid: 3
+          default:
+          - 0.0.0.0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Ipv4TunnelEndPointAddress.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved:
+      description: |-
+        Reserved field, MUST be zero.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.Reserved.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId:
+      description: |-
+        A 16-bit identifier used in the SESSION that remains constant over the life of the tunnel.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.TunnelId.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId:
+      description: |-
+        A 32-bit identifier used in the SESSION that remains constant over the life of the tunnel. Normally set to all zeros. Ingress nodes that wish to narrow the scope of a SESSION to the ingress-egress pair may place their IPv4 address here as a globally unique identifier.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
           x-field-uid: 6
     Version:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7896,14 +7896,13 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: |-
-        "Path" message requires the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
+        "Path" message requires the following list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
       type: object
       properties:
         objects:
           description: |-
             "Path" message requires atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
           type: array
-          minItems: 6
           items:
             $ref: '#/components/schemas/Flow.RSVP.PathObjects'
           x-field-uid: 1
@@ -8261,7 +8260,7 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address'
         prefix:
           description: |-
-            The prefix of the IPv4 address.
+            The prefix length of the IPv4 address.
           type: integer
           format: uint32
           minimum: 1
@@ -8821,7 +8820,7 @@ components:
         c_type:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.CType'
-        contents_of_label_obejct:
+        label:
           description: |-
             The contents of the Label Object. Copied from the Label Object.
           type: string
@@ -29174,7 +29173,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 0
+          default: 64
           format: uint32
           maximum: 255
         step:
@@ -29215,7 +29214,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 0
+          default: 64
           format: uint32
           maximum: 255
         values:
@@ -29226,7 +29225,7 @@ components:
             maximum: 255
           x-field-uid: 3
           default:
-          - 0
+          - 64
         increment:
           $ref: '#/components/schemas/Pattern.Flow.Rsvp.TimeToLive.Counter'
           x-field-uid: 5
@@ -29579,7 +29578,7 @@ components:
           format: uint32
     Pattern.Flow.RSVP.PathSessionExtTunnelId.AsIpv4:
       description: |-
-        IPv4 address of the egress node for the tunnel.
+        IPv4 address of the ingress endpoint for the tunnel.
       type: object
       properties:
         choice:
@@ -30160,7 +30159,8 @@ components:
           maximum: 65535
     Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid:
       description: "An identifier of the layer 3 protocol using this path.  Standard\
-        \ Ethertype values are used.          "
+        \ Ethertype values are used e.g. The default value of 2048 ( 0x0800 ) represents\
+        \ Ethertype for IPv4.          "
       type: object
       properties:
         choice:
@@ -31279,7 +31279,7 @@ components:
           maximum: 255
     Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.PrefixLength:
       description: |-
-        Prefix-length of ipv4 address.
+        Prefix-length of IPv4 address.
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8463,6 +8463,14 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize'
     Flow.RSVP.PathObjectsClassRecordRoute:
       description: |-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsRecordRouteCType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsRecordRouteCType:
+      description: |-
         Object for RECORD_ROUTE class. c-type is Type 1 Route Record (1).
       type: object
       properties:
@@ -8480,7 +8488,34 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathRecordRouteType1:
       description: |-
-        Type1 record route has subobjects. Currently supported subobjects are IPv4 address and Label.
+        C-Type of Type 1 Record Route.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1CType'
+          x-field-uid: 1
+    Flow.RSVP.PathRecordRouteType1CType:
+      description: |-
+        Type1 record route has list of subobjects. Currently supported subobjects are IPv4 address(1) and Label(3).
+      type: object
+      properties:
+        subobjects:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/Flow.RSVP.Type1RecordRouteSubobjects'
+          x-field-uid: 1
+    Flow.RSVP.Type1RecordRouteSubobjects:
+      description: |-
+        Type is specific to a subobject.
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsRecordRouteSubObjectType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsRecordRouteSubObjectType:
+      description: |-
+        Currently supported subobjects are IPv4 address(1) and Label(3).
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7897,12 +7897,12 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: |-
-        "Path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
+        "Path" message requires the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15: 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE [optional]
       type: object
       properties:
         objects:
           description: |-
-            "Path" message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
+            "Path" message requires atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
           type: array
           minItems: 6
           items:
@@ -7956,7 +7956,7 @@ components:
           x-field-uid: 3
     Flow.RSVP.PathObjectsClass:
       description: |-
-        The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "Path" message type. "Path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored in above options.
+        The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "Path" message type. "Path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not supported in above options.
       type: object
       required:
       - choice
@@ -29696,7 +29696,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 0
+          default: 30000
           format: uint32
         step:
           type: integer
@@ -29734,7 +29734,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 0
+          default: 30000
           format: uint32
         values:
           type: array
@@ -29743,7 +29743,7 @@ components:
             format: uint32
           x-field-uid: 3
           default:
-          - 0
+          - 30000
         increment:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathTimeValuesType1.RefreshPeriodR.Counter'
           x-field-uid: 5

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8838,8 +8838,6 @@ components:
       type: object
       description: |-
         Custom packet header
-      required:
-      - bytes
       properties:
         type:
           x-field-uid: 1
@@ -8849,9 +8847,12 @@ components:
           x-field-uid: 2
         bytes:
           description: |-
-            A custom packet header defined as a string of hex bytes. The string MUST contain sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be discarded. This packet header can be used in multiple places in the packet.
+            A custom packet header defined as a string of hex bytes. The string MUST contain sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be discarded. Value of the this field should not excced 65525 bytes since maximum 65528 bytes can be added as object-contents in RSVP header. For type and length requires 3 bytes, hence maximum of 65524 bytes are expected. Maximum length of this attribute is 131050 (65525 * 2 hex character per byte).
           type: string
-          pattern: '^[A-Fa-f0-9: ]+$'
+          format: hex
+          minLength: 1
+          maxLength: 131050
+          default: '0000'
           x-field-uid: 3
     Flow.Size:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8102,9 +8102,9 @@ components:
         IPv4 RSVP_HOP object: Class = 3, C-Type = 1
       type: object
       properties:
-        ipv4_next_previous_hop_address:
+        ipv4_address:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4Address'
         logical_interface_handle:
           x-field-uid: 2
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.LogicalInterfaceHandle'
@@ -8129,13 +8129,13 @@ components:
         choice:
           type: string
           x-field-uid: 1
-          default: type_1_time_value
+          default: type_1
           x-enum:
-            type_1_time_value:
+            type_1:
               x-field-uid: 1
           enum:
-          - type_1_time_value
-        type_1_time_value:
+          - type_1
+        type_1:
           $ref: '#/components/schemas/Flow.RSVP.PathTimeValuesType1'
           x-field-uid: 2
     Flow.RSVP.PathTimeValuesType1:
@@ -8166,14 +8166,14 @@ components:
       properties:
         choice:
           type: string
-          default: type_1_explicit_route
+          default: type_1
           x-field-uid: 1
           x-enum:
-            type_1_explicit_route:
+            type_1:
               x-field-uid: 1
           enum:
-          - type_1_explicit_route
-        type_1_explicit_route:
+          - type_1
+        type_1:
           $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1'
           x-field-uid: 2
     Flow.RSVP.PathExplicitRouteType1:
@@ -8667,14 +8667,14 @@ components:
       properties:
         choice:
           type: string
-          default: type_1_route_record
+          default: type_1
           x-field-uid: 1
           x-enum:
-            type_1_route_record:
+            type_1:
               x-field-uid: 1
           enum:
-          - type_1_route_record
-        type_1_route_record:
+          - type_1
+        type_1:
           $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1'
           x-field-uid: 2
     Flow.RSVP.PathRecordRouteType1:
@@ -29506,7 +29506,7 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter:
+    Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4Address.Counter:
       description: |-
         ipv4 counter pattern
       type: object
@@ -29526,7 +29526,7 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress:
+    Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4Address:
       description: |-
         The IPv4 address of the interface through which the last RSVP-knowledgeable hop forwarded this message.
       type: object
@@ -29563,10 +29563,10 @@ components:
           default:
           - 0.0.0.0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4Address.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRsvpHopIpv4.Ipv4Address.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathRsvpHopIpv4.LogicalInterfaceHandle.Counter:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8835,7 +8835,7 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathObjectsSessionAttributeCType:
       description: |-
-        Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
+        Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel_RA (1) and LSP_Tunnel (7).
       type: object
       properties:
         choice:
@@ -8890,6 +8890,7 @@ components:
         session_name:
           description: "A null padded string of characters.          "
           type: string
+          default: ''
           minLength: 0
           maxLength: 254
           x-field-uid: 5
@@ -8965,6 +8966,7 @@ components:
         session_name:
           description: "A null padded string of characters.          "
           type: string
+          default: ''
           minLength: 0
           maxLength: 254
           x-field-uid: 8

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -32428,7 +32428,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 0
+          default: 5
           format: uint32
           maximum: 65535
         step:
@@ -32469,7 +32469,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 0
+          default: 5
           format: uint32
           maximum: 65535
         values:
@@ -32480,7 +32480,7 @@ components:
             maximum: 65535
           x-field-uid: 3
           default:
-          - 0
+          - 5
         increment:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Length.Counter'
           x-field-uid: 5

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -31402,7 +31402,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 0
+          default: 1
           format: uint32
           maximum: 255
         values:
@@ -31413,7 +31413,7 @@ components:
             maximum: 255
           x-field-uid: 3
           default:
-          - 0
+          - 1
     Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter:
       description: |-
         integer counter pattern

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8404,10 +8404,7 @@ components:
         name_length:
           description: "The length of the display string before padding, in bytes.\
             \          "
-          type: string
-          format: hex
-          default: '0'
-          maxLength: 2
+          $ref: '#/components/schemas/Flow.RSVPSessionAttributeName.Length'
           x-field-uid: 4
         session_name:
           description: "A null padded string of characters.          "
@@ -8482,10 +8479,7 @@ components:
         name_length:
           description: "The length of the display string before padding, in bytes.\
             \          "
-          type: string
-          format: hex
-          default: '0'
-          maxLength: 2
+          $ref: '#/components/schemas/Flow.RSVPSessionAttributeName.Length'
           x-field-uid: 7
         session_name:
           description: "A null padded string of characters.          "
@@ -8511,6 +8505,37 @@ components:
           - local_protection_desired
           - label_recording_desired
           - se_style_desired
+    Flow.RSVPSessionAttributeName.Length:
+      type: object
+      properties:
+        choice:
+          description: |-
+            auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        auto:
+          description: |-
+            OTG will provide a system generated value for this property.  If OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 3
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: |-
         C-Type is specific to a class num.
@@ -30030,7 +30055,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 0
+          default: 2048
           format: uint32
           maximum: 65535
         step:
@@ -30047,7 +30072,7 @@ components:
           maximum: 65535
     Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid:
       description: "An identifier of the layer 3 protocol using this path.  Standard\
-        \ Ethertype values are used.             "
+        \ Ethertype values are used.          "
       type: object
       properties:
         choice:
@@ -30071,7 +30096,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 0
+          default: 2048
           format: uint32
           maximum: 65535
         values:
@@ -30082,7 +30107,7 @@ components:
             maximum: 65535
           x-field-uid: 3
           default:
-          - 0
+          - 2048
         increment:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid.Counter'
           x-field-uid: 5

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8823,10 +8823,39 @@ components:
         label:
           description: |-
             The contents of the Label Object. Copied from the Label Object.
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteLabel'
+          x-field-uid: 4
+    Flow.RSVP.PathRecordRouteLabel:
+      type: object
+      properties:
+        choice:
+          description: |-
+            32 bit integer or hex value.
+          type: string
+          default: as_integer
+          x-field-uid: 1
+          x-enum:
+            as_integer:
+              x-field-uid: 1
+            as_hex:
+              x-field-uid: 2
+          enum:
+          - as_integer
+          - as_hex
+        as_integer:
+          type: integer
+          format: uint32
+          default: 16
+          maximum: 1048575
+          x-field-uid: 2
+        as_hex:
+          description: |-
+            Value of the this field should not excced 4 bytes. Maximum length of this attribute is 8 (4 * 2 hex character per byte).
           type: string
           format: hex
-          default: '00'
-          x-field-uid: 4
+          default: '10'
+          maxLength: 8
+          x-field-uid: 3
     Flow.RSVPRouteRecord.Length:
       type: object
       properties:
@@ -29435,7 +29464,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 0
+          default: 1
           format: uint32
           maximum: 65535
         step:
@@ -29476,7 +29505,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 0
+          default: 1
           format: uint32
           maximum: 65535
         values:
@@ -29487,7 +29516,7 @@ components:
             maximum: 65535
           x-field-uid: 3
           default:
-          - 0
+          - 1
         increment:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionLspTunnelIpv4.TunnelId.Counter'
           x-field-uid: 5
@@ -30339,7 +30368,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 0
+          default: 1
           format: uint32
           maximum: 65535
         step:
@@ -30380,7 +30409,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 0
+          default: 1
           format: uint32
           maximum: 65535
         values:
@@ -30391,7 +30420,7 @@ components:
             maximum: 65535
           x-field-uid: 3
           default:
-          - 0
+          - 1
         increment:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.LspId.Counter'
           x-field-uid: 5

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7808,13 +7808,27 @@ components:
       type: object
       properties:
         version:
+          description: |-
+            RSVP Protocol Version.
+          type: integer
+          format: uint32
+          default: 1
+          maximum: 15
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Version'
         flag:
           description: |-
             Flag, 0x01-0x08: Reserved.
-          $ref: '#/components/schemas/Flow.RSVP.Flag'
+          type: string
+          default: not_refresh_reduction_capable
+          x-enum:
+            not_refresh_reduction_capable:
+              x-field-uid: 1
+            refresh_reduction_capable:
+              x-field-uid: 2
           x-field-uid: 2
+          enum:
+          - not_refresh_reduction_capable
+          - refresh_reduction_capable
         rsvp_checksum:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.Rsvp.RsvpChecksum'
@@ -7834,21 +7848,6 @@ components:
             An 8-bit number that identifies the function of the RSVP message. There are aound 20 message types defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 . Among these presently supported is "Path"(value: 1) message type.
           $ref: '#/components/schemas/Flow.RSVP.Message'
           x-field-uid: 7
-    Flow.RSVP.Flag:
-      type: object
-      properties:
-        choice:
-          type: string
-          default: not_refresh_reduction_capable
-          x-enum:
-            not_refresh_reduction_capable:
-              x-field-uid: 1
-            refresh_reduction_capable:
-              x-field-uid: 2
-          x-field-uid: 1
-          enum:
-          - not_refresh_reduction_capable
-          - refresh_reduction_capable
     Flow.RSVP.Length:
       type: object
       properties:
@@ -29067,72 +29066,6 @@ components:
           items:
             $ref: '#/components/schemas/Pattern.Flow.Mpls.TimeToLive.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Rsvp.Version.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 1
-          format: uint32
-          maximum: 15
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 15
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 15
-    Pattern.Flow.Rsvp.Version:
-      description: "RSVP Protocol Version. "
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 15
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 15
-          x-field-uid: 3
-          default:
-          - 1
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Version.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Rsvp.Version.Counter'
-          x-field-uid: 6
     Pattern.Flow.Rsvp.RsvpChecksum:
       description: |-
         The one's complement of the one's complement sum of the message, with the checksum field replaced by zero for the purpose of computing the checksum.   An all-zero value means that no checksum was transmitted.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8691,15 +8691,15 @@ components:
           x-enum:
             ipv4_prefix:
               x-field-uid: 1
-            four_byte_as_number:
+            as_number:
               x-field-uid: 2
           enum:
           - ipv4_prefix
-          - four_byte_as_number
+          - as_number
         ipv4_prefix:
           $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1Ipv4Prefix'
           x-field-uid: 2
-        four_byte_as_number:
+        as_number:
           $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1ASNumber'
           x-field-uid: 3
     Flow.RSVP.PathExplicitRouteType1Ipv4Prefix:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8740,9 +8740,6 @@ components:
             The Length contains the total length of the subobject in bytes,including L, Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
           $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
           x-field-uid: 2
-        reserved:
-          x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved'
         as_number:
           description: |-
             Autonomous System number to be set in the ERO sub-object that this LSP should traverse through. This field is applicable only if the value of 'type' is set to 'as_number'.
@@ -8750,7 +8747,7 @@ components:
           format: uint32
           default: 0
           maximum: 65535
-          x-field-uid: 4
+          x-field-uid: 3
     Flow.RSVPExplicitRoute.Length:
       type: object
       properties:
@@ -31488,73 +31485,6 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.LBit.Counter'
-          x-field-uid: 6
-    Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: uint32
-          maximum: 255
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 255
-    Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved:
-      description: |-
-        Reserved.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.Reserved.Counter:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7954,6 +7954,14 @@ components:
           x-field-uid: 10
     Flow.RSVP.PathObjectsClassSession:
       description: |-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionCType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsSessionCType:
+      description: |-
         The body of an object corresponding to the class number and c-type. Currently supported c-type for SESSION object is LSP Tunnel IPv4 (7).
       type: object
       properties:
@@ -7988,6 +7996,14 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId'
     Flow.RSVP.PathObjectsClassRsvpHop:
       description: |-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsRsvpHopCType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsRsvpHopCType:
+      description: |-
         Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
       type: object
       properties:
@@ -8015,6 +8031,14 @@ components:
           x-field-uid: 2
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle'
     Flow.RSVP.PathObjectsClassTimeValues:
+      description: |-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        c_type:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsTimeValuesCType'
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsTimeValuesCType:
       description: |-
         Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
       type: object

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8662,7 +8662,7 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathExplicitRouteType1:
       description: |-
-        Type1 Explicit Route has subobjects. Currently supported subobjects are IPv4 prefix and 4-byte AS number.
+        Type1 Explicit Route has subobjects. Currently supported subobjects are IPv4 prefix and Autonomous system number.
       type: object
       properties:
         subobjects:
@@ -8681,7 +8681,7 @@ components:
           x-field-uid: 1
     Flow.RSVP.Type1ExplicitRouteSubobjectsType:
       description: |-
-        Currently supported subobjects are IPv4 address(1) and 4-byte AS number(5).
+        Currently supported subobjects are IPv4 address(1) and Autonomous system number(32).
       type: object
       properties:
         choice:
@@ -8700,7 +8700,7 @@ components:
           $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1Ipv4Prefix'
           x-field-uid: 2
         four_byte_as_number:
-          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1FourByteASNumber'
+          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1ASNumber'
           x-field-uid: 3
     Flow.RSVP.PathExplicitRouteType1Ipv4Prefix:
       description: |-
@@ -8727,14 +8727,14 @@ components:
           maximum: 32
           default: 32
           x-field-uid: 4
-    Flow.RSVP.PathExplicitRouteType1FourByteASNumber:
+    Flow.RSVP.PathExplicitRouteType1ASNumber:
       description: |-
-        Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: 4-byte AS number, C-Type: 32
+        Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: Autonomous system number, C-Type: 32
       type: object
       properties:
         l_bit:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.LBit'
         length:
           description: |-
             The Length contains the total length of the subobject in bytes,including L, Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
@@ -8742,10 +8742,10 @@ components:
           x-field-uid: 2
         reserved:
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved'
         as_number:
           description: |-
-            Autonomous System number to be set in the ERO sub-object that this LSP should traverse through. This field is applicable only if the value of 'type' is set to 'as_number'. Note that as per RFC3209, 4-byte AS encoding is not supported.
+            Autonomous System number to be set in the ERO sub-object that this LSP should traverse through. This field is applicable only if the value of 'type' is set to 'as_number'.
           type: integer
           format: uint32
           default: 0
@@ -31422,7 +31422,7 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit.Counter:
+    Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.LBit.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -31445,7 +31445,7 @@ components:
           default: 1
           format: uint32
           maximum: 1
-    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit:
+    Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.LBit:
       description: |-
         The L bit is an attribute of the subobject. The L bit is set if the subobject represents a loose hop in the explicit route. If the bit is not set, the subobject represents a strict hop in the explicit route.
       type: object
@@ -31484,12 +31484,12 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.LBit.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.LBit.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved.Counter:
+    Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -31512,7 +31512,7 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved:
+    Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved:
       description: |-
         Reserved.
       type: object
@@ -31551,10 +31551,10 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1ASNumber.Reserved.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.Reserved.Counter:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7888,7 +7888,7 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathObjectsClass:
       description: |-
-        The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "path" message type. "path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21.
+        The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 . Curently supported class numbers are for "path" message type. "path" message: Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored in above options.
       type: object
       required:
       - choice
@@ -7915,6 +7915,8 @@ components:
               x-field-uid: 8
             record_route:
               x-field-uid: 9
+            custom:
+              x-field-uid: 10
           enum:
           - session
           - rsvp_hop
@@ -7925,6 +7927,7 @@ components:
           - sender_template
           - sender_tspec
           - record_route
+          - custom
         session:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSession'
           x-field-uid: 2
@@ -7952,6 +7955,9 @@ components:
         record_route:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRecordRoute'
           x-field-uid: 10
+        custom:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsCustom'
+          x-field-uid: 11
     Flow.RSVP.PathObjectsClassSession:
       description: |-
         C-Type is specific to a class num.
@@ -8138,9 +8144,6 @@ components:
         l_bit:
           x-field-uid: 1
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit'
-        type:
-          x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type'
         length:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length'
@@ -8164,9 +8167,6 @@ components:
         l_bit:
           x-field-uid: 1
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit'
-        type:
-          x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type'
         length:
           x-field-uid: 3
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length'
@@ -8560,9 +8560,6 @@ components:
         Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: IPv4 Address, C-Type: 1
       type: object
       properties:
-        type:
-          x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type'
         length:
           x-field-uid: 2
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length'
@@ -8580,9 +8577,6 @@ components:
         Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: Label, C-Type: 3
       type: object
       properties:
-        type:
-          x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Type'
         length:
           x-field-uid: 2
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Length'
@@ -8599,6 +8593,56 @@ components:
           format: hex
           default: '00'
           x-field-uid: 5
+    Flow.RSVP.PathObjectsCustom:
+      type: object
+      description: |-
+        Custom packet header
+      required:
+      - bytes
+      properties:
+        type:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type'
+        length:
+          $ref: '#/components/schemas/Flow.RSVP.ObjectOptionsCustom.Length'
+          x-field-uid: 2
+        bytes:
+          description: |-
+            A custom packet header defined as a string of hex bytes. The string MUST contain sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be discarded. This packet header can be used in multiple places in the packet.
+          type: string
+          pattern: '^[A-Fa-f0-9: ]+$'
+          x-field-uid: 3
+    Flow.RSVP.ObjectOptionsCustom.Length:
+      description: |-
+        Length for custom options.
+      type: object
+      properties:
+        choice:
+          description: |-
+            auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        auto:
+          description: |-
+            The OTG implementation can provide a system generated value for this property. If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          default: 4
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          default: 4
+          x-field-uid: 3
     Flow.Size:
       description: |-
         The frame size which overrides the total length of the packet
@@ -29743,73 +29787,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 1
-          format: uint32
-          maximum: 255
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 255
-    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type:
-      description: |-
-        Subobject type; 0x01  IPv4 address.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 1
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type.Counter'
-          x-field-uid: 6
     Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length.Counter:
       description: |-
         integer counter pattern
@@ -30005,73 +29982,6 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit.Counter'
-          x-field-uid: 6
-    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 1
-          format: uint32
-          maximum: 127
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 127
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 127
-    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type:
-      description: |-
-        Subobject type; 0x05  AS Number.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 127
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 127
-          x-field-uid: 3
-          default:
-          - 1
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type.Counter'
           x-field-uid: 6
     Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length.Counter:
       description: |-
@@ -31403,77 +31313,6 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize.Counter'
           x-field-uid: 6
-    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 1
-          format: uint32
-          maximum: 255
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 255
-      x-constants:
-        ipv4_address: 1
-    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type:
-      description: |-
-        0x01  IPv4 address
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 1
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type.Counter'
-          x-field-uid: 6
-      x-constants:
-        ipv4_address: 1
     Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length.Counter:
       description: |-
         integer counter pattern
@@ -31705,77 +31544,6 @@ components:
       x-constants:
         local_protection_available: 1
         local_protection_in_use: 2
-    Pattern.Flow.RSVP.PathRecordRouteType1Label.Type.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 3
-          format: uint32
-          maximum: 255
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-          maximum: 255
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-          maximum: 255
-      x-constants:
-        label: 3
-    Pattern.Flow.RSVP.PathRecordRouteType1Label.Type:
-      description: |-
-        0x03  Label
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 3
-          format: uint32
-          maximum: 255
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-            maximum: 255
-          x-field-uid: 3
-          default:
-          - 3
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Type.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Type.Counter'
-          x-field-uid: 6
-      x-constants:
-        label: 3
     Pattern.Flow.RSVP.PathRecordRouteType1Label.Length.Counter:
       description: |-
         integer counter pattern
@@ -31910,6 +31678,73 @@ components:
           x-field-uid: 3
           default:
           - 0
+    Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathObjectsCustom.Type:
+      description: |-
+        User defined object type.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter'
+          x-field-uid: 6
     Version:
       description: |-
         Version details

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7990,34 +7990,505 @@ components:
       description: |-
         Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: ipv4
+          x-enum:
+            ipv4:
+              x-field-uid: 1
+          enum:
+          - ipv4
+        ipv4:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRsvpHopIpv4'
+          x-field-uid: 2
+    Flow.RSVP.PathObjectsClassRsvpHopIpv4:
+      description: |-
+        IPv4 RSVP_HOP object: Class = 3, C-Type = 1
+      type: object
+      properties:
+        ipv4_next_previous_hop_address:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress'
+        logical_interface_handle:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle'
     Flow.RSVP.PathObjectsClassTimeValues:
       description: |-
         Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: type_1_time_value
+          x-enum:
+            type_1_time_value:
+              x-field-uid: 1
+          enum:
+          - type_1_time_value
+        type_1_time_value:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassTimeValuesType1'
+          x-field-uid: 2
+    Flow.RSVP.PathObjectsClassTimeValuesType1:
+      description: |-
+        TIME_VALUES Object: Class = 5, C-Type = 1
+      type: object
+      properties:
+        refresh_period_r:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR'
     Flow.RSVP.PathObjectsClassExplicitRoute:
       description: |-
         Object for EXPLICIT_ROUTE class. Currently supported c-type is Type 1 Explicit Route (1).
       type: object
+      properties:
+        choice:
+          type: string
+          default: type_1_explicit_route
+          x-field-uid: 1
+          x-enum:
+            type_1_explicit_route:
+              x-field-uid: 1
+          enum:
+          - type_1_explicit_route
+        type_1_explicit_route:
+          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1'
+          x-field-uid: 2
+    Flow.RSVP.PathExplicitRouteType1:
+      description: |-
+        Type1 Explicit Route has subobjects. Currently supported subobjects are IPv4 prefix and 4-byte AS number.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: ipv4_prefix
+          x-enum:
+            ipv4_prefix:
+              x-field-uid: 1
+            four_byte_as_number:
+              x-field-uid: 2
+          enum:
+          - ipv4_prefix
+          - four_byte_as_number
+        ipv4_prefix:
+          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1Ipv4Prefix'
+          x-field-uid: 2
+        four_byte_as_number:
+          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1FourByteASNumber'
+          x-field-uid: 3
+    Flow.RSVP.PathExplicitRouteType1Ipv4Prefix:
+      description: |-
+        Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: IPv4 Prefix, C-Type: 1
+      type: object
+      properties:
+        l_bit:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit'
+        type:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type'
+        length:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length'
+        ipv4_address:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address'
+        prefix:
+          description: |-
+            The prefix of the IPv4 address.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 32
+          default: 32
+          x-field-uid: 5
+    Flow.RSVP.PathExplicitRouteType1FourByteASNumber:
+      description: |-
+        Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: 4-byte AS number, C-Type: 32
+      type: object
+      properties:
+        l_bit:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit'
+        type:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type'
+        length:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length'
+        reserved:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved'
+        as_number:
+          description: |-
+            Autonomous System number to be set in the ERO sub-object that this LSP should traverse through. This field is applicable only if the value of 'type' is set to 'as_number'. Note that as per RFC3209, 4-byte AS encoding is not supported.
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 65535
+          x-field-uid: 5
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: |-
         Object for LABEL_REQUEST class. Currently supported c-type is Without Label Range (1).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: without_label_range
+          x-enum:
+            without_label_range:
+              x-field-uid: 1
+          enum:
+          - without_label_range
+        without_label_range:
+          $ref: '#/components/schemas/Flow.RSVP.PathLabelRequestWithoutLabelRange'
+          x-field-uid: 2
+    Flow.RSVP.PathLabelRequestWithoutLabelRange:
+      description: |-
+        Class = LABEL_REQUEST, Without Label Range C-Type = 1
+      type: object
+      properties:
+        reserved:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.Reserved'
+        l3pid:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid'
     Flow.RSVP.PathObjectsClassSessionAttribute:
       description: |-
         Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: lsp_tunnel
+          x-enum:
+            lsp_tunnel:
+              x-field-uid: 1
+            lsp_tunnel_ra:
+              x-field-uid: 2
+          enum:
+          - lsp_tunnel
+          - lsp_tunnel_ra
+        lsp_tunnel:
+          $ref: '#/components/schemas/Flow.RSVP.PathSessionAttributeLspTunnel'
+          x-field-uid: 2
+        lsp_tunnel_ra:
+          $ref: '#/components/schemas/Flow.RSVP.PathSessionAttributeLspTunnelRa'
+          x-field-uid: 3
+    Flow.RSVP.PathSessionAttributeLspTunnel:
+      description: |-
+        SESSION_ATTRIBUTE class = 207, LSP_TUNNEL_RA C-Type = 7, resource affinity information.
+      type: object
+      properties:
+        setup_priority:
+          description: |-
+            The priority of the session with respect to taking resources,in the range of 0 to 7. The value 0 is the highest priority. The Setup Priority is used in deciding whether this session can preempt another session.
+          type: integer
+          format: uint32
+          default: 7
+          maximum: 7
+          x-field-uid: 1
+        holding_priority:
+          description: |-
+            The priority of the session with respect to holding resources,in the range of 0 to 7. The value 0 is the highest priority. The Setup Priority is used in deciding whether this session can preempt another session.
+          type: integer
+          format: uint32
+          default: 7
+          maximum: 7
+          x-field-uid: 2
+        flags:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionAttributeLspTunnel.Flags'
+        name_length:
+          description: "The length of the display string before padding, in bytes.\
+            \          "
+          type: string
+          format: hex
+          default: '0'
+          maxLength: 2
+          x-field-uid: 4
+        session_name:
+          description: "A null padded string of characters.          "
+          type: string
+          minLength: 0
+          maxLength: 254
+          x-field-uid: 5
+    Flow.RSVP.PathSessionAttributeLspTunnelRa:
+      description: |-
+        SESSION_ATTRIBUTE class = 207, LSP_TUNNEL_RA C-Type = 1, it carries resource affinity information.
+      type: object
+      properties:
+        exclude_any:
+          description: "A 32-bit vector representing a set of attribute filters associated\
+            \ with a tunnel any of which renders a link unacceptable. A null set (all\
+            \ bits set to zero) doesn't render the link unacceptable. The most significant\
+            \ byte in the hex-string is the farthest  to the left in the byte sequence.\
+            \  Leading zero bytes in the configured value may be omitted for brevity.\
+            \           "
+          type: string
+          format: hex
+          default: '0'
+          minLength: 0
+          maxLength: 8
+          x-field-uid: 1
+        include_any:
+          description: "A 32-bit vector representing a set of attribute filters associated\
+            \ with a tunnel any of which renders a link acceptable. A null set (all\
+            \ bits set to zero) automatically passes. The most significant byte in\
+            \ the hex-string is the farthest  to the left in the byte sequence.  Leading\
+            \ zero bytes in the configured value may be omitted for brevity.     "
+          type: string
+          format: hex
+          default: '0'
+          minLength: 0
+          maxLength: 8
+          x-field-uid: 2
+        include_all:
+          description: "A 32-bit vector representing a set of attribute filters associated\
+            \ with a tunnel all of which must be present for a link to be acceptable.\
+            \ A null set (all bits set to zero) automatically passes. The most significant\
+            \ byte in the hex-string is the farthest  to the left in the byte sequence.\
+            \  Leading zero bytes in the configured value may be omitted for brevity.\
+            \          "
+          type: string
+          format: hex
+          default: '0'
+          minLength: 0
+          maxLength: 8
+          x-field-uid: 3
+        setup_priority:
+          description: |-
+            The priority of the session with respect to taking resources,in the range of 0 to 7. The value 0 is the highest priority. The Setup Priority is used in deciding whether this session can preempt another session.
+          type: integer
+          format: uint32
+          default: 7
+          maximum: 7
+          x-field-uid: 4
+        holding_priority:
+          description: |-
+            The priority of the session with respect to holding resources,in the range of 0 to 7. The value 0 is the highest priority. The Setup Priority is used in deciding whether this session can preempt another session.
+          type: integer
+          format: uint32
+          default: 7
+          maximum: 7
+          x-field-uid: 5
+        flags:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSessionAttributeLspTunnelRa.Flags'
+        name_length:
+          description: "The length of the display string before padding, in bytes.\
+            \          "
+          type: string
+          format: hex
+          default: '0'
+          maxLength: 2
+          x-field-uid: 7
+        session_name:
+          description: "A null padded string of characters.          "
+          type: string
+          minLength: 0
+          maxLength: 254
+          x-field-uid: 8
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: |-
         Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: lsp_tunnel_ipv4
+          x-enum:
+            lsp_tunnel_ipv4:
+              x-field-uid: 1
+          enum:
+          - lsp_tunnel_ipv4
+        lsp_tunnel_ipv4:
+          $ref: '#/components/schemas/Flow.RSVP.PathSenderTemplateLspTunnelIpv4'
+          x-field-uid: 2
+    Flow.RSVP.PathSenderTemplateLspTunnelIpv4:
+      description: |-
+        Class = SENDER_TEMPLATE, LSP_TUNNEL_IPv4 C-Type = 7
+      type: object
+      properties:
+        ipv4_tunnel_sender_address:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Ipv4TunnelSenderAddress'
+        reserved:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Reserved'
+        lsp_id:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.LspId'
     Flow.RSVP.PathObjectsClassSenderTspec:
       description: |-
         Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: int_serv
+          x-enum:
+            int_serv:
+              x-field-uid: 1
+          enum:
+          - int_serv
+        int_serv:
+          $ref: '#/components/schemas/Flow.RSVP.PathSenderTspecIntServ'
+          x-field-uid: 2
+    Flow.RSVP.PathSenderTspecIntServ:
+      description: |-
+        int-serv SENDER_TSPEC object: Class = 12, C-Type = 2
+      type: object
+      properties:
+        version:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Version'
+        reserved1:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved1'
+        overall_length:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.OverallLength'
+        service_header:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader'
+        zero_bit:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ZeroBit'
+        reserved2:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved2'
+        length_of_service_data:
+          x-field-uid: 7
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.LengthOfServiceData'
+        parameter_id_token_bucket_tspec:
+          x-field-uid: 8
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ParameterIdTokenBucketTspec'
+        parameter_127_flag:
+          x-field-uid: 9
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Flag'
+        parameter_127_length:
+          x-field-uid: 10
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Length'
+        token_bucket_rate:
+          description: |-
+            Token bucket rate is set to sender's view of its generated traffic.
+          type: number
+          format: float
+          default: 0
+          x-field-uid: 11
+        token_bucket_size:
+          description: |-
+            Token bucket size is set to sender's view of its generated traffic.
+          type: number
+          format: float
+          default: 0
+          x-field-uid: 12
+        peak_data_rate:
+          description: |-
+            The peak rate may be set to the sender's peak traffic generation rate (if known and controlled), the physical interface line rate (if known), or positive infinity (if no better value is available).
+          type: number
+          format: float
+          default: 0
+          x-field-uid: 13
+        minimum_policed_unit:
+          x-field-uid: 14
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit'
+        maximum_packet_size:
+          x-field-uid: 15
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize'
     Flow.RSVP.PathObjectsClassRecordRoute:
       description: |-
-        Object for RECORD_ROUTE class. Currently supported c-type is Type 1 Route Record (1)
+        Object for RECORD_ROUTE class. c-type is Type 1 Route Record (1).
       type: object
+      properties:
+        choice:
+          type: string
+          default: type_1_route_record
+          x-field-uid: 1
+          x-enum:
+            type_1_route_record:
+              x-field-uid: 1
+          enum:
+          - type_1_route_record
+        type_1_route_record:
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1'
+          x-field-uid: 2
+    Flow.RSVP.PathRecordRouteType1:
+      description: |-
+        Type1 record route has subobjects. Currently supported subobjects are IPv4 address and Label.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: ipv4_address
+          x-enum:
+            ipv4_address:
+              x-field-uid: 1
+            label:
+              x-field-uid: 2
+          enum:
+          - ipv4_address
+          - label
+        ipv4_address:
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1Ipv4Address'
+          x-field-uid: 2
+        label:
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1Label'
+          x-field-uid: 3
+    Flow.RSVP.PathRecordRouteType1Ipv4Address:
+      description: |-
+        Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: IPv4 Address, C-Type: 1
+      type: object
+      properties:
+        type:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type'
+        length:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length'
+        ipv4_address:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address'
+        prefix_length:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.PrefixLength'
+        flags:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Flags'
+    Flow.RSVP.PathRecordRouteType1Label:
+      description: |-
+        Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: Label, C-Type: 3
+      type: object
+      properties:
+        type:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Type'
+        length:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Length'
+        flags:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Flags'
+        c_type:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.CType'
+        contents_of_label_obejct:
+          description: |-
+            The contents of the Label Object. Copied from the Label Object.
+          type: string
+          format: hex
+          default: '00'
+          x-field-uid: 5
     Flow.Size:
       description: |-
         The frame size which overrides the total length of the packet
@@ -28909,6 +29380,2426 @@ components:
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsSessionLspTunnelIpv4.ExtendedTunnelId.Counter'
           x-field-uid: 6
+    Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter:
+      description: |-
+        ipv4 counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 0.0.0.0
+          format: ipv4
+        step:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.1
+          format: ipv4
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress:
+      description: |-
+        The IPv4 address of the interface through which the last RSVP-knowledgeable hop forwarded this message.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.0
+          format: ipv4
+        values:
+          type: array
+          items:
+            type: string
+            format: ipv4
+          x-field-uid: 3
+          default:
+          - 0.0.0.0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.Ipv4NextPreviousHopAddress.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle:
+      description: |-
+        Logical Interface Handle (LIH) is used to distinguish logical outgoing interfaces. A node receiving an LIH in a Path message saves its value and returns it in the HOP objects of subsequent Resv messages sent to the node that originated the LIH. The LIH should be identically zero if there is no logical interface handle.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassRsvpHopIpv4.LogicalInterfaceHandle.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR:
+      description: |-
+        The refresh timeout period R used to generate this message;in milliseconds.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsClassTimeValuesType1.RefreshPeriodR.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit:
+      description: |-
+        The L bit is an attribute of the subobject.The L bit is set if the subobject represents a loose hop in the explicit route. If the bit is not set, the subobject represents a strict hop in the explicit route.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.LBit.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type:
+      description: |-
+        Subobject type; 0x01  IPv4 address.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 8
+          format: uint32
+          maximum: 127
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 127
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 127
+    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length:
+      description: |-
+        The Length contains the total length of the subobject in bytes,including the Type and Length fields.   The Length is always 8.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 8
+          format: uint32
+          maximum: 127
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 127
+          x-field-uid: 3
+          default:
+          - 8
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address.Counter:
+      description: |-
+        ipv4 counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 0.0.0.0
+          format: ipv4
+        step:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.1
+          format: ipv4
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address:
+      description: |-
+        This IPv4 address is treated as a prefix based on the prefix length value below.  Bits beyond the prefix are ignored on receipt and SHOULD be set to zero on transmission.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.0
+          format: ipv4
+        values:
+          type: array
+          items:
+            type: string
+            format: ipv4
+          x-field-uid: 3
+          default:
+          - 0.0.0.0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1Ipv4Prefix.Ipv4Address.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit:
+      description: |-
+        The L bit is an attribute of the subobject.The L bit is set if the subobject represents a loose hop in the explicit route. If the bit is not set, the subobject represents a strict hop in the explicit route.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.LBit.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 127
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 127
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 127
+    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type:
+      description: |-
+        Subobject type; 0x05  AS Number.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 127
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 127
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 8
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length:
+      description: |-
+        The Length contains the total length of the subobject in bytes,including the Type and Length fields.   The Length is always 8.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 8
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 8
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved:
+      description: |-
+        Reserved.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathExplicitRouteType1FourByteASNumber.Reserved.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.Reserved.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.Reserved:
+      description: "This field is reserved.   It MUST be set to zero on transmission\
+        \ and MUST be ignored on receipt.              "
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.Reserved.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.Reserved.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid:
+      description: "An identifier of the layer 3 protocol using this path.  Standard\
+        \ Ethertype values are used.             "
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathLabelRequestWithoutLabelRange.L3pid.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSessionAttributeLspTunnel.Flags:
+      description: |-
+        0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+      x-constants:
+        local_protection_desired: 1
+        label_recording_desired: 2
+        se_style_desired: 3
+    Pattern.Flow.RSVP.PathSessionAttributeLspTunnelRa.Flags:
+      description: |-
+        0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+      x-constants:
+        local_protection_desired: 1
+        label_recording_desired: 2
+        se_style_desired: 4
+    Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Ipv4TunnelSenderAddress.Counter:
+      description: |-
+        ipv4 counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 0.0.0.0
+          format: ipv4
+        step:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.1
+          format: ipv4
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Ipv4TunnelSenderAddress:
+      description: |-
+        IPv4 address for a sender node.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.0
+          format: ipv4
+        values:
+          type: array
+          items:
+            type: string
+            format: ipv4
+          x-field-uid: 3
+          default:
+          - 0.0.0.0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Ipv4TunnelSenderAddress.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Ipv4TunnelSenderAddress.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Reserved.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Reserved:
+      description: |-
+        Reserved field, MUST be zero.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Reserved.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.Reserved.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.LspId.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.LspId:
+      description: |-
+        A 16-bit identifier used in the SENDER_TEMPLATE that can be changed to allow a sender to share resources with itself.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.LspId.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTemplateLspTunnelIpv4.LspId.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Version.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 15
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 15
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 15
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Version:
+      description: |-
+        Message format version number.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 15
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 15
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Version.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Version.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved1.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 4095
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 4095
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 4095
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved1:
+      description: |-
+        Reserved.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 4095
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 4095
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved1.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved1.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.OverallLength.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 7
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.OverallLength:
+      description: |-
+        Overall length (7 words not including header).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 7
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 7
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.OverallLength.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.OverallLength.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader:
+      description: |-
+        Service header, service number - '1' (Generic information) if in a PATH message.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ServiceHeader.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.ZeroBit.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.ZeroBit:
+      description: |-
+        MUST be 0.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ZeroBit.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ZeroBit.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved2.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 127
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 127
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 127
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved2:
+      description: |-
+        Reserved.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 127
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 127
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved2.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Reserved2.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.LengthOfServiceData.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 6
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.LengthOfServiceData:
+      description: |-
+        Length of service data, 6 words not including per-service header.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 6
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 6
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.LengthOfServiceData.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.LengthOfServiceData.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.ParameterIdTokenBucketTspec.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 127
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.ParameterIdTokenBucketTspec:
+      description: |-
+        Parameter ID, parameter 127 (Token Bucket TSpec)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 127
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 127
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ParameterIdTokenBucketTspec.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.ParameterIdTokenBucketTspec.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Flag.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Flag:
+      description: |-
+        Parameter 127 flags (none set)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Flag.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Flag.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Length:
+      description: |-
+        Parameter 127 length, 5 words not including per-service header
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.Parameter127Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit:
+      description: |-
+        The minimum policed unit parameter should generally be set equal to the size of the smallest packet generated by the application.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MinimumPolicedUnit.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize:
+      description: |-
+        The maximum packet size parameter should be set to the size of the largest packet the application might wish to generate. This value must, by definition, be equal to or larger than the value of The minimum policed unit.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathSenderTspecIntServ.MaximumPacketSize.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+      x-constants:
+        ipv4_address: 1
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type:
+      description: |-
+        0x01  IPv4 address
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Type.Counter'
+          x-field-uid: 6
+      x-constants:
+        ipv4_address: 1
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 8
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length:
+      description: |-
+        The Length contains the total length of the subobject in bytes, including the Type and Length fields.  The Length is always 8.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 8
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 8
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address.Counter:
+      description: |-
+        ipv4 counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 0.0.0.0
+          format: ipv4
+        step:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.1
+          format: ipv4
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address:
+      description: |-
+        A 32-bit unicast, host address.  Any network-reachable interface address is allowed here. Illegal addresses, such as certain loopback addresses, SHOULD NOT be used.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.0
+          format: ipv4
+        values:
+          type: array
+          items:
+            type: string
+            format: ipv4
+          x-field-uid: 3
+          default:
+          - 0.0.0.0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Ipv4Address.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.PrefixLength.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 32
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.PrefixLength:
+      description: |-
+        Prefix-length of ipv4 address.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 32
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 32
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.PrefixLength.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.PrefixLength.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathRecordRouteType1Ipv4Address.Flags:
+      description: |-
+        0x01  local_protection_available, 0x02  local_protection_in_use
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+      x-constants:
+        local_protection_available: 1
+        local_protection_in_use: 2
+    Pattern.Flow.RSVP.PathRecordRouteType1Label.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 3
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+      x-constants:
+        label: 3
+    Pattern.Flow.RSVP.PathRecordRouteType1Label.Type:
+      description: |-
+        0x03  Label
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 3
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 3
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Type.Counter'
+          x-field-uid: 6
+      x-constants:
+        label: 3
+    Pattern.Flow.RSVP.PathRecordRouteType1Label.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 8
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.RSVP.PathRecordRouteType1Label.Length:
+      description: "The Length contains the total length of the subobject in bytes,\
+        \ including the Type and Length fields.  "
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 8
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 8
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.RSVP.PathRecordRouteType1Label.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.RSVP.PathRecordRouteType1Label.Flags:
+      description: |-
+        0x01 = Global label. This flag indicates that the label will be understood if received on any interface.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+      x-constants:
+        local_protection_available: 1
+        local_protection_in_use: 2
+    Pattern.Flow.RSVP.PathRecordRouteType1Label.CType:
+      description: |-
+        The C-Type of the included Label Object. Copied from the Label object.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
     Version:
       description: |-
         Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5833,7 +5833,7 @@ message FlowMpls {
 }
 
 // RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message
-// type is path.
+// type is path with mandatory objects and sub-objects.
 message FlowRsvp {
 
   // Description missing in models
@@ -5851,8 +5851,8 @@ message FlowRsvp {
   // Description missing in models
   PatternFlowRsvpReserved reserved = 5;
 
-  // Description missing in models
-  PatternFlowRsvpRsvpLength rsvp_length = 6;
+  // The sum of the lengths of the common header and all objects included in the message.
+  FlowRSVPLength rsvp_length = 6;
 
   // An 8-bit number that identifies the function of the RSVP message. There are aound
   // 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
@@ -5876,7 +5876,38 @@ message FlowRSVPFlag {
 }
 
 // Description missing in models
+message FlowRSVPLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // The OTG implementation can provide a system generated value for this property. If
+  // the OTG is unable to generate a value the default value must be used.
+  // default = 0
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 3;
+}
+
+// RSVP Message type. Currently only path message type is supported.
 message FlowRSVPMessage {
+
+  // Description missing in models
+  FlowRSVPMessageType message_type = 1;
+}
+
+// Description missing in models
+message FlowRSVPMessageType {
 
   message Choice {
     enum Enum {
@@ -5892,9 +5923,10 @@ message FlowRSVPMessage {
   FlowRSVPPathMessage path = 2;
 }
 
-// path message required the follwoing list of objects in order: 1. SESSION 2. RSVP_HOP
-// 3. TIME_VALUES 4. EXPLICIT ROUTE  5. LABEL_REQUEST 6. SESSION_ATTRIBUTE 7. SENDER_TEMPLATE
-// 8. SENDER_TSPEC 9. RECORD_ROUTE
+// path message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+// 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT ROUTE [optional] 5. LABEL_REQUEST
+// 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
+// [optional]
 message FlowRSVPPathMessage {
 
   // path message required atleast SESSION, RSVP_HOP and TIME_VALUES objects.
@@ -20630,60 +20662,6 @@ message PatternFlowRsvpReserved {
 
   // Description missing in models
   PatternFlowRsvpReservedCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowRsvpRsvpLengthCounter {
-
-  // Description missing in models
-  // default = auto
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// The sum of the lengths of the common header and all objects included in the message.
-message PatternFlowRsvpRsvpLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      auto = 1;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.auto
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = auto
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = ['auto']
-  repeated uint32 values = 3;
-
-  // The OTG implementation can provide a system generated
-  // value for this property. If the OTG is unable to generate a value
-  // the default value must be used.
-  // default = auto
-  optional uint32 auto = 4;
-
-  // Description missing in models
-  PatternFlowRsvpRsvpLengthCounter increment = 6;
-
-  // Description missing in models
-  PatternFlowRsvpRsvpLengthCounter decrement = 7;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6348,8 +6348,7 @@ message FlowRSVPPathSessionAttributeLspTunnel {
   FlowRSVPLspTunnelFlag flags = 3;
 
   // The length of the display string before padding, in bytes.
-  // default = 0
-  optional string name_length = 4;
+  FlowRSVPSessionAttributeNameLength name_length = 4;
 
   // A null padded string of characters.
   optional string session_name = 5;
@@ -6399,8 +6398,7 @@ message FlowRSVPPathSessionAttributeLspTunnelRa {
   FlowRSVPLspTunnelFlag flags = 6;
 
   // The length of the display string before padding, in bytes.
-  // default = 0
-  optional string name_length = 7;
+  FlowRSVPSessionAttributeNameLength name_length = 7;
 
   // A null padded string of characters.
   optional string session_name = 8;
@@ -6420,6 +6418,30 @@ message FlowRSVPLspTunnelFlag {
   // Description missing in models
   // default = Choice.Enum.local_protection_desired
   optional Choice.Enum choice = 1;
+}
+
+// Description missing in models
+message FlowRSVPSessionAttributeNameLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
+  // default = 0
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 3;
 }
 
 // C-Type is specific to a class num.
@@ -21302,7 +21324,7 @@ message PatternFlowRSVPPathLabelRequestWithoutLabelRangeReserved {
 message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pidCounter {
 
   // Description missing in models
-  // default = 0
+  // default = 2048
   optional uint32 start = 1;
 
   // Description missing in models
@@ -21332,11 +21354,11 @@ message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pid {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 0
+  // default = 2048
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [0]
+  // default = [2048]
   repeated uint32 values = 3;
 
   // Description missing in models

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5925,16 +5925,12 @@ message FlowRSVPPathMessage {
 // and the object's contents.
 message FlowRSVPPathObjects {
 
-  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
-  // of 4 or at least 4.
-  FlowRSVPPathObjectLength length = 1;
-
   // Description missing in models
-  FlowRSVPPathObjectsClass class_num = 2;
+  FlowRSVPPathObjectsClass class_num = 1;
 }
 
 // Description missing in models
-message FlowRSVPPathObjectLength {
+message FlowRSVPObjectLength {
 
   message Choice {
     enum Enum {
@@ -6018,8 +6014,12 @@ message FlowRSVPPathObjectsClass {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassSession {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsSessionCType c_type = 1;
+  FlowRSVPPathObjectsSessionCType c_type = 2;
 }
 
 // The body of an object corresponding to the class number and c-type. Currently supported
@@ -6059,8 +6059,12 @@ message FlowRSVPPathSessionLspTunnelIpv4 {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassRsvpHop {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsRsvpHopCType c_type = 1;
+  FlowRSVPPathObjectsRsvpHopCType c_type = 2;
 }
 
 // Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
@@ -6093,8 +6097,12 @@ message FlowRSVPPathRsvpHopIpv4 {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassTimeValues {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsTimeValuesCType c_type = 1;
+  FlowRSVPPathObjectsTimeValuesCType c_type = 2;
 }
 
 // Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
@@ -6124,8 +6132,12 @@ message FlowRSVPPathTimeValuesType1 {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassExplicitRoute {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsClassExplicitRouteCType c_type = 1;
+  FlowRSVPPathObjectsClassExplicitRouteCType c_type = 2;
 }
 
 // Object for EXPLICIT_ROUTE class and c-type is Type 1 Explicit Route (1).
@@ -6248,8 +6260,12 @@ message FlowRSVPExplicitRouteLength {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassLabelRequest {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsLabelRequestCType c_type = 1;
+  FlowRSVPPathObjectsLabelRequestCType c_type = 2;
 }
 
 // Object for LABEL_REQUEST class. Currently supported c-type is Without Label Range
@@ -6283,8 +6299,12 @@ message FlowRSVPPathLabelRequestWithoutLabelRange {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassSessionAttribute {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsSessionAttributeCType c_type = 1;
+  FlowRSVPPathObjectsSessionAttributeCType c_type = 2;
 }
 
 // Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1)
@@ -6405,8 +6425,12 @@ message FlowRSVPLspTunnelFlag {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassSenderTemplate {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsSenderTemplateCType c_type = 1;
+  FlowRSVPPathObjectsSenderTemplateCType c_type = 2;
 }
 
 // Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
@@ -6442,8 +6466,12 @@ message FlowRSVPPathSenderTemplateLspTunnelIpv4 {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassSenderTspec {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsSenderTspecCType c_type = 1;
+  FlowRSVPPathObjectsSenderTspecCType c_type = 2;
 }
 
 // Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
@@ -6520,8 +6548,12 @@ message FlowRSVPPathSenderTspecIntServ {
 // C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassRecordRoute {
 
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
   // Description missing in models
-  FlowRSVPPathObjectsRecordRouteCType c_type = 1;
+  FlowRSVPPathObjectsRecordRouteCType c_type = 2;
 }
 
 // Object for RECORD_ROUTE class. c-type is Type 1 Route Record (1).
@@ -6659,37 +6691,13 @@ message FlowRSVPPathObjectsCustom {
   PatternFlowRSVPPathObjectsCustomType type = 1;
 
   // Description missing in models
-  FlowRSVPObjectOptionsCustomLength length = 2;
+  FlowRSVPObjectLength length = 2;
 
   // A custom packet header defined as a string of hex bytes. The string MUST contain
   // sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be
   // discarded. This packet header can be used in multiple places in the packet.
   // required = true
   optional string bytes = 3;
-}
-
-// Length for custom options.
-message FlowRSVPObjectOptionsCustomLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      auto = 1;
-      value = 2;
-    }
-  }
-  // auto or configured value.
-  // default = Choice.Enum.auto
-  optional Choice.Enum choice = 1;
-
-  // OTG will provide a system generated value for this property.  If OTG is unable to
-  // generate a value the default value must be used.
-  // default = 4
-  optional uint32 auto = 2;
-
-  // Description missing in models
-  // default = 4
-  optional uint32 value = 3;
 }
 
 // The frame size which overrides the total length of the packet

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5916,13 +5916,13 @@ message FlowRSVPMessage {
   FlowRSVPPathMessage path = 2;
 }
 
-// Path message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+// Path message requires the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
 // 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST
 // 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
 // [optional]
 message FlowRSVPPathMessage {
 
-  // Path message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE
+  // Path message requires atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE
   // and SENDER_TSPEC objects in order.
   repeated FlowRSVPPathObjects objects = 1;
 }
@@ -5967,7 +5967,7 @@ message FlowRSVPPathObjectLength {
 // . Curently supported class numbers are for Path message type. Path message: Supported
 // Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE:
 // 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC:
-// 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored
+// 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not supported
 // in above options.
 message FlowRSVPPathObjectsClass {
 
@@ -21059,7 +21059,7 @@ message PatternFlowRSVPPathRsvpHopIpv4LogicalInterfaceHandle {
 message PatternFlowRSVPPathTimeValuesType1RefreshPeriodRCounter {
 
   // Description missing in models
-  // default = 0
+  // default = 30000
   optional uint32 start = 1;
 
   // Description missing in models
@@ -21088,11 +21088,11 @@ message PatternFlowRSVPPathTimeValuesType1RefreshPeriodR {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 0
+  // default = 30000
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [0]
+  // default = [30000]
   repeated uint32 values = 3;
 
   // Description missing in models

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5899,15 +5899,8 @@ message FlowRSVPLength {
   optional uint32 value = 3;
 }
 
-// RSVP Message type. Currently only path message type is supported.
-message FlowRSVPMessage {
-
-  // Description missing in models
-  FlowRSVPMessageType message_type = 1;
-}
-
 // Description missing in models
-message FlowRSVPMessageType {
+message FlowRSVPMessage {
 
   message Choice {
     enum Enum {
@@ -5924,12 +5917,13 @@ message FlowRSVPMessageType {
 }
 
 // path message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
-// 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT ROUTE [optional] 5. LABEL_REQUEST
+// 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST
 // 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
 // [optional]
 message FlowRSVPPathMessage {
 
-  // path message required atleast SESSION, RSVP_HOP and TIME_VALUES objects.
+  // path message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE
+  // and SENDER_TSPEC objects in order.
   repeated FlowRSVPPathObjects objects = 1;
 }
 
@@ -5937,11 +5931,36 @@ message FlowRSVPPathMessage {
 // and the object's contents.
 message FlowRSVPPathObjects {
 
-  // Description missing in models
-  PatternFlowRSVPPathObjectsLength length = 1;
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4, and at least 4.
+  FlowRSVPPathObjectLength length = 1;
 
   // Description missing in models
   FlowRSVPPathObjectsClass class_num = 2;
+}
+
+// Description missing in models
+message FlowRSVPPathObjectLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // The OTG implementation can provide a system generated value for this property. If
+  // the OTG is unable to generate a value the default value must be used.
+  // default = 4
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 4
+  optional uint32 value = 3;
 }
 
 // The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4
@@ -6024,23 +6043,23 @@ message FlowRSVPPathObjectsSessionCType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  FlowRSVPPathObjectsSessionLspTunnelIpv4 lsp_tunnel_ipv4 = 2;
+  FlowRSVPPathSessionLspTunnelIpv4 lsp_tunnel_ipv4 = 2;
 }
 
 // Class = SESSION, LSP_TUNNEL_IPv4 C-Type = 7.
-message FlowRSVPPathObjectsSessionLspTunnelIpv4 {
+message FlowRSVPPathSessionLspTunnelIpv4 {
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddress ipv4_tunnel_end_point_address = 1;
+  PatternFlowRSVPPathSessionLspTunnelIpv4Ipv4TunnelEndPointAddress ipv4_tunnel_end_point_address = 1;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Reserved reserved = 2;
+  PatternFlowRSVPPathSessionLspTunnelIpv4Reserved reserved = 2;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelId tunnel_id = 3;
+  PatternFlowRSVPPathSessionLspTunnelIpv4TunnelId tunnel_id = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelId extended_tunnel_id = 4;
+  PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelId extended_tunnel_id = 4;
 }
 
 // C-Type is specific to a class num.
@@ -6064,17 +6083,17 @@ message FlowRSVPPathObjectsRsvpHopCType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  FlowRSVPPathObjectsClassRsvpHopIpv4 ipv4 = 2;
+  FlowRSVPPathRsvpHopIpv4 ipv4 = 2;
 }
 
 // IPv4 RSVP_HOP object: Class = 3, C-Type = 1
-message FlowRSVPPathObjectsClassRsvpHopIpv4 {
+message FlowRSVPPathRsvpHopIpv4 {
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddress ipv4_next_previous_hop_address = 1;
+  PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddress ipv4_next_previous_hop_address = 1;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandle logical_interface_handle = 2;
+  PatternFlowRSVPPathRsvpHopIpv4LogicalInterfaceHandle logical_interface_handle = 2;
 }
 
 // C-Type is specific to a class num.
@@ -6098,14 +6117,14 @@ message FlowRSVPPathObjectsTimeValuesCType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  FlowRSVPPathObjectsClassTimeValuesType1 type_1_time_value = 2;
+  FlowRSVPPathTimeValuesType1 type_1_time_value = 2;
 }
 
 // TIME_VALUES Object: Class = 5, C-Type = 1
-message FlowRSVPPathObjectsClassTimeValuesType1 {
+message FlowRSVPPathTimeValuesType1 {
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodR refresh_period_r = 1;
+  PatternFlowRSVPPathTimeValuesType1RefreshPeriodR refresh_period_r = 1;
 }
 
 // C-Type is specific to a class num.
@@ -6115,8 +6134,7 @@ message FlowRSVPPathObjectsClassExplicitRoute {
   FlowRSVPPathObjectsClassExplicitRouteCType c_type = 1;
 }
 
-// Object for EXPLICIT_ROUTE class. Currently supported c-type is Type 1 Explicit Route
-// (1).
+// Object for EXPLICIT_ROUTE class and c-type is Type 1 Explicit Route (1).
 message FlowRSVPPathObjectsClassExplicitRouteCType {
 
   message Choice {
@@ -6176,15 +6194,16 @@ message FlowRSVPPathExplicitRouteType1Ipv4Prefix {
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBit l_bit = 1;
 
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLength length = 3;
+  // The Length contains the total length of the subobject in bytes,including L ,Type
+  // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+  FlowRSVPExplicitRouteLength length = 2;
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4Address ipv4_address = 4;
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4Address ipv4_address = 3;
 
   // The prefix of the IPv4 address.
   // default = 32
-  optional uint32 prefix = 5;
+  optional uint32 prefix = 4;
 }
 
 // Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: 4-byte AS number,
@@ -6194,17 +6213,42 @@ message FlowRSVPPathExplicitRouteType1FourByteASNumber {
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit l_bit = 1;
 
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLength length = 3;
+  // The Length contains the total length of the subobject in bytes,including L ,Type
+  // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+  FlowRSVPExplicitRouteLength length = 2;
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReserved reserved = 4;
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReserved reserved = 3;
 
   // Autonomous System number to be set in the ERO sub-object that this LSP should traverse
   // through. This field is applicable only if the value of 'type' is set to 'as_number'.
   // Note that as per RFC3209, 4-byte AS encoding is not supported.
   // default = 0
-  optional uint32 as_number = 5;
+  optional uint32 as_number = 4;
+}
+
+// Description missing in models
+message FlowRSVPExplicitRouteLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // The OTG implementation can provide a system generated value for this property. If
+  // the OTG is unable to generate a value the default value must be used.
+  // default = 8
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 8
+  optional uint32 value = 3;
 }
 
 // C-Type is specific to a class num.
@@ -6286,8 +6330,8 @@ message FlowRSVPPathSessionAttributeLspTunnel {
   // default = 7
   optional uint32 holding_priority = 2;
 
-  // Description missing in models
-  PatternFlowRSVPPathSessionAttributeLspTunnelFlags flags = 3;
+  // 0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+  FlowRSVPLspTunnelFlag flags = 3;
 
   // The length of the display string before padding, in bytes.
   // default = 0
@@ -6337,8 +6381,8 @@ message FlowRSVPPathSessionAttributeLspTunnelRa {
   // default = 7
   optional uint32 holding_priority = 5;
 
-  // Description missing in models
-  PatternFlowRSVPPathSessionAttributeLspTunnelRaFlags flags = 6;
+  // 0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+  FlowRSVPLspTunnelFlag flags = 6;
 
   // The length of the display string before padding, in bytes.
   // default = 0
@@ -6346,6 +6390,22 @@ message FlowRSVPPathSessionAttributeLspTunnelRa {
 
   // A null padded string of characters.
   optional string session_name = 8;
+}
+
+// Description missing in models
+message FlowRSVPLspTunnelFlag {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      local_protection_desired = 1;
+      label_recording_desired = 2;
+      se_style_desired = 3;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.local_protection_desired
+  optional Choice.Enum choice = 1;
 }
 
 // C-Type is specific to a class num.
@@ -6527,34 +6587,75 @@ message FlowRSVPPathObjectsRecordRouteSubObjectType {
 // 1
 message FlowRSVPPathRecordRouteType1Ipv4Address {
 
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressLength length = 2;
+  // The Length contains the total length of the subobject in bytes, including the Type
+  // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+  FlowRSVPRouteRecordLength length = 1;
 
   // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressIpv4Address ipv4_address = 3;
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressIpv4Address ipv4_address = 2;
 
   // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLength prefix_length = 4;
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLength prefix_length = 3;
 
+  // 0x01  local_protection_available, 0x02  local_protection_in_use
+  FlowRSVPRecordRouteIPv4Flag flags = 4;
+}
+
+// Description missing in models
+message FlowRSVPRecordRouteIPv4Flag {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      local_protection_available = 1;
+      local_protection_in_use = 2;
+    }
+  }
   // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressFlags flags = 5;
+  // default = Choice.Enum.local_protection_available
+  optional Choice.Enum choice = 1;
 }
 
 // Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: Label, C-Type: 3
 message FlowRSVPPathRecordRouteType1Label {
 
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1LabelLength length = 2;
+  // The Length contains the total length of the subobject in bytes, including the Type
+  // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+  FlowRSVPRouteRecordLength length = 1;
 
   // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1LabelFlags flags = 3;
+  PatternFlowRSVPPathRecordRouteType1LabelFlags flags = 2;
 
   // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1LabelCType c_type = 4;
+  PatternFlowRSVPPathRecordRouteType1LabelCType c_type = 3;
 
   // The contents of the Label Object. Copied from the Label Object.
   // default = 00
-  optional string contents_of_label_obejct = 5;
+  optional string contents_of_label_obejct = 4;
+}
+
+// Description missing in models
+message FlowRSVPRouteRecordLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // The OTG implementation can provide a system generated value for this property. If
+  // the OTG is unable to generate a value the default value must be used.
+  // default = 8
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 8
+  optional uint32 value = 3;
 }
 
 // Custom packet header
@@ -20664,56 +20765,8 @@ message PatternFlowRsvpReserved {
   PatternFlowRsvpReservedCounter decrement = 6;
 }
 
-// integer counter pattern
-message PatternFlowRSVPPathObjectsLengthCounter {
-
-  // Description missing in models
-  // default = 4
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Contains the total length of the object including the object's header, measured in
-// bytes.  Objects must be aligned to 32-bit words.
-message PatternFlowRSVPPathObjectsLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 4
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [4]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathObjectsLengthCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathObjectsLengthCounter decrement = 6;
-}
-
 // ipv4 counter pattern
-message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter {
+message PatternFlowRSVPPathSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter {
 
   // Description missing in models
   // default = 0.0.0.0
@@ -20729,7 +20782,7 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddressC
 }
 
 // IPv4 address of the egress node for the tunnel.
-message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddress {
+message PatternFlowRSVPPathSessionLspTunnelIpv4Ipv4TunnelEndPointAddress {
 
   message Choice {
     enum Enum {
@@ -20753,14 +20806,14 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddress 
   repeated string values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter increment = 5;
+  PatternFlowRSVPPathSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter decrement = 6;
+  PatternFlowRSVPPathSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ReservedCounter {
+message PatternFlowRSVPPathSessionLspTunnelIpv4ReservedCounter {
 
   // Description missing in models
   // default = 0
@@ -20776,7 +20829,7 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ReservedCounter {
 }
 
 // Reserved field, MUST be zero.
-message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Reserved {
+message PatternFlowRSVPPathSessionLspTunnelIpv4Reserved {
 
   message Choice {
     enum Enum {
@@ -20800,14 +20853,14 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Reserved {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ReservedCounter increment = 5;
+  PatternFlowRSVPPathSessionLspTunnelIpv4ReservedCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ReservedCounter decrement = 6;
+  PatternFlowRSVPPathSessionLspTunnelIpv4ReservedCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelIdCounter {
+message PatternFlowRSVPPathSessionLspTunnelIpv4TunnelIdCounter {
 
   // Description missing in models
   // default = 0
@@ -20824,7 +20877,7 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelIdCounter {
 
 // A 16-bit identifier used in the SESSION that remains constant over the life of the
 // tunnel.
-message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelId {
+message PatternFlowRSVPPathSessionLspTunnelIpv4TunnelId {
 
   message Choice {
     enum Enum {
@@ -20848,14 +20901,14 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelId {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelIdCounter increment = 5;
+  PatternFlowRSVPPathSessionLspTunnelIpv4TunnelIdCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelIdCounter decrement = 6;
+  PatternFlowRSVPPathSessionLspTunnelIpv4TunnelIdCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelIdCounter {
+message PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelIdCounter {
 
   // Description missing in models
   // default = 0
@@ -20874,7 +20927,7 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelIdCounter {
 // tunnel. Normally set to all zeros. Ingress nodes that wish to narrow the scope of
 // a SESSION to the ingress-egress pair may place their IPv4 address here as a globally
 // unique identifier.
-message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelId {
+message PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelId {
 
   message Choice {
     enum Enum {
@@ -20898,14 +20951,14 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelId {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelIdCounter increment = 5;
+  PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelIdCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelIdCounter decrement = 6;
+  PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelIdCounter decrement = 6;
 }
 
 // ipv4 counter pattern
-message PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddressCounter {
+message PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddressCounter {
 
   // Description missing in models
   // default = 0.0.0.0
@@ -20922,7 +20975,7 @@ message PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddressCoun
 
 // The IPv4 address of the interface through which the last RSVP-knowledgeable hop forwarded
 // this message.
-message PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddress {
+message PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddress {
 
   message Choice {
     enum Enum {
@@ -20946,14 +20999,14 @@ message PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddress {
   repeated string values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddressCounter increment = 5;
+  PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddressCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddressCounter decrement = 6;
+  PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddressCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandleCounter {
+message PatternFlowRSVPPathRsvpHopIpv4LogicalInterfaceHandleCounter {
 
   // Description missing in models
   // default = 0
@@ -20972,7 +21025,7 @@ message PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandleCounter 
 // A node receiving an LIH in a Path message saves its value and returns it in the HOP
 // objects of subsequent Resv messages sent to the node that originated the LIH. The
 // LIH should be identically zero if there is no logical interface handle.
-message PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandle {
+message PatternFlowRSVPPathRsvpHopIpv4LogicalInterfaceHandle {
 
   message Choice {
     enum Enum {
@@ -20996,14 +21049,14 @@ message PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandle {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandleCounter increment = 5;
+  PatternFlowRSVPPathRsvpHopIpv4LogicalInterfaceHandleCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandleCounter decrement = 6;
+  PatternFlowRSVPPathRsvpHopIpv4LogicalInterfaceHandleCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodRCounter {
+message PatternFlowRSVPPathTimeValuesType1RefreshPeriodRCounter {
 
   // Description missing in models
   // default = 0
@@ -21019,7 +21072,7 @@ message PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodRCounter {
 }
 
 // The refresh timeout period R used to generate this message;in milliseconds.
-message PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodR {
+message PatternFlowRSVPPathTimeValuesType1RefreshPeriodR {
 
   message Choice {
     enum Enum {
@@ -21043,10 +21096,10 @@ message PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodR {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodRCounter increment = 5;
+  PatternFlowRSVPPathTimeValuesType1RefreshPeriodRCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodRCounter decrement = 6;
+  PatternFlowRSVPPathTimeValuesType1RefreshPeriodRCounter decrement = 6;
 }
 
 // integer counter pattern
@@ -21096,54 +21149,6 @@ message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBit {
 
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBitCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLengthCounter {
-
-  // Description missing in models
-  // default = 8
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// The Length contains the total length of the subobject in bytes,including the Type
-// and Length fields.   The Length is always 8.
-message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 8
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [8]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLengthCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLengthCounter decrement = 6;
 }
 
 // ipv4 counter pattern
@@ -21241,54 +21246,6 @@ message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit {
 
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLengthCounter {
-
-  // Description missing in models
-  // default = 8
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// The Length contains the total length of the subobject in bytes,including the Type
-// and Length fields.   The Length is always 8.
-message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 8
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [8]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLengthCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLengthCounter decrement = 6;
 }
 
 // integer counter pattern
@@ -21432,52 +21389,6 @@ message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pid {
 
   // Description missing in models
   PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pidCounter decrement = 6;
-}
-
-// 0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
-message PatternFlowRSVPPathSessionAttributeLspTunnelFlags {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [1]
-  repeated uint32 values = 3;
-}
-
-// 0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
-message PatternFlowRSVPPathSessionAttributeLspTunnelRaFlags {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [1]
-  repeated uint32 values = 3;
 }
 
 // ipv4 counter pattern
@@ -22189,54 +22100,6 @@ message PatternFlowRSVPPathSenderTspecIntServMaximumPacketSize {
   PatternFlowRSVPPathSenderTspecIntServMaximumPacketSizeCounter decrement = 6;
 }
 
-// integer counter pattern
-message PatternFlowRSVPPathRecordRouteType1Ipv4AddressLengthCounter {
-
-  // Description missing in models
-  // default = 8
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// The Length contains the total length of the subobject in bytes, including the Type
-// and Length fields.  The Length is always 8.
-message PatternFlowRSVPPathRecordRouteType1Ipv4AddressLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 8
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [8]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressLengthCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressLengthCounter decrement = 6;
-}
-
 // ipv4 counter pattern
 message PatternFlowRSVPPathRecordRouteType1Ipv4AddressIpv4AddressCounter {
 
@@ -22330,77 +22193,6 @@ message PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLength {
 
   // Description missing in models
   PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLengthCounter decrement = 6;
-}
-
-// 0x01  local_protection_available, 0x02  local_protection_in_use
-message PatternFlowRSVPPathRecordRouteType1Ipv4AddressFlags {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [1]
-  repeated uint32 values = 3;
-}
-
-// integer counter pattern
-message PatternFlowRSVPPathRecordRouteType1LabelLengthCounter {
-
-  // Description missing in models
-  // default = 8
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// The Length contains the total length of the subobject in bytes, including the Type
-// and Length fields.
-message PatternFlowRSVPPathRecordRouteType1LabelLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 8
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [8]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1LabelLengthCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1LabelLengthCounter decrement = 6;
 }
 
 // 0x01 = Global label. This flag indicates that the label will be understood if received

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -23080,7 +23080,7 @@ message PatternFlowRSVPPathSenderTspecIntServParameter127Flag {
 message PatternFlowRSVPPathSenderTspecIntServParameter127LengthCounter {
 
   // Description missing in models
-  // default = 0
+  // default = 5
   optional uint32 start = 1;
 
   // Description missing in models
@@ -23109,11 +23109,11 @@ message PatternFlowRSVPPathSenderTspecIntServParameter127Length {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 0
+  // default = 5
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [0]
+  // default = [5]
   repeated uint32 values = 3;
 
   // Description missing in models

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6717,8 +6717,11 @@ message FlowRSVPPathObjectsCustom {
 
   // A custom packet header defined as a string of hex bytes. The string MUST contain
   // sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be
-  // discarded. This packet header can be used in multiple places in the packet.
-  // required = true
+  // discarded. Value of the this field should not excced 65525 bytes since maximum 65528
+  // bytes can be added as object-contents in RSVP header. For type and length requires
+  // 3 bytes, hence maximum of 65524 bytes are expected. Maximum length of this attribute
+  // is 131050 (65525 * 2 hex character per byte).
+  // default = 0000
   optional string bytes = 3;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6155,9 +6155,16 @@ message FlowRSVPPathExplicitRouteType1FourByteASNumber {
   optional uint32 as_number = 5;
 }
 
+// C-Type is specific to a class num.
+message FlowRSVPPathObjectsClassLabelRequest {
+
+  // Description missing in models
+  FlowRSVPPathObjectsLabelRequestCType c_type = 1;
+}
+
 // Object for LABEL_REQUEST class. Currently supported c-type is Without Label Range
 // (1).
-message FlowRSVPPathObjectsClassLabelRequest {
+message FlowRSVPPathObjectsLabelRequestCType {
 
   message Choice {
     enum Enum {
@@ -6183,9 +6190,16 @@ message FlowRSVPPathLabelRequestWithoutLabelRange {
   PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pid l3pid = 2;
 }
 
+// C-Type is specific to a class num.
+message FlowRSVPPathObjectsClassSessionAttribute {
+
+  // Description missing in models
+  FlowRSVPPathObjectsSessionAttributeCType c_type = 1;
+}
+
 // Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1)
 // and LSP_Tunnel (7).
-message FlowRSVPPathObjectsClassSessionAttribute {
+message FlowRSVPPathObjectsSessionAttributeCType {
 
   message Choice {
     enum Enum {
@@ -6282,8 +6296,15 @@ message FlowRSVPPathSessionAttributeLspTunnelRa {
   optional string session_name = 8;
 }
 
-// Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
+// C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassSenderTemplate {
+
+  // Description missing in models
+  FlowRSVPPathObjectsSenderTemplateCType c_type = 1;
+}
+
+// Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
+message FlowRSVPPathObjectsSenderTemplateCType {
 
   message Choice {
     enum Enum {
@@ -6312,8 +6333,15 @@ message FlowRSVPPathSenderTemplateLspTunnelIpv4 {
   PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspId lsp_id = 3;
 }
 
-// Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
+// C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassSenderTspec {
+
+  // Description missing in models
+  FlowRSVPPathObjectsSenderTspecCType c_type = 1;
+}
+
+// Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
+message FlowRSVPPathObjectsSenderTspecCType {
 
   message Choice {
     enum Enum {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6599,13 +6599,10 @@ message FlowRSVPPathExplicitRouteType1ASNumber {
   // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
   FlowRSVPExplicitRouteLength length = 2;
 
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1ASNumberReserved reserved = 3;
-
   // Autonomous System number to be set in the ERO sub-object that this LSP should traverse
   // through. This field is applicable only if the value of 'type' is set to 'as_number'.
   // default = 0
-  optional uint32 as_number = 4;
+  optional uint32 as_number = 3;
 }
 
 // Description missing in models
@@ -22415,53 +22412,6 @@ message PatternFlowRSVPPathExplicitRouteType1ASNumberLBit {
 
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1ASNumberLBitCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowRSVPPathExplicitRouteType1ASNumberReservedCounter {
-
-  // Description missing in models
-  // default = 0
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Reserved.
-message PatternFlowRSVPPathExplicitRouteType1ASNumberReserved {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1ASNumberReservedCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1ASNumberReservedCounter decrement = 6;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6555,7 +6555,7 @@ message FlowRSVPType1ExplicitRouteSubobjectsType {
     enum Enum {
       unspecified = 0;
       ipv4_prefix = 1;
-      four_byte_as_number = 2;
+      as_number = 2;
     }
   }
   // Description missing in models
@@ -6566,7 +6566,7 @@ message FlowRSVPType1ExplicitRouteSubobjectsType {
   FlowRSVPPathExplicitRouteType1Ipv4Prefix ipv4_prefix = 2;
 
   // Description missing in models
-  FlowRSVPPathExplicitRouteType1ASNumber four_byte_as_number = 3;
+  FlowRSVPPathExplicitRouteType1ASNumber as_number = 3;
 }
 
 // Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: IPv4 Prefix, C-Type:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5967,37 +5967,67 @@ message FlowRSVPPathObjectsClass {
 
 // Object for SESSION class.
 message FlowRSVPPathObjectsClassSession {
+
+  message CType {
+    enum Enum {
+      unspecified = 0;
+      lsp_tunnel_ipv4 = 1;
+    }
+  }
+  // Currently supported c-type is LSP Tunnel IPv4 (7).
+  // default = CType.Enum.lsp_tunnel_ipv4
+  optional CType.Enum c_type = 1;
 }
 
-// Object for RSVP_HOP class.
+// Class = SESSION, LSP_TUNNEL_IPv4 C-Type = 7.
+message FlowRSVPPathObjectsSessionLspTunnelIpv4 {
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddress ipv4_tunnel_end_point_address = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Reserved reserved = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelId tunnel_id = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelId extended_tunnel_id = 4;
+}
+
+// Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
 message FlowRSVPPathObjectsClassRsvpHop {
 }
 
-// Object for TIME_VALUES class.
+// Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
 message FlowRSVPPathObjectsClassTimeValues {
 }
 
-// Object for EXPLICIT_ROUTE class.
+// Object for EXPLICIT_ROUTE class. Currently supported c-type is Type 1 Explicit Route
+// (1).
 message FlowRSVPPathObjectsClassExplicitRoute {
 }
 
-// Object for LABEL_REQUEST class.
+// Object for LABEL_REQUEST class. Currently supported c-type is Without Label Range
+// (1).
 message FlowRSVPPathObjectsClassLabelRequest {
 }
 
-// Object for SESSION_ATTRIBUTE class.
+// Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1)
+// and LSP_Tunnel (7).
 message FlowRSVPPathObjectsClassSessionAttribute {
 }
 
-// Object for SENDER_TEMPLATE class.
+// Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
 message FlowRSVPPathObjectsClassSenderTemplate {
 }
 
-// Object for SENDER_TSPEC class.
+// Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
 message FlowRSVPPathObjectsClassSenderTspec {
 }
 
-// Object for RECORD_ROUTE class.
+// Object for RECORD_ROUTE class. Currently supported c-type is Type 1 Route Record
+// (1)
 message FlowRSVPPathObjectsClassRecordRoute {
 }
 
@@ -20168,6 +20198,198 @@ message PatternFlowRSVPPathObjectsLength {
 
   // Description missing in models
   PatternFlowRSVPPathObjectsLengthCounter decrement = 6;
+}
+
+// ipv4 counter pattern
+message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter {
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 0.0.0.1
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// IPv4 address of the egress node for the tunnel.
+message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddress {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['0.0.0.0']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Ipv4TunnelEndPointAddressCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ReservedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Reserved field, MUST be zero.
+message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4Reserved {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ReservedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ReservedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelIdCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// A 16-bit identifier used in the SESSION that remains constant over the life of the
+// tunnel.
+message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4TunnelIdCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelIdCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// A 32-bit identifier used in the SESSION that remains constant over the life of the
+// tunnel. Normally set to all zeros. Ingress nodes that wish to narrow the scope of
+// a SESSION to the ingress-egress pair may place their IPv4 address here as a globally
+// unique identifier.
+message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelIdCounter decrement = 6;
 }
 
 // Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5832,8 +5832,48 @@ message FlowMpls {
   PatternFlowMplsTimeToLive time_to_live = 4;
 }
 
-// RSVP packet header as defined in RFC2205 and RFC3209.
+// RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message
+// type is path.
 message FlowRsvp {
+
+  // Description missing in models
+  PatternFlowRsvpVersion version = 1;
+
+  message Flag {
+    enum Enum {
+      unspecified = 0;
+      not_refresh_reduction_capable = 1;
+      refresh_reduction_capable = 2;
+    }
+  }
+  // Flag, 0x01-0x08: Reserved.
+  // default = Flag.Enum.not_refresh_reduction_capable
+  optional Flag.Enum flag = 2;
+
+  // Description missing in models
+  PatternFlowRsvpRsvpChecksum rsvp_checksum = 3;
+
+  // Description missing in models
+  PatternFlowRsvpTimeToLive time_to_live = 4;
+
+  // Description missing in models
+  PatternFlowRsvpReserved reserved = 5;
+
+  // Description missing in models
+  PatternFlowRsvpRsvpLength rsvp_length = 6;
+
+  message MessageType {
+    enum Enum {
+      unspecified = 0;
+      path = 1;
+    }
+  }
+  // An 8-bit number that identifies the function of the RSVP message. There are aound
+  // 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
+  // . Among Those we are presently supporting path(value: 1) and hello (value: 20) message
+  // type.
+  // default = MessageType.Enum.path
+  optional MessageType.Enum message_type = 7;
 }
 
 // The frame size which overrides the total length of the packet
@@ -19729,6 +19769,232 @@ message PatternFlowMplsTimeToLive {
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
   repeated PatternFlowMplsTimeToLiveMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowRsvpVersionCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Protocol Version number.
+message PatternFlowRsvpVersion {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRsvpVersionCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRsvpVersionCounter decrement = 6;
+}
+
+// The one's complement of the one's complement sum of the message, with the checksum
+// field replaced by zero for the purpose of computing the checksum.   An all-zero value
+// means that no checksum was transmitted.
+message PatternFlowRsvpRsvpChecksum {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      generated = 1;
+      custom = 2;
+    }
+  }
+  // The type of checksum
+  // default = Choice.Enum.generated
+  optional Choice.Enum choice = 1;
+
+  message Generated {
+    enum Enum {
+      unspecified = 0;
+      good = 1;
+      bad = 2;
+    }
+  }
+  // A system generated checksum value
+  // default = Generated.Enum.good
+  optional Generated.Enum generated = 2;
+
+  // A custom checksum value
+  optional uint32 custom = 3;
+}
+
+// integer counter pattern
+message PatternFlowRsvpTimeToLiveCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The IP time-to-live(TTL) value with which the message was sent.
+message PatternFlowRsvpTimeToLive {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRsvpTimeToLiveCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRsvpTimeToLiveCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRsvpReservedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Reserved
+message PatternFlowRsvpReserved {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRsvpReservedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRsvpReservedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRsvpRsvpLengthCounter {
+
+  // Description missing in models
+  // default = auto
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The sum of the lengths of the common header and all objects included in the message.
+message PatternFlowRsvpRsvpLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      auto = 1;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = auto
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = ['auto']
+  repeated uint32 values = 3;
+
+  // The OTG implementation can provide a system generated
+  // value for this property. If the OTG is unable to generate a value
+  // the default value must be used.
+  // default = auto
+  optional uint32 auto = 4;
+
+  // Description missing in models
+  PatternFlowRsvpRsvpLengthCounter increment = 6;
+
+  // Description missing in models
+  PatternFlowRsvpRsvpLengthCounter decrement = 7;
 }
 
 // Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5916,7 +5916,8 @@ message FlowRSVPPathObjects {
 // . Curently supported class numbers are for path message type. path message: Supported
 // Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE:
 // 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC:
-// 12, RECORD_ROUTE: 21.
+// 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored
+// in above options.
 message FlowRSVPPathObjectsClass {
 
   message Choice {
@@ -5931,6 +5932,7 @@ message FlowRSVPPathObjectsClass {
       sender_template = 7;
       sender_tspec = 8;
       record_route = 9;
+      custom = 10;
     }
   }
   // Description missing in models
@@ -5963,6 +5965,9 @@ message FlowRSVPPathObjectsClass {
 
   // Description missing in models
   FlowRSVPPathObjectsClassRecordRoute record_route = 10;
+
+  // Description missing in models
+  FlowRSVPPathObjectsCustom custom = 11;
 }
 
 // C-Type is specific to a class num.
@@ -6140,9 +6145,6 @@ message FlowRSVPPathExplicitRouteType1Ipv4Prefix {
   PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBit l_bit = 1;
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixType type = 2;
-
-  // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLength length = 3;
 
   // Description missing in models
@@ -6159,9 +6161,6 @@ message FlowRSVPPathExplicitRouteType1FourByteASNumber {
 
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit l_bit = 1;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberType type = 2;
 
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLength length = 3;
@@ -6497,9 +6496,6 @@ message FlowRSVPPathObjectsRecordRouteSubObjectType {
 message FlowRSVPPathRecordRouteType1Ipv4Address {
 
   // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressType type = 1;
-
-  // Description missing in models
   PatternFlowRSVPPathRecordRouteType1Ipv4AddressLength length = 2;
 
   // Description missing in models
@@ -6516,9 +6512,6 @@ message FlowRSVPPathRecordRouteType1Ipv4Address {
 message FlowRSVPPathRecordRouteType1Label {
 
   // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1LabelType type = 1;
-
-  // Description missing in models
   PatternFlowRSVPPathRecordRouteType1LabelLength length = 2;
 
   // Description missing in models
@@ -6530,6 +6523,46 @@ message FlowRSVPPathRecordRouteType1Label {
   // The contents of the Label Object. Copied from the Label Object.
   // default = 00
   optional string contents_of_label_obejct = 5;
+}
+
+// Custom packet header
+message FlowRSVPPathObjectsCustom {
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsCustomType type = 1;
+
+  // Description missing in models
+  FlowRSVPObjectOptionsCustomLength length = 2;
+
+  // A custom packet header defined as a string of hex bytes. The string MUST contain
+  // sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be
+  // discarded. This packet header can be used in multiple places in the packet.
+  // required = true
+  optional string bytes = 3;
+}
+
+// Length for custom options.
+message FlowRSVPObjectOptionsCustomLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // The OTG implementation can provide a system generated value for this property. If
+  // the OTG is unable to generate a value the default value must be used.
+  // default = 4
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 4
+  optional uint32 value = 3;
 }
 
 // The frame size which overrides the total length of the packet
@@ -21088,53 +21121,6 @@ message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBit {
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixTypeCounter {
-
-  // Description missing in models
-  // default = 1
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Subobject type; 0x01  IPv4 address.
-message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixType {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [1]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixTypeCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixTypeCounter decrement = 6;
-}
-
-// integer counter pattern
 message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLengthCounter {
 
   // Description missing in models
@@ -21277,53 +21263,6 @@ message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit {
 
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberTypeCounter {
-
-  // Description missing in models
-  // default = 1
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Subobject type; 0x05  AS Number.
-message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberType {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [1]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberTypeCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberTypeCounter decrement = 6;
 }
 
 // integer counter pattern
@@ -22273,53 +22212,6 @@ message PatternFlowRSVPPathSenderTspecIntServMaximumPacketSize {
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathRecordRouteType1Ipv4AddressTypeCounter {
-
-  // Description missing in models
-  // default = 1
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// 0x01  IPv4 address
-message PatternFlowRSVPPathRecordRouteType1Ipv4AddressType {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [1]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressTypeCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1Ipv4AddressTypeCounter decrement = 6;
-}
-
-// integer counter pattern
 message PatternFlowRSVPPathRecordRouteType1Ipv4AddressLengthCounter {
 
   // Description missing in models
@@ -22486,53 +22378,6 @@ message PatternFlowRSVPPathRecordRouteType1Ipv4AddressFlags {
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathRecordRouteType1LabelTypeCounter {
-
-  // Description missing in models
-  // default = 3
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// 0x03  Label
-message PatternFlowRSVPPathRecordRouteType1LabelType {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 3
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [3]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1LabelTypeCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRSVPPathRecordRouteType1LabelTypeCounter decrement = 6;
-}
-
-// integer counter pattern
 message PatternFlowRSVPPathRecordRouteType1LabelLengthCounter {
 
   // Description missing in models
@@ -22625,6 +22470,53 @@ message PatternFlowRSVPPathRecordRouteType1LabelCType {
   // Description missing in models
   // default = [0]
   repeated uint32 values = 3;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathObjectsCustomTypeCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// User defined object type.
+message PatternFlowRSVPPathObjectsCustomType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsCustomTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsCustomTypeCounter decrement = 6;
 }
 
 // Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -22306,11 +22306,11 @@ message PatternFlowRSVPPathRecordRouteType1LabelCType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 0
+  // default = 1
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [0]
+  // default = [1]
   repeated uint32 values = 3;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5910,7 +5910,7 @@ message FlowRSVPMessage {
   FlowRSVPPathMessage path = 2;
 }
 
-// Path message requires the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+// Path message requires the following list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
 // 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST
 // 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
 // [optional]
@@ -6231,7 +6231,7 @@ message FlowRSVPPathExplicitRouteType1Ipv4Prefix {
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4Address ipv4_address = 3;
 
-  // The prefix of the IPv4 address.
+  // The prefix length of the IPv4 address.
   // default = 32
   optional uint32 prefix = 4;
 }
@@ -6703,7 +6703,7 @@ message FlowRSVPPathRecordRouteType1Label {
 
   // The contents of the Label Object. Copied from the Label Object.
   // default = 00
-  optional string contents_of_label_obejct = 4;
+  optional string label = 4;
 }
 
 // Description missing in models
@@ -20679,7 +20679,7 @@ message PatternFlowRsvpRsvpChecksum {
 message PatternFlowRsvpTimeToLiveCounter {
 
   // Description missing in models
-  // default = 0
+  // default = 64
   optional uint32 start = 1;
 
   // Description missing in models
@@ -20708,11 +20708,11 @@ message PatternFlowRsvpTimeToLive {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 0
+  // default = 64
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [0]
+  // default = [64]
   repeated uint32 values = 3;
 
   // Description missing in models
@@ -20974,7 +20974,7 @@ message PatternFlowRSVPPathSessionExtTunnelIdAsIpv4Counter {
   optional uint32 count = 3;
 }
 
-// IPv4 address of the egress node for the tunnel.
+// IPv4 address of the ingress endpoint for the tunnel.
 message PatternFlowRSVPPathSessionExtTunnelIdAsIpv4 {
 
   message Choice {
@@ -21408,7 +21408,8 @@ message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pidCounter {
 }
 
 // An identifier of the layer 3 protocol using this path.  Standard Ethertype values
-// are used.
+// are used e.g. The default value of 2048 ( 0x0800 ) represents Ethertype for IPv4.
+// 
 message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pid {
 
   message Choice {
@@ -22212,7 +22213,7 @@ message PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLengthCounter {
   optional uint32 count = 3;
 }
 
-// Prefix-length of ipv4 address.
+// Prefix-length of IPv4 address.
 message PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLength {
 
   message Choice {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6052,8 +6052,32 @@ message FlowRSVPPathSessionLspTunnelIpv4 {
   // Description missing in models
   PatternFlowRSVPPathSessionLspTunnelIpv4TunnelId tunnel_id = 3;
 
+  // A 32-bit identifier used in the SESSION that remains constant over the life of the
+  // tunnel. Normally set to all zeros. Ingress nodes that wish to narrow the scope of
+  // a SESSION to the ingress-egress pair may place their IPv4 address here as a globally
+  // unique identifier.
+  FlowRSVPPathSessionExtTunnelId extended_tunnel_id = 4;
+}
+
+// Description missing in models
+message FlowRSVPPathSessionExtTunnelId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      as_integer = 1;
+      as_ipv4 = 2;
+    }
+  }
+  // 32 bit integer or IPv4 address.
+  // default = Choice.Enum.as_integer
+  optional Choice.Enum choice = 1;
+
   // Description missing in models
-  PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelId extended_tunnel_id = 4;
+  PatternFlowRSVPPathSessionExtTunnelIdAsInteger as_integer = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathSessionExtTunnelIdAsIpv4 as_ipv4 = 3;
 }
 
 // C-Type is specific to a class num.
@@ -20888,7 +20912,7 @@ message PatternFlowRSVPPathSessionLspTunnelIpv4TunnelId {
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelIdCounter {
+message PatternFlowRSVPPathSessionExtTunnelIdAsIntegerCounter {
 
   // Description missing in models
   // default = 0
@@ -20903,11 +20927,8 @@ message PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelIdCounter {
   optional uint32 count = 3;
 }
 
-// A 32-bit identifier used in the SESSION that remains constant over the life of the
-// tunnel. Normally set to all zeros. Ingress nodes that wish to narrow the scope of
-// a SESSION to the ingress-egress pair may place their IPv4 address here as a globally
-// unique identifier.
-message PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelId {
+// TBD
+message PatternFlowRSVPPathSessionExtTunnelIdAsInteger {
 
   message Choice {
     enum Enum {
@@ -20931,10 +20952,57 @@ message PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelId {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelIdCounter increment = 5;
+  PatternFlowRSVPPathSessionExtTunnelIdAsIntegerCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelIdCounter decrement = 6;
+  PatternFlowRSVPPathSessionExtTunnelIdAsIntegerCounter decrement = 6;
+}
+
+// ipv4 counter pattern
+message PatternFlowRSVPPathSessionExtTunnelIdAsIpv4Counter {
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 0.0.0.1
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// IPv4 address of the egress node for the tunnel.
+message PatternFlowRSVPPathSessionExtTunnelIdAsIpv4 {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['0.0.0.0']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSessionExtTunnelIdAsIpv4Counter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSessionExtTunnelIdAsIpv4Counter decrement = 6;
 }
 
 // ipv4 counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6435,16 +6435,9 @@ message FlowRSVPPathObjectsRecordRouteCType {
   FlowRSVPPathRecordRouteType1 type_1_route_record = 2;
 }
 
-// C-Type of Type 1 Record Route.
-message FlowRSVPPathRecordRouteType1 {
-
-  // Description missing in models
-  FlowRSVPPathRecordRouteType1CType c_type = 1;
-}
-
 // Type1 record route has list of subobjects. Currently supported subobjects are IPv4
 // address(1) and Label(3).
-message FlowRSVPPathRecordRouteType1CType {
+message FlowRSVPPathRecordRouteType1 {
 
   // Description missing in models
   repeated FlowRSVPType1RecordRouteSubobjects subobjects = 1;

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6001,38 +6001,444 @@ message FlowRSVPPathObjectsSessionLspTunnelIpv4 {
 
 // Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
 message FlowRSVPPathObjectsClassRsvpHop {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      ipv4 = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.ipv4
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassRsvpHopIpv4 ipv4 = 2;
+}
+
+// IPv4 RSVP_HOP object: Class = 3, C-Type = 1
+message FlowRSVPPathObjectsClassRsvpHopIpv4 {
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddress ipv4_next_previous_hop_address = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandle logical_interface_handle = 2;
 }
 
 // Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
 message FlowRSVPPathObjectsClassTimeValues {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      type_1_time_value = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.type_1_time_value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassTimeValuesType1 type_1_time_value = 2;
+}
+
+// TIME_VALUES Object: Class = 5, C-Type = 1
+message FlowRSVPPathObjectsClassTimeValuesType1 {
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodR refresh_period_r = 1;
 }
 
 // Object for EXPLICIT_ROUTE class. Currently supported c-type is Type 1 Explicit Route
 // (1).
 message FlowRSVPPathObjectsClassExplicitRoute {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      type_1_explicit_route = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.type_1_explicit_route
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathExplicitRouteType1 type_1_explicit_route = 2;
+}
+
+// Type1 Explicit Route has subobjects. Currently supported subobjects are IPv4 prefix
+// and 4-byte AS number.
+message FlowRSVPPathExplicitRouteType1 {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      ipv4_prefix = 1;
+      four_byte_as_number = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.ipv4_prefix
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathExplicitRouteType1Ipv4Prefix ipv4_prefix = 2;
+
+  // Description missing in models
+  FlowRSVPPathExplicitRouteType1FourByteASNumber four_byte_as_number = 3;
+}
+
+// Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: IPv4 Prefix, C-Type:
+// 1
+message FlowRSVPPathExplicitRouteType1Ipv4Prefix {
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBit l_bit = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixType type = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLength length = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4Address ipv4_address = 4;
+
+  // The prefix of the IPv4 address.
+  // default = 32
+  optional uint32 prefix = 5;
+}
+
+// Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: 4-byte AS number,
+// C-Type: 32
+message FlowRSVPPathExplicitRouteType1FourByteASNumber {
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit l_bit = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberType type = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLength length = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReserved reserved = 4;
+
+  // Autonomous System number to be set in the ERO sub-object that this LSP should traverse
+  // through. This field is applicable only if the value of 'type' is set to 'as_number'.
+  // Note that as per RFC3209, 4-byte AS encoding is not supported.
+  // default = 0
+  optional uint32 as_number = 5;
 }
 
 // Object for LABEL_REQUEST class. Currently supported c-type is Without Label Range
 // (1).
 message FlowRSVPPathObjectsClassLabelRequest {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      without_label_range = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.without_label_range
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathLabelRequestWithoutLabelRange without_label_range = 2;
+}
+
+// Class = LABEL_REQUEST, Without Label Range C-Type = 1
+message FlowRSVPPathLabelRequestWithoutLabelRange {
+
+  // Description missing in models
+  PatternFlowRSVPPathLabelRequestWithoutLabelRangeReserved reserved = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pid l3pid = 2;
 }
 
 // Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1)
 // and LSP_Tunnel (7).
 message FlowRSVPPathObjectsClassSessionAttribute {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      lsp_tunnel = 1;
+      lsp_tunnel_ra = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.lsp_tunnel
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathSessionAttributeLspTunnel lsp_tunnel = 2;
+
+  // Description missing in models
+  FlowRSVPPathSessionAttributeLspTunnelRa lsp_tunnel_ra = 3;
+}
+
+// SESSION_ATTRIBUTE class = 207, LSP_TUNNEL_RA C-Type = 7, resource affinity information.
+message FlowRSVPPathSessionAttributeLspTunnel {
+
+  // The priority of the session with respect to taking resources,in the range of 0 to
+  // 7. The value 0 is the highest priority. The Setup Priority is used in deciding whether
+  // this session can preempt another session.
+  // default = 7
+  optional uint32 setup_priority = 1;
+
+  // The priority of the session with respect to holding resources,in the range of 0 to
+  // 7. The value 0 is the highest priority. The Setup Priority is used in deciding whether
+  // this session can preempt another session.
+  // default = 7
+  optional uint32 holding_priority = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathSessionAttributeLspTunnelFlags flags = 3;
+
+  // The length of the display string before padding, in bytes.
+  // default = 0
+  optional string name_length = 4;
+
+  // A null padded string of characters.
+  optional string session_name = 5;
+}
+
+// SESSION_ATTRIBUTE class = 207, LSP_TUNNEL_RA C-Type = 1, it carries resource affinity
+// information.
+message FlowRSVPPathSessionAttributeLspTunnelRa {
+
+  // A 32-bit vector representing a set of attribute filters associated with a tunnel
+  // any of which renders a link unacceptable. A null set (all bits set to zero) doesn't
+  // render the link unacceptable. The most significant byte in the hex-string is the
+  // farthest  to the left in the byte sequence.  Leading zero bytes in the configured
+  // value may be omitted for brevity.
+  // default = 0
+  optional string exclude_any = 1;
+
+  // A 32-bit vector representing a set of attribute filters associated with a tunnel
+  // any of which renders a link acceptable. A null set (all bits set to zero) automatically
+  // passes. The most significant byte in the hex-string is the farthest  to the left
+  // in the byte sequence.  Leading zero bytes in the configured value may be omitted
+  // for brevity.
+  // default = 0
+  optional string include_any = 2;
+
+  // A 32-bit vector representing a set of attribute filters associated with a tunnel
+  // all of which must be present for a link to be acceptable. A null set (all bits set
+  // to zero) automatically passes. The most significant byte in the hex-string is the
+  // farthest  to the left in the byte sequence.  Leading zero bytes in the configured
+  // value may be omitted for brevity.
+  // default = 0
+  optional string include_all = 3;
+
+  // The priority of the session with respect to taking resources,in the range of 0 to
+  // 7. The value 0 is the highest priority. The Setup Priority is used in deciding whether
+  // this session can preempt another session.
+  // default = 7
+  optional uint32 setup_priority = 4;
+
+  // The priority of the session with respect to holding resources,in the range of 0 to
+  // 7. The value 0 is the highest priority. The Setup Priority is used in deciding whether
+  // this session can preempt another session.
+  // default = 7
+  optional uint32 holding_priority = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSessionAttributeLspTunnelRaFlags flags = 6;
+
+  // The length of the display string before padding, in bytes.
+  // default = 0
+  optional string name_length = 7;
+
+  // A null padded string of characters.
+  optional string session_name = 8;
 }
 
 // Object for SENDER_TEMPLATE class. Currently supported c-type is LSP Tunnel IPv4 (7).
 message FlowRSVPPathObjectsClassSenderTemplate {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      lsp_tunnel_ipv4 = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.lsp_tunnel_ipv4
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathSenderTemplateLspTunnelIpv4 lsp_tunnel_ipv4 = 2;
+}
+
+// Class = SENDER_TEMPLATE, LSP_TUNNEL_IPv4 C-Type = 7
+message FlowRSVPPathSenderTemplateLspTunnelIpv4 {
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Ipv4TunnelSenderAddress ipv4_tunnel_sender_address = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Reserved reserved = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspId lsp_id = 3;
 }
 
 // Object for SENDER_TSPEC class. Currently supported c-type is int-serv (2).
 message FlowRSVPPathObjectsClassSenderTspec {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      int_serv = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.int_serv
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathSenderTspecIntServ int_serv = 2;
 }
 
-// Object for RECORD_ROUTE class. Currently supported c-type is Type 1 Route Record
-// (1)
+// int-serv SENDER_TSPEC object: Class = 12, C-Type = 2
+message FlowRSVPPathSenderTspecIntServ {
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServVersion version = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServReserved1 reserved1 = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServOverallLength overall_length = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServServiceHeader service_header = 4;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServZeroBit zero_bit = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServReserved2 reserved2 = 6;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServLengthOfServiceData length_of_service_data = 7;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameterIdTokenBucketTspec parameter_id_token_bucket_tspec = 8;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameter127Flag parameter_127_flag = 9;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameter127Length parameter_127_length = 10;
+
+  // Token bucket rate is set to sender's view of its generated traffic.
+  // default = 0
+  optional float token_bucket_rate = 11;
+
+  // Token bucket size is set to sender's view of its generated traffic.
+  // default = 0
+  optional float token_bucket_size = 12;
+
+  // The peak rate may be set to the sender's peak traffic generation rate (if known and
+  // controlled), the physical interface line rate (if known), or positive infinity (if
+  // no better value is available).
+  // default = 0
+  optional float peak_data_rate = 13;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServMinimumPolicedUnit minimum_policed_unit = 14;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServMaximumPacketSize maximum_packet_size = 15;
+}
+
+// Object for RECORD_ROUTE class. c-type is Type 1 Route Record (1).
 message FlowRSVPPathObjectsClassRecordRoute {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      type_1_route_record = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.type_1_route_record
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathRecordRouteType1 type_1_route_record = 2;
+}
+
+// Type1 record route has subobjects. Currently supported subobjects are IPv4 address
+// and Label.
+message FlowRSVPPathRecordRouteType1 {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      ipv4_address = 1;
+      label = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.ipv4_address
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathRecordRouteType1Ipv4Address ipv4_address = 2;
+
+  // Description missing in models
+  FlowRSVPPathRecordRouteType1Label label = 3;
+}
+
+// Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: IPv4 Address, C-Type:
+// 1
+message FlowRSVPPathRecordRouteType1Ipv4Address {
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressType type = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressLength length = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressIpv4Address ipv4_address = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLength prefix_length = 4;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressFlags flags = 5;
+}
+
+// Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: Label, C-Type: 3
+message FlowRSVPPathRecordRouteType1Label {
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1LabelType type = 1;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1LabelLength length = 2;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1LabelFlags flags = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1LabelCType c_type = 4;
+
+  // The contents of the Label Object. Copied from the Label Object.
+  // default = 00
+  optional string contents_of_label_obejct = 5;
 }
 
 // The frame size which overrides the total length of the packet
@@ -20394,6 +20800,1740 @@ message PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelId {
 
   // Description missing in models
   PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelIdCounter decrement = 6;
+}
+
+// ipv4 counter pattern
+message PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddressCounter {
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 0.0.0.1
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The IPv4 address of the interface through which the last RSVP-knowledgeable hop forwarded
+// this message.
+message PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddress {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['0.0.0.0']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddressCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassRsvpHopIpv4Ipv4NextPreviousHopAddressCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandleCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Logical Interface Handle (LIH) is used to distinguish logical outgoing interfaces.
+// A node receiving an LIH in a Path message saves its value and returns it in the HOP
+// objects of subsequent Resv messages sent to the node that originated the LIH. The
+// LIH should be identically zero if there is no logical interface handle.
+message PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandle {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandleCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandleCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodRCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The refresh timeout period R used to generate this message;in milliseconds.
+message PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodR {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodRCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsClassTimeValuesType1RefreshPeriodRCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBitCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The L bit is an attribute of the subobject.The L bit is set if the subobject represents
+// a loose hop in the explicit route. If the bit is not set, the subobject represents
+// a strict hop in the explicit route.
+message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBit {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBitCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBitCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixTypeCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Subobject type; 0x01  IPv4 address.
+message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLengthCounter {
+
+  // Description missing in models
+  // default = 8
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The Length contains the total length of the subobject in bytes,including the Type
+// and Length fields.   The Length is always 8.
+message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 8
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [8]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLengthCounter decrement = 6;
+}
+
+// ipv4 counter pattern
+message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4AddressCounter {
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 0.0.0.1
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// This IPv4 address is treated as a prefix based on the prefix length value below.
+// Bits beyond the prefix are ignored on receipt and SHOULD be set to zero on transmission.
+message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4Address {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['0.0.0.0']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4AddressCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4AddressCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The L bit is an attribute of the subobject.The L bit is set if the subobject represents
+// a loose hop in the explicit route. If the bit is not set, the subobject represents
+// a strict hop in the explicit route.
+message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberTypeCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Subobject type; 0x05  AS Number.
+message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLengthCounter {
+
+  // Description missing in models
+  // default = 8
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The Length contains the total length of the subobject in bytes,including the Type
+// and Length fields.   The Length is always 8.
+message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 8
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [8]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLengthCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReservedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Reserved.
+message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReserved {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReservedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReservedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathLabelRequestWithoutLabelRangeReservedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// This field is reserved.   It MUST be set to zero on transmission and MUST be ignored
+// on receipt.
+message PatternFlowRSVPPathLabelRequestWithoutLabelRangeReserved {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathLabelRequestWithoutLabelRangeReservedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathLabelRequestWithoutLabelRangeReservedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pidCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// An identifier of the layer 3 protocol using this path.  Standard Ethertype values
+// are used.
+message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pid {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pidCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pidCounter decrement = 6;
+}
+
+// 0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+message PatternFlowRSVPPathSessionAttributeLspTunnelFlags {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+}
+
+// 0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+message PatternFlowRSVPPathSessionAttributeLspTunnelRaFlags {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+}
+
+// ipv4 counter pattern
+message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Ipv4TunnelSenderAddressCounter {
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 0.0.0.1
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// IPv4 address for a sender node.
+message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Ipv4TunnelSenderAddress {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['0.0.0.0']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Ipv4TunnelSenderAddressCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Ipv4TunnelSenderAddressCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4ReservedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Reserved field, MUST be zero.
+message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Reserved {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4ReservedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4ReservedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspIdCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// A 16-bit identifier used in the SENDER_TEMPLATE that can be changed to allow a sender
+// to share resources with itself.
+message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspIdCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServVersionCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Message format version number.
+message PatternFlowRSVPPathSenderTspecIntServVersion {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServVersionCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServVersionCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServReserved1Counter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Reserved.
+message PatternFlowRSVPPathSenderTspecIntServReserved1 {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServReserved1Counter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServReserved1Counter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServOverallLengthCounter {
+
+  // Description missing in models
+  // default = 7
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Overall length (7 words not including header).
+message PatternFlowRSVPPathSenderTspecIntServOverallLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 7
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [7]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServOverallLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServOverallLengthCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServServiceHeaderCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Service header, service number - '1' (Generic information) if in a PATH message.
+message PatternFlowRSVPPathSenderTspecIntServServiceHeader {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServServiceHeaderCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServServiceHeaderCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServZeroBitCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// MUST be 0.
+message PatternFlowRSVPPathSenderTspecIntServZeroBit {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServZeroBitCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServZeroBitCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServReserved2Counter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Reserved.
+message PatternFlowRSVPPathSenderTspecIntServReserved2 {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServReserved2Counter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServReserved2Counter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServLengthOfServiceDataCounter {
+
+  // Description missing in models
+  // default = 6
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Length of service data, 6 words not including per-service header.
+message PatternFlowRSVPPathSenderTspecIntServLengthOfServiceData {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 6
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [6]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServLengthOfServiceDataCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServLengthOfServiceDataCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServParameterIdTokenBucketTspecCounter {
+
+  // Description missing in models
+  // default = 127
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Parameter ID, parameter 127 (Token Bucket TSpec)
+message PatternFlowRSVPPathSenderTspecIntServParameterIdTokenBucketTspec {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 127
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [127]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameterIdTokenBucketTspecCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameterIdTokenBucketTspecCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServParameter127FlagCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Parameter 127 flags (none set)
+message PatternFlowRSVPPathSenderTspecIntServParameter127Flag {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameter127FlagCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameter127FlagCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServParameter127LengthCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Parameter 127 length, 5 words not including per-service header
+message PatternFlowRSVPPathSenderTspecIntServParameter127Length {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameter127LengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServParameter127LengthCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServMinimumPolicedUnitCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The minimum policed unit parameter should generally be set equal to the size of the
+// smallest packet generated by the application.
+message PatternFlowRSVPPathSenderTspecIntServMinimumPolicedUnit {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServMinimumPolicedUnitCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServMinimumPolicedUnitCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathSenderTspecIntServMaximumPacketSizeCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The maximum packet size parameter should be set to the size of the largest packet
+// the application might wish to generate. This value must, by definition, be equal
+// to or larger than the value of The minimum policed unit.
+message PatternFlowRSVPPathSenderTspecIntServMaximumPacketSize {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServMaximumPacketSizeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathSenderTspecIntServMaximumPacketSizeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressTypeCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// 0x01  IPv4 address
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressLengthCounter {
+
+  // Description missing in models
+  // default = 8
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The Length contains the total length of the subobject in bytes, including the Type
+// and Length fields.  The Length is always 8.
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 8
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [8]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressLengthCounter decrement = 6;
+}
+
+// ipv4 counter pattern
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressIpv4AddressCounter {
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 0.0.0.1
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// A 32-bit unicast, host address.  Any network-reachable interface address is allowed
+// here. Illegal addresses, such as certain loopback addresses, SHOULD NOT be used.
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressIpv4Address {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['0.0.0.0']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressIpv4AddressCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressIpv4AddressCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLengthCounter {
+
+  // Description missing in models
+  // default = 32
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Prefix-length of ipv4 address.
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 32
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [32]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1Ipv4AddressPrefixLengthCounter decrement = 6;
+}
+
+// 0x01  local_protection_available, 0x02  local_protection_in_use
+message PatternFlowRSVPPathRecordRouteType1Ipv4AddressFlags {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathRecordRouteType1LabelTypeCounter {
+
+  // Description missing in models
+  // default = 3
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// 0x03  Label
+message PatternFlowRSVPPathRecordRouteType1LabelType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 3
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [3]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1LabelTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1LabelTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathRecordRouteType1LabelLengthCounter {
+
+  // Description missing in models
+  // default = 8
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The Length contains the total length of the subobject in bytes, including the Type
+// and Length fields.
+message PatternFlowRSVPPathRecordRouteType1LabelLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 8
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [8]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1LabelLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathRecordRouteType1LabelLengthCounter decrement = 6;
+}
+
+// 0x01 = Global label. This flag indicates that the label will be understood if received
+// on any interface.
+message PatternFlowRSVPPathRecordRouteType1LabelFlags {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+}
+
+// The C-Type of the included Label Object. Copied from the Label object.
+message PatternFlowRSVPPathRecordRouteType1LabelCType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
 }
 
 // Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6534,7 +6534,7 @@ message FlowRSVPPathObjectsClassExplicitRouteCType {
 }
 
 // Type1 Explicit Route has subobjects. Currently supported subobjects are IPv4 prefix
-// and 4-byte AS number.
+// and Autonomous system number.
 message FlowRSVPPathExplicitRouteType1 {
 
   // Description missing in models
@@ -6548,7 +6548,7 @@ message FlowRSVPType1ExplicitRouteSubobjects {
   FlowRSVPType1ExplicitRouteSubobjectsType type = 1;
 }
 
-// Currently supported subobjects are IPv4 address(1) and 4-byte AS number(5).
+// Currently supported subobjects are IPv4 address(1) and Autonomous system number(32).
 message FlowRSVPType1ExplicitRouteSubobjectsType {
 
   message Choice {
@@ -6566,7 +6566,7 @@ message FlowRSVPType1ExplicitRouteSubobjectsType {
   FlowRSVPPathExplicitRouteType1Ipv4Prefix ipv4_prefix = 2;
 
   // Description missing in models
-  FlowRSVPPathExplicitRouteType1FourByteASNumber four_byte_as_number = 3;
+  FlowRSVPPathExplicitRouteType1ASNumber four_byte_as_number = 3;
 }
 
 // Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: IPv4 Prefix, C-Type:
@@ -6588,23 +6588,22 @@ message FlowRSVPPathExplicitRouteType1Ipv4Prefix {
   optional uint32 prefix = 4;
 }
 
-// Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: 4-byte AS number,
-// C-Type: 32
-message FlowRSVPPathExplicitRouteType1FourByteASNumber {
+// Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1 Subobject: Autonomous system
+// number, C-Type: 32
+message FlowRSVPPathExplicitRouteType1ASNumber {
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit l_bit = 1;
+  PatternFlowRSVPPathExplicitRouteType1ASNumberLBit l_bit = 1;
 
   // The Length contains the total length of the subobject in bytes,including L, Type
   // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
   FlowRSVPExplicitRouteLength length = 2;
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReserved reserved = 3;
+  PatternFlowRSVPPathExplicitRouteType1ASNumberReserved reserved = 3;
 
   // Autonomous System number to be set in the ERO sub-object that this LSP should traverse
   // through. This field is applicable only if the value of 'type' is set to 'as_number'.
-  // Note that as per RFC3209, 4-byte AS encoding is not supported.
   // default = 0
   optional uint32 as_number = 4;
 }
@@ -22370,7 +22369,7 @@ message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixIpv4Address {
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter {
+message PatternFlowRSVPPathExplicitRouteType1ASNumberLBitCounter {
 
   // Description missing in models
   // default = 0
@@ -22388,7 +22387,7 @@ message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter {
 // The L bit is an attribute of the subobject. The L bit is set if the subobject represents
 // a loose hop in the explicit route. If the bit is not set, the subobject represents
 // a strict hop in the explicit route.
-message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit {
+message PatternFlowRSVPPathExplicitRouteType1ASNumberLBit {
 
   message Choice {
     enum Enum {
@@ -22412,14 +22411,14 @@ message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter increment = 5;
+  PatternFlowRSVPPathExplicitRouteType1ASNumberLBitCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter decrement = 6;
+  PatternFlowRSVPPathExplicitRouteType1ASNumberLBitCounter decrement = 6;
 }
 
 // integer counter pattern
-message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReservedCounter {
+message PatternFlowRSVPPathExplicitRouteType1ASNumberReservedCounter {
 
   // Description missing in models
   // default = 0
@@ -22435,7 +22434,7 @@ message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReservedCounter {
 }
 
 // Reserved.
-message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReserved {
+message PatternFlowRSVPPathExplicitRouteType1ASNumberReserved {
 
   message Choice {
     enum Enum {
@@ -22459,10 +22458,10 @@ message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReserved {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReservedCounter increment = 5;
+  PatternFlowRSVPPathExplicitRouteType1ASNumberReservedCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathExplicitRouteType1FourByteASNumberReservedCounter decrement = 6;
+  PatternFlowRSVPPathExplicitRouteType1ASNumberReservedCounter decrement = 6;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6702,8 +6702,31 @@ message FlowRSVPPathRecordRouteType1Label {
   PatternFlowRSVPPathRecordRouteType1LabelCType c_type = 3;
 
   // The contents of the Label Object. Copied from the Label Object.
-  // default = 00
-  optional string label = 4;
+  FlowRSVPPathRecordRouteLabel label = 4;
+}
+
+// Description missing in models
+message FlowRSVPPathRecordRouteLabel {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      as_integer = 1;
+      as_hex = 2;
+    }
+  }
+  // 32 bit integer or hex value.
+  // default = Choice.Enum.as_integer
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 16
+  optional uint32 as_integer = 2;
+
+  // Value of the this field should not excced 4 bytes. Maximum length of this attribute
+  // is 8 (4 * 2 hex character per byte).
+  // default = 10
+  optional string as_hex = 3;
 }
 
 // Description missing in models
@@ -20867,7 +20890,7 @@ message PatternFlowRSVPPathSessionLspTunnelIpv4Reserved {
 message PatternFlowRSVPPathSessionLspTunnelIpv4TunnelIdCounter {
 
   // Description missing in models
-  // default = 0
+  // default = 1
   optional uint32 start = 1;
 
   // Description missing in models
@@ -20897,11 +20920,11 @@ message PatternFlowRSVPPathSessionLspTunnelIpv4TunnelId {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 0
+  // default = 1
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [0]
+  // default = [1]
   repeated uint32 values = 3;
 
   // Description missing in models
@@ -21538,7 +21561,7 @@ message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Reserved {
 message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspIdCounter {
 
   // Description missing in models
-  // default = 0
+  // default = 1
   optional uint32 start = 1;
 
   // Description missing in models
@@ -21568,11 +21591,11 @@ message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspId {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 0
+  // default = 1
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [0]
+  // default = [1]
   repeated uint32 values = 3;
 
   // Description missing in models

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6679,7 +6679,7 @@ message FlowRSVPPathObjectsClassSessionAttribute {
   FlowRSVPPathObjectsSessionAttributeCType c_type = 2;
 }
 
-// Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel (1)
+// Object for SESSION_ATTRIBUTE class. Currently supported c-type is LSP_Tunnel_RA (1)
 // and LSP_Tunnel (7).
 message FlowRSVPPathObjectsSessionAttributeCType {
 
@@ -6723,6 +6723,7 @@ message FlowRSVPPathSessionAttributeLspTunnel {
   FlowRSVPSessionAttributeNameLength name_length = 4;
 
   // A null padded string of characters.
+  // default =
   optional string session_name = 5;
 }
 
@@ -6773,6 +6774,7 @@ message FlowRSVPPathSessionAttributeLspTunnelRa {
   FlowRSVPSessionAttributeNameLength name_length = 7;
 
   // A null padded string of characters.
+  // default =
   optional string session_name = 8;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6411,8 +6411,15 @@ message FlowRSVPPathSenderTspecIntServ {
   PatternFlowRSVPPathSenderTspecIntServMaximumPacketSize maximum_packet_size = 15;
 }
 
-// Object for RECORD_ROUTE class. c-type is Type 1 Route Record (1).
+// C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassRecordRoute {
+
+  // Description missing in models
+  FlowRSVPPathObjectsRecordRouteCType c_type = 1;
+}
+
+// Object for RECORD_ROUTE class. c-type is Type 1 Route Record (1).
+message FlowRSVPPathObjectsRecordRouteCType {
 
   message Choice {
     enum Enum {
@@ -6428,9 +6435,30 @@ message FlowRSVPPathObjectsClassRecordRoute {
   FlowRSVPPathRecordRouteType1 type_1_route_record = 2;
 }
 
-// Type1 record route has subobjects. Currently supported subobjects are IPv4 address
-// and Label.
+// C-Type of Type 1 Record Route.
 message FlowRSVPPathRecordRouteType1 {
+
+  // Description missing in models
+  FlowRSVPPathRecordRouteType1CType c_type = 1;
+}
+
+// Type1 record route has list of subobjects. Currently supported subobjects are IPv4
+// address(1) and Label(3).
+message FlowRSVPPathRecordRouteType1CType {
+
+  // Description missing in models
+  repeated FlowRSVPType1RecordRouteSubobjects subobjects = 1;
+}
+
+// Type is specific to a subobject.
+message FlowRSVPType1RecordRouteSubobjects {
+
+  // Description missing in models
+  FlowRSVPPathObjectsRecordRouteSubObjectType type = 1;
+}
+
+// Currently supported subobjects are IPv4 address(1) and Label(3).
+message FlowRSVPPathObjectsRecordRouteSubObjectType {
 
   message Choice {
     enum Enum {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5839,16 +5839,8 @@ message FlowRsvp {
   // Description missing in models
   PatternFlowRsvpVersion version = 1;
 
-  message Flag {
-    enum Enum {
-      unspecified = 0;
-      not_refresh_reduction_capable = 1;
-      refresh_reduction_capable = 2;
-    }
-  }
   // Flag, 0x01-0x08: Reserved.
-  // default = Flag.Enum.not_refresh_reduction_capable
-  optional Flag.Enum flag = 2;
+  FlowRSVPFlag flag = 2;
 
   // Description missing in models
   PatternFlowRsvpRsvpChecksum rsvp_checksum = 3;
@@ -5862,18 +5854,151 @@ message FlowRsvp {
   // Description missing in models
   PatternFlowRsvpRsvpLength rsvp_length = 6;
 
-  message MessageType {
+  // An 8-bit number that identifies the function of the RSVP message. There are aound
+  // 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
+  // . Among Those we are presently supporting path(value: 1) message type.
+  FlowRSVPMessage message_type = 7;
+}
+
+// Description missing in models
+message FlowRSVPFlag {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      not_refresh_reduction_capable = 1;
+      refresh_reduction_capable = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.not_refresh_reduction_capable
+  optional Choice.Enum choice = 1;
+}
+
+// Description missing in models
+message FlowRSVPMessage {
+
+  message Choice {
     enum Enum {
       unspecified = 0;
       path = 1;
     }
   }
-  // An 8-bit number that identifies the function of the RSVP message. There are aound
-  // 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
-  // . Among Those we are presently supporting path(value: 1) and hello (value: 20) message
-  // type.
-  // default = MessageType.Enum.path
-  optional MessageType.Enum message_type = 7;
+  // Description missing in models
+  // default = Choice.Enum.path
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathMessage path = 2;
+}
+
+// path message required the follwoing list of objects in order: 1. SESSION 2. RSVP_HOP
+// 3. TIME_VALUES 4. EXPLICIT ROUTE  5. LABEL_REQUEST 6. SESSION_ATTRIBUTE 7. SENDER_TEMPLATE
+// 8. SENDER_TSPEC 9. RECORD_ROUTE
+message FlowRSVPPathMessage {
+
+  // path message required atleast SESSION, RSVP_HOP and TIME_VALUES objects.
+  repeated FlowRSVPPathObjects objects = 1;
+}
+
+// Every RSVP object encapsulated in an RSVP message consists of a 32-bit word header
+// and the object's contents.
+message FlowRSVPPathObjects {
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsLength length = 1;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClass class_num = 2;
+}
+
+// The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4
+// . Curently supported class numbers are for path message type. path message: Supported
+// Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE:
+// 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC:
+// 12, RECORD_ROUTE: 21.
+message FlowRSVPPathObjectsClass {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      session = 1;
+      rsvp_hop = 2;
+      time_values = 3;
+      explicit_route = 4;
+      label_request = 5;
+      session_attribute = 6;
+      sender_template = 7;
+      sender_tspec = 8;
+      record_route = 9;
+    }
+  }
+  // Description missing in models
+  // required = true
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassSession session = 2;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassRsvpHop rsvp_hop = 3;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassTimeValues time_values = 4;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassExplicitRoute explicit_route = 5;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassLabelRequest label_request = 6;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassSessionAttribute session_attribute = 7;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassSenderTemplate sender_template = 8;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassSenderTspec sender_tspec = 9;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassRecordRoute record_route = 10;
+}
+
+// Object for SESSION class.
+message FlowRSVPPathObjectsClassSession {
+}
+
+// Object for RSVP_HOP class.
+message FlowRSVPPathObjectsClassRsvpHop {
+}
+
+// Object for TIME_VALUES class.
+message FlowRSVPPathObjectsClassTimeValues {
+}
+
+// Object for EXPLICIT_ROUTE class.
+message FlowRSVPPathObjectsClassExplicitRoute {
+}
+
+// Object for LABEL_REQUEST class.
+message FlowRSVPPathObjectsClassLabelRequest {
+}
+
+// Object for SESSION_ATTRIBUTE class.
+message FlowRSVPPathObjectsClassSessionAttribute {
+}
+
+// Object for SENDER_TEMPLATE class.
+message FlowRSVPPathObjectsClassSenderTemplate {
+}
+
+// Object for SENDER_TSPEC class.
+message FlowRSVPPathObjectsClassSenderTspec {
+}
+
+// Object for RECORD_ROUTE class.
+message FlowRSVPPathObjectsClassRecordRoute {
 }
 
 // The frame size which overrides the total length of the packet
@@ -19995,6 +20120,54 @@ message PatternFlowRsvpRsvpLength {
 
   // Description missing in models
   PatternFlowRsvpRsvpLengthCounter decrement = 7;
+}
+
+// integer counter pattern
+message PatternFlowRSVPPathObjectsLengthCounter {
+
+  // Description missing in models
+  // default = 4
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Contains the total length of the object including the object's header, measured in
+// bytes.  Objects must be aligned to 32-bit words.
+message PatternFlowRSVPPathObjectsLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 4
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [4]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowRSVPPathObjectsLengthCounter decrement = 6;
 }
 
 // Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5965,9 +5965,16 @@ message FlowRSVPPathObjectsClass {
   FlowRSVPPathObjectsClassRecordRoute record_route = 10;
 }
 
+// C-Type is specific to a class num.
+message FlowRSVPPathObjectsClassSession {
+
+  // Description missing in models
+  FlowRSVPPathObjectsSessionCType c_type = 1;
+}
+
 // The body of an object corresponding to the class number and c-type. Currently supported
 // c-type for SESSION object is LSP Tunnel IPv4 (7).
-message FlowRSVPPathObjectsClassSession {
+message FlowRSVPPathObjectsSessionCType {
 
   message Choice {
     enum Enum {
@@ -5999,8 +6006,15 @@ message FlowRSVPPathObjectsSessionLspTunnelIpv4 {
   PatternFlowRSVPPathObjectsSessionLspTunnelIpv4ExtendedTunnelId extended_tunnel_id = 4;
 }
 
-// Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
+// C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassRsvpHop {
+
+  // Description missing in models
+  FlowRSVPPathObjectsRsvpHopCType c_type = 1;
+}
+
+// Object for RSVP_HOP class. Currently supported c-type is IPv4 (1).
+message FlowRSVPPathObjectsRsvpHopCType {
 
   message Choice {
     enum Enum {
@@ -6026,8 +6040,15 @@ message FlowRSVPPathObjectsClassRsvpHopIpv4 {
   PatternFlowRSVPPathObjectsClassRsvpHopIpv4LogicalInterfaceHandle logical_interface_handle = 2;
 }
 
-// Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
+// C-Type is specific to a class num.
 message FlowRSVPPathObjectsClassTimeValues {
+
+  // Description missing in models
+  FlowRSVPPathObjectsTimeValuesCType c_type = 1;
+}
+
+// Object for TIME_VALUES class. Currently supported c-type is Type 1 Time Value (1).
+message FlowRSVPPathObjectsTimeValuesCType {
 
   message Choice {
     enum Enum {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6161,7 +6161,29 @@ message FlowSnmpv2cVariableBindingValue {
   PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValue unsigned_integer_value = 10;
 }
 
-<<<<<<< HEAD
+// It contains the raw/ascii string value to be sent.
+message FlowSnmpv2cVariableBindingStringValue {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      ascii = 1;
+      raw = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.ascii
+  optional Choice.Enum choice = 1;
+
+  // It contains the ASCII string to be sent.  As of now it is restricted to 10000 bytes.
+  // default = ascii
+  optional string ascii = 2;
+
+  // It contains the hex string to be sent.  As of now it is restricted to 10000 bytes.
+  // default = 00
+  optional string raw = 3;
+}
+
 // RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message
 // type is Path with mandatory objects and sub-objects.
 message FlowRsvp {
@@ -6201,15 +6223,10 @@ message FlowRsvp {
 
 // Description missing in models
 message FlowRSVPLength {
-=======
-// It contains the raw/ascii string value to be sent.
-message FlowSnmpv2cVariableBindingStringValue {
->>>>>>> master
 
   message Choice {
     enum Enum {
       unspecified = 0;
-<<<<<<< HEAD
       auto = 1;
       value = 2;
     }
@@ -7105,23 +7122,6 @@ message FlowRSVPPathObjectsCustom {
   // is 131050 (65525 * 2 hex character per byte).
   // default = 0000
   optional string bytes = 3;
-=======
-      ascii = 1;
-      raw = 2;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.ascii
-  optional Choice.Enum choice = 1;
-
-  // It contains the ASCII string to be sent.  As of now it is restricted to 10000 bytes.
-  // default = ascii
-  optional string ascii = 2;
-
-  // It contains the hex string to be sent.  As of now it is restricted to 10000 bytes.
-  // default = 00
-  optional string raw = 3;
->>>>>>> master
 }
 
 // The frame size which overrides the total length of the packet

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5836,11 +5836,20 @@ message FlowMpls {
 // type is Path with mandatory objects and sub-objects.
 message FlowRsvp {
 
-  // Description missing in models
-  PatternFlowRsvpVersion version = 1;
+  // RSVP Protocol Version.
+  // default = 1
+  optional uint32 version = 1;
 
+  message Flag {
+    enum Enum {
+      unspecified = 0;
+      not_refresh_reduction_capable = 1;
+      refresh_reduction_capable = 2;
+    }
+  }
   // Flag, 0x01-0x08: Reserved.
-  FlowRSVPFlag flag = 2;
+  // default = Flag.Enum.not_refresh_reduction_capable
+  optional Flag.Enum flag = 2;
 
   // Description missing in models
   PatternFlowRsvpRsvpChecksum rsvp_checksum = 3;
@@ -5858,21 +5867,6 @@ message FlowRsvp {
   // 20 message types defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
   // . Among these presently supported is Path(value: 1) message type.
   FlowRSVPMessage message_type = 7;
-}
-
-// Description missing in models
-message FlowRSVPFlag {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      not_refresh_reduction_capable = 1;
-      refresh_reduction_capable = 2;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.not_refresh_reduction_capable
-  optional Choice.Enum choice = 1;
 }
 
 // Description missing in models
@@ -20591,53 +20585,6 @@ message PatternFlowMplsTimeToLive {
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
   repeated PatternFlowMplsTimeToLiveMetricTag metric_tags = 7;
-}
-
-// integer counter pattern
-message PatternFlowRsvpVersionCounter {
-
-  // Description missing in models
-  // default = 1
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// RSVP Protocol Version.
-message PatternFlowRsvpVersion {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [1]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowRsvpVersionCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowRsvpVersionCounter decrement = 6;
 }
 
 // The one's complement of the one's complement sum of the message, with the checksum

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6088,7 +6088,7 @@ message FlowRSVPPathObjectsRsvpHopCType {
 message FlowRSVPPathRsvpHopIpv4 {
 
   // Description missing in models
-  PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddress ipv4_next_previous_hop_address = 1;
+  PatternFlowRSVPPathRsvpHopIpv4Ipv4Address ipv4_address = 1;
 
   // Description missing in models
   PatternFlowRSVPPathRsvpHopIpv4LogicalInterfaceHandle logical_interface_handle = 2;
@@ -6111,15 +6111,15 @@ message FlowRSVPPathObjectsTimeValuesCType {
   message Choice {
     enum Enum {
       unspecified = 0;
-      type_1_time_value = 1;
+      type_1 = 1;
     }
   }
   // Description missing in models
-  // default = Choice.Enum.type_1_time_value
+  // default = Choice.Enum.type_1
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  FlowRSVPPathTimeValuesType1 type_1_time_value = 2;
+  FlowRSVPPathTimeValuesType1 type_1 = 2;
 }
 
 // TIME_VALUES Object: Class = 5, C-Type = 1
@@ -6146,15 +6146,15 @@ message FlowRSVPPathObjectsClassExplicitRouteCType {
   message Choice {
     enum Enum {
       unspecified = 0;
-      type_1_explicit_route = 1;
+      type_1 = 1;
     }
   }
   // Description missing in models
-  // default = Choice.Enum.type_1_explicit_route
+  // default = Choice.Enum.type_1
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  FlowRSVPPathExplicitRouteType1 type_1_explicit_route = 2;
+  FlowRSVPPathExplicitRouteType1 type_1 = 2;
 }
 
 // Type1 Explicit Route has subobjects. Currently supported subobjects are IPv4 prefix
@@ -6562,15 +6562,15 @@ message FlowRSVPPathObjectsRecordRouteCType {
   message Choice {
     enum Enum {
       unspecified = 0;
-      type_1_route_record = 1;
+      type_1 = 1;
     }
   }
   // Description missing in models
-  // default = Choice.Enum.type_1_route_record
+  // default = Choice.Enum.type_1
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  FlowRSVPPathRecordRouteType1 type_1_route_record = 2;
+  FlowRSVPPathRecordRouteType1 type_1 = 2;
 }
 
 // Type1 record route has list of subobjects. Currently supported subobjects are IPv4
@@ -20913,7 +20913,7 @@ message PatternFlowRSVPPathSessionLspTunnelIpv4ExtendedTunnelId {
 }
 
 // ipv4 counter pattern
-message PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddressCounter {
+message PatternFlowRSVPPathRsvpHopIpv4Ipv4AddressCounter {
 
   // Description missing in models
   // default = 0.0.0.0
@@ -20930,7 +20930,7 @@ message PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddressCounter {
 
 // The IPv4 address of the interface through which the last RSVP-knowledgeable hop forwarded
 // this message.
-message PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddress {
+message PatternFlowRSVPPathRsvpHopIpv4Ipv4Address {
 
   message Choice {
     enum Enum {
@@ -20954,10 +20954,10 @@ message PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddress {
   repeated string values = 3;
 
   // Description missing in models
-  PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddressCounter increment = 5;
+  PatternFlowRSVPPathRsvpHopIpv4Ipv4AddressCounter increment = 5;
 
   // Description missing in models
-  PatternFlowRSVPPathRsvpHopIpv4Ipv4NextPreviousHopAddressCounter decrement = 6;
+  PatternFlowRSVPPathRsvpHopIpv4Ipv4AddressCounter decrement = 6;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5833,7 +5833,7 @@ message FlowMpls {
 }
 
 // RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message
-// type is path with mandatory objects and sub-objects.
+// type is Path with mandatory objects and sub-objects.
 message FlowRsvp {
 
   // Description missing in models
@@ -5855,8 +5855,8 @@ message FlowRsvp {
   FlowRSVPLength rsvp_length = 6;
 
   // An 8-bit number that identifies the function of the RSVP message. There are aound
-  // 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
-  // . Among Those we are presently supporting path(value: 1) message type.
+  // 20 message types defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
+  // . Among these presently supported is Path(value: 1) message type.
   FlowRSVPMessage message_type = 7;
 }
 
@@ -5889,8 +5889,8 @@ message FlowRSVPLength {
   // default = Choice.Enum.auto
   optional Choice.Enum choice = 1;
 
-  // The OTG implementation can provide a system generated value for this property. If
-  // the OTG is unable to generate a value the default value must be used.
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
   // default = 0
   optional uint32 auto = 2;
 
@@ -5916,13 +5916,13 @@ message FlowRSVPMessage {
   FlowRSVPPathMessage path = 2;
 }
 
-// path message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+// Path message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
 // 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST
 // 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
 // [optional]
 message FlowRSVPPathMessage {
 
-  // path message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE
+  // Path message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE
   // and SENDER_TSPEC objects in order.
   repeated FlowRSVPPathObjects objects = 1;
 }
@@ -5932,7 +5932,7 @@ message FlowRSVPPathMessage {
 message FlowRSVPPathObjects {
 
   // A 16-bit field containing the total object length in bytes.  Must always be a multiple
-  // of 4, and at least 4.
+  // of 4 or at least 4.
   FlowRSVPPathObjectLength length = 1;
 
   // Description missing in models
@@ -5953,8 +5953,8 @@ message FlowRSVPPathObjectLength {
   // default = Choice.Enum.auto
   optional Choice.Enum choice = 1;
 
-  // The OTG implementation can provide a system generated value for this property. If
-  // the OTG is unable to generate a value the default value must be used.
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
   // default = 4
   optional uint32 auto = 2;
 
@@ -5964,7 +5964,7 @@ message FlowRSVPPathObjectLength {
 }
 
 // The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4
-// . Curently supported class numbers are for path message type. path message: Supported
+// . Curently supported class numbers are for Path message type. Path message: Supported
 // Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE:
 // 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC:
 // 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored
@@ -6194,8 +6194,8 @@ message FlowRSVPPathExplicitRouteType1Ipv4Prefix {
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBit l_bit = 1;
 
-  // The Length contains the total length of the subobject in bytes,including L ,Type
-  // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
+  // The Length contains the total length of the subobject in bytes,including L,Type and
+  // Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
   FlowRSVPExplicitRouteLength length = 2;
 
   // Description missing in models
@@ -6213,7 +6213,7 @@ message FlowRSVPPathExplicitRouteType1FourByteASNumber {
   // Description missing in models
   PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit l_bit = 1;
 
-  // The Length contains the total length of the subobject in bytes,including L ,Type
+  // The Length contains the total length of the subobject in bytes,including L, Type
   // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
   FlowRSVPExplicitRouteLength length = 2;
 
@@ -6241,8 +6241,8 @@ message FlowRSVPExplicitRouteLength {
   // default = Choice.Enum.auto
   optional Choice.Enum choice = 1;
 
-  // The OTG implementation can provide a system generated value for this property. If
-  // the OTG is unable to generate a value the default value must be used.
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
   // default = 8
   optional uint32 auto = 2;
 
@@ -6330,7 +6330,7 @@ message FlowRSVPPathSessionAttributeLspTunnel {
   // default = 7
   optional uint32 holding_priority = 2;
 
-  // 0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+  // 0x01 Local protection desired, 0x02 Label recording desired, 0x04 SE Style desired
   FlowRSVPLspTunnelFlag flags = 3;
 
   // The length of the display string before padding, in bytes.
@@ -6364,7 +6364,7 @@ message FlowRSVPPathSessionAttributeLspTunnelRa {
   // A 32-bit vector representing a set of attribute filters associated with a tunnel
   // all of which must be present for a link to be acceptable. A null set (all bits set
   // to zero) automatically passes. The most significant byte in the hex-string is the
-  // farthest  to the left in the byte sequence.  Leading zero bytes in the configured
+  // farthest to the left in the byte sequence.  Leading zero bytes in the configured
   // value may be omitted for brevity.
   // default = 0
   optional string include_all = 3;
@@ -6381,7 +6381,7 @@ message FlowRSVPPathSessionAttributeLspTunnelRa {
   // default = 7
   optional uint32 holding_priority = 5;
 
-  // 0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+  // 0x01 Local protection desired, 0x02 Label recording desired, 0x04 SE Style desired
   FlowRSVPLspTunnelFlag flags = 6;
 
   // The length of the display string before padding, in bytes.
@@ -6648,8 +6648,8 @@ message FlowRSVPRouteRecordLength {
   // default = Choice.Enum.auto
   optional Choice.Enum choice = 1;
 
-  // The OTG implementation can provide a system generated value for this property. If
-  // the OTG is unable to generate a value the default value must be used.
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
   // default = 8
   optional uint32 auto = 2;
 
@@ -6688,8 +6688,8 @@ message FlowRSVPObjectOptionsCustomLength {
   // default = Choice.Enum.auto
   optional Choice.Enum choice = 1;
 
-  // The OTG implementation can provide a system generated value for this property. If
-  // the OTG is unable to generate a value the default value must be used.
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
   // default = 4
   optional uint32 auto = 2;
 
@@ -20609,7 +20609,7 @@ message PatternFlowRsvpVersionCounter {
   optional uint32 count = 3;
 }
 
-// Protocol Version number.
+// RSVP Protocol Version.
 message PatternFlowRsvpVersion {
 
   message Choice {
@@ -21118,7 +21118,7 @@ message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBitCounter {
   optional uint32 count = 3;
 }
 
-// The L bit is an attribute of the subobject.The L bit is set if the subobject represents
+// The L bit is an attribute of the subobject. The L bit is set if the subobject represents
 // a loose hop in the explicit route. If the bit is not set, the subobject represents
 // a strict hop in the explicit route.
 message PatternFlowRSVPPathExplicitRouteType1Ipv4PrefixLBit {
@@ -21215,7 +21215,7 @@ message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBitCounter {
   optional uint32 count = 3;
 }
 
-// The L bit is an attribute of the subobject.The L bit is set if the subobject represents
+// The L bit is an attribute of the subobject. The L bit is set if the subobject represents
 // a loose hop in the explicit route. If the bit is not set, the subobject represents
 // a strict hop in the explicit route.
 message PatternFlowRSVPPathExplicitRouteType1FourByteASNumberLBit {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5162,11 +5162,8 @@ message FlowHeader {
       ppp = 17;
       igmpv1 = 18;
       mpls = 19;
-<<<<<<< HEAD
-      rsvp = 20;
-=======
       snmpv2c = 20;
->>>>>>> master
+      rsvp = 21;
     }
   }
   // The available types of flow headers. If one is not provided the
@@ -5232,11 +5229,10 @@ message FlowHeader {
   FlowMpls mpls = 20;
 
   // Description missing in models
-<<<<<<< HEAD
-  FlowRsvp rsvp = 21;
-=======
   FlowSnmpv2c snmpv2c = 21;
->>>>>>> master
+
+  // Description missing in models
+  FlowRsvp rsvp = 22;
 }
 
 // Custom packet header
@@ -5926,47 +5922,6 @@ message FlowMpls {
   PatternFlowMplsTimeToLive time_to_live = 4;
 }
 
-<<<<<<< HEAD
-// RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message
-// type is Path with mandatory objects and sub-objects.
-message FlowRsvp {
-
-  // RSVP Protocol Version.
-  // default = 1
-  optional uint32 version = 1;
-
-  message Flag {
-    enum Enum {
-      unspecified = 0;
-      not_refresh_reduction_capable = 1;
-      refresh_reduction_capable = 2;
-    }
-  }
-  // Flag, 0x01-0x08: Reserved.
-  // default = Flag.Enum.not_refresh_reduction_capable
-  optional Flag.Enum flag = 2;
-
-  // Description missing in models
-  PatternFlowRsvpRsvpChecksum rsvp_checksum = 3;
-
-  // Description missing in models
-  PatternFlowRsvpTimeToLive time_to_live = 4;
-
-  // Description missing in models
-  PatternFlowRsvpReserved reserved = 5;
-
-  // The sum of the lengths of the common header and all objects included in the message.
-  FlowRSVPLength rsvp_length = 6;
-
-  // An 8-bit number that identifies the function of the RSVP message. There are aound
-  // 20 message types defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
-  // . Among these presently supported is Path(value: 1) message type.
-  FlowRSVPMessage message_type = 7;
-}
-
-// Description missing in models
-message FlowRSVPLength {
-=======
 // SNMPv2C packet header as defined in RFC1901 and RFC3416.
 message FlowSnmpv2c {
 
@@ -5989,112 +5944,10 @@ message FlowSnmpv2c {
 // - Encoding of subsequent fields follow ASN.1 specification.
 // Refer: http://www.itu.int/ITU-T/asn1/
 message FlowSnmpv2cData {
->>>>>>> master
 
   message Choice {
     enum Enum {
       unspecified = 0;
-<<<<<<< HEAD
-      auto = 1;
-      value = 2;
-    }
-  }
-  // auto or configured value.
-  // default = Choice.Enum.auto
-  optional Choice.Enum choice = 1;
-
-  // OTG will provide a system generated value for this property.  If OTG is unable to
-  // generate a value the default value must be used.
-  // default = 0
-  optional uint32 auto = 2;
-
-  // Description missing in models
-  // default = 0
-  optional uint32 value = 3;
-}
-
-// Description missing in models
-message FlowRSVPMessage {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      path = 1;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.path
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  FlowRSVPPathMessage path = 2;
-}
-
-// Path message requires the following list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
-// 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST
-// 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
-// [optional]
-message FlowRSVPPathMessage {
-
-  // Path message requires atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE
-  // and SENDER_TSPEC objects in order.
-  repeated FlowRSVPPathObjects objects = 1;
-}
-
-// Every RSVP object encapsulated in an RSVP message consists of a 32-bit word header
-// and the object's contents.
-message FlowRSVPPathObjects {
-
-  // Description missing in models
-  FlowRSVPPathObjectsClass class_num = 1;
-}
-
-// Description missing in models
-message FlowRSVPObjectLength {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      auto = 1;
-      value = 2;
-    }
-  }
-  // auto or configured value.
-  // default = Choice.Enum.auto
-  optional Choice.Enum choice = 1;
-
-  // OTG will provide a system generated value for this property.  If OTG is unable to
-  // generate a value the default value must be used.
-  // default = 4
-  optional uint32 auto = 2;
-
-  // Description missing in models
-  // default = 4
-  optional uint32 value = 3;
-}
-
-// The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4
-// . Curently supported class numbers are for Path message type. Path message: Supported
-// Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE:
-// 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC:
-// 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not supported
-// in above options.
-message FlowRSVPPathObjectsClass {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      session = 1;
-      rsvp_hop = 2;
-      time_values = 3;
-      explicit_route = 4;
-      label_request = 5;
-      session_attribute = 6;
-      sender_template = 7;
-      sender_tspec = 8;
-      record_route = 9;
-      custom = 10;
-=======
       get_request = 1;
       get_next_request = 2;
       response = 3;
@@ -6103,7 +5956,6 @@ message FlowRSVPPathObjectsClass {
       inform_request = 6;
       snmpv2_trap = 7;
       report = 8;
->>>>>>> master
     }
   }
   // Description missing in models
@@ -6111,52 +5963,6 @@ message FlowRSVPPathObjectsClass {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-<<<<<<< HEAD
-  FlowRSVPPathObjectsClassSession session = 2;
-
-  // Description missing in models
-  FlowRSVPPathObjectsClassRsvpHop rsvp_hop = 3;
-
-  // Description missing in models
-  FlowRSVPPathObjectsClassTimeValues time_values = 4;
-
-  // Description missing in models
-  FlowRSVPPathObjectsClassExplicitRoute explicit_route = 5;
-
-  // Description missing in models
-  FlowRSVPPathObjectsClassLabelRequest label_request = 6;
-
-  // Description missing in models
-  FlowRSVPPathObjectsClassSessionAttribute session_attribute = 7;
-
-  // Description missing in models
-  FlowRSVPPathObjectsClassSenderTemplate sender_template = 8;
-
-  // Description missing in models
-  FlowRSVPPathObjectsClassSenderTspec sender_tspec = 9;
-
-  // Description missing in models
-  FlowRSVPPathObjectsClassRecordRoute record_route = 10;
-
-  // Description missing in models
-  FlowRSVPPathObjectsCustom custom = 11;
-}
-
-// C-Type is specific to a class num.
-message FlowRSVPPathObjectsClassSession {
-
-  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
-  // of 4 or at least 4.
-  FlowRSVPObjectLength length = 1;
-
-  // Description missing in models
-  FlowRSVPPathObjectsSessionCType c_type = 2;
-}
-
-// The body of an object corresponding to the class number and c-type. Currently supported
-// c-type for SESSION object is LSP Tunnel IPv4 (7).
-message FlowRSVPPathObjectsSessionCType {
-=======
   FlowSnmpv2cPDU get_request = 2;
 
   // Description missing in models
@@ -6279,12 +6085,281 @@ message FlowSnmpv2cVariableBinding {
 
 // The value for the object_identifier as per RFC2578.
 message FlowSnmpv2cVariableBindingValue {
->>>>>>> master
 
   message Choice {
     enum Enum {
       unspecified = 0;
-<<<<<<< HEAD
+      no_value = 1;
+      integer_value = 2;
+      string_value = 3;
+      object_identifier_value = 4;
+      ip_address_value = 5;
+      counter_value = 6;
+      timeticks_value = 7;
+      arbitrary_value = 8;
+      big_counter_value = 9;
+      unsigned_integer_value = 10;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.no_value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueIntegerValue integer_value = 2;
+
+  // It contains the hex bytes of the value to be sent.  As of now it is restricted to
+  // 5000 bytes.
+  // default = string
+  optional string string_value = 3;
+
+  // The Object Identifier points to a particular parameter in the SNMP agent.
+  // - Encoding of this field follows RFC2578(section 3.5) and ASN.1 X.690(section 8.1.3.6)
+  // specification.
+  // Refer: http://www.itu.int/ITU-T/asn1/
+  // - According to BER, the first two numbers of any OID (x.y) are encoded as one value
+  // using the formula (40*x)+y.
+  // Example, the first two numbers of an SNMP OID 1.3... are encoded as 43 or 0x2B,
+  // because (40*1)+3 = 43.
+  // - After the first two numbers are encoded, the subsequent numbers in the OID are
+  // each encoded as a byte.
+  // - However, a special rule is required for large numbers because one byte can only
+  // represent a number from 0-127.
+  // - The rule for large numbers states that only the lower 7 bits in the byte are used
+  // for holding the value (0-127).
+  // - The highest order bit(8th) is used as a flag to indicate that this number spans
+  // more than one byte. Therefore, any number over 127 must be encoded using more than
+  // one byte.
+  // - Example, the number 2680 in the OID '1.3.6.1.4.1.2680.1.2.7.3.2.0' cannot be
+  // encoded using a single byte.
+  // According to this rule, the number 2680 must be encoded as 0x94 0x78.
+  // Since the most significant bit is set in the first byte (0x94), it indicates
+  // that number spans to the next byte.
+  // Since the most significant bit is not set in the next byte (0x78), it indicates
+  // that the number ends at the second byte.
+  // The value is derived by appending 7 bits from each of the concatenated bytes
+  // i.e (0x14 *128^1) + (0x78 * 128^0) = 2680.
+  // default = 0.1
+  optional string object_identifier_value = 4;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueIpAddressValue ip_address_value = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueCounterValue counter_value = 6;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueTimeticksValue timeticks_value = 7;
+
+  // It contains the hex bytes of the value to be sent.  As of now it is restricted to
+  // 5000 bytes.
+  // default = 00
+  optional string arbitrary_value = 8;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueBigCounterValue big_counter_value = 9;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValue unsigned_integer_value = 10;
+}
+
+// RSVP packet header as defined in RFC2205 and RFC3209. Currently only supported message
+// type is Path with mandatory objects and sub-objects.
+message FlowRsvp {
+
+  // RSVP Protocol Version.
+  // default = 1
+  optional uint32 version = 1;
+
+  message Flag {
+    enum Enum {
+      unspecified = 0;
+      not_refresh_reduction_capable = 1;
+      refresh_reduction_capable = 2;
+    }
+  }
+  // Flag, 0x01-0x08: Reserved.
+  // default = Flag.Enum.not_refresh_reduction_capable
+  optional Flag.Enum flag = 2;
+
+  // Description missing in models
+  PatternFlowRsvpRsvpChecksum rsvp_checksum = 3;
+
+  // Description missing in models
+  PatternFlowRsvpTimeToLive time_to_live = 4;
+
+  // Description missing in models
+  PatternFlowRsvpReserved reserved = 5;
+
+  // The sum of the lengths of the common header and all objects included in the message.
+  FlowRSVPLength rsvp_length = 6;
+
+  // An 8-bit number that identifies the function of the RSVP message. There are aound
+  // 20 message types defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2
+  // . Among these presently supported is Path(value: 1) message type.
+  FlowRSVPMessage message_type = 7;
+}
+
+// Description missing in models
+message FlowRSVPLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
+  // default = 0
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 3;
+}
+
+// Description missing in models
+message FlowRSVPMessage {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      path = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.path
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathMessage path = 2;
+}
+
+// Path message requires the following list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+// 1. SESSION 2. RSVP_HOP 3. TIME_VALUES 4. EXPLICIT_ROUTE [optional] 5. LABEL_REQUEST
+// 6. SESSION_ATTRIBUTE [optional] 7. SENDER_TEMPLATE 8. SENDER_TSPEC 9. RECORD_ROUTE
+// [optional]
+message FlowRSVPPathMessage {
+
+  // Path message requires atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE
+  // and SENDER_TSPEC objects in order.
+  repeated FlowRSVPPathObjects objects = 1;
+}
+
+// Every RSVP object encapsulated in an RSVP message consists of a 32-bit word header
+// and the object's contents.
+message FlowRSVPPathObjects {
+
+  // Description missing in models
+  FlowRSVPPathObjectsClass class_num = 1;
+}
+
+// Description missing in models
+message FlowRSVPObjectLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
+  // default = 4
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 4
+  optional uint32 value = 3;
+}
+
+// The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4
+// . Curently supported class numbers are for Path message type. Path message: Supported
+// Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE:
+// 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC:
+// 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not supported
+// in above options.
+message FlowRSVPPathObjectsClass {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      session = 1;
+      rsvp_hop = 2;
+      time_values = 3;
+      explicit_route = 4;
+      label_request = 5;
+      session_attribute = 6;
+      sender_template = 7;
+      sender_tspec = 8;
+      record_route = 9;
+      custom = 10;
+    }
+  }
+  // Description missing in models
+  // required = true
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassSession session = 2;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassRsvpHop rsvp_hop = 3;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassTimeValues time_values = 4;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassExplicitRoute explicit_route = 5;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassLabelRequest label_request = 6;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassSessionAttribute session_attribute = 7;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassSenderTemplate sender_template = 8;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassSenderTspec sender_tspec = 9;
+
+  // Description missing in models
+  FlowRSVPPathObjectsClassRecordRoute record_route = 10;
+
+  // Description missing in models
+  FlowRSVPPathObjectsCustom custom = 11;
+}
+
+// C-Type is specific to a class num.
+message FlowRSVPPathObjectsClassSession {
+
+  // A 16-bit field containing the total object length in bytes.  Must always be a multiple
+  // of 4 or at least 4.
+  FlowRSVPObjectLength length = 1;
+
+  // Description missing in models
+  FlowRSVPPathObjectsSessionCType c_type = 2;
+}
+
+// The body of an object corresponding to the class number and c-type. Currently supported
+// c-type for SESSION object is LSP Tunnel IPv4 (7).
+message FlowRSVPPathObjectsSessionCType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
       lsp_tunnel_ipv4 = 1;
     }
   }
@@ -7026,80 +7101,6 @@ message FlowRSVPPathObjectsCustom {
   // is 131050 (65525 * 2 hex character per byte).
   // default = 0000
   optional string bytes = 3;
-=======
-      no_value = 1;
-      integer_value = 2;
-      string_value = 3;
-      object_identifier_value = 4;
-      ip_address_value = 5;
-      counter_value = 6;
-      timeticks_value = 7;
-      arbitrary_value = 8;
-      big_counter_value = 9;
-      unsigned_integer_value = 10;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.no_value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueIntegerValue integer_value = 2;
-
-  // It contains the hex bytes of the value to be sent.  As of now it is restricted to
-  // 5000 bytes.
-  // default = string
-  optional string string_value = 3;
-
-  // The Object Identifier points to a particular parameter in the SNMP agent.
-  // - Encoding of this field follows RFC2578(section 3.5) and ASN.1 X.690(section 8.1.3.6)
-  // specification.
-  // Refer: http://www.itu.int/ITU-T/asn1/
-  // - According to BER, the first two numbers of any OID (x.y) are encoded as one value
-  // using the formula (40*x)+y.
-  // Example, the first two numbers of an SNMP OID 1.3... are encoded as 43 or 0x2B,
-  // because (40*1)+3 = 43.
-  // - After the first two numbers are encoded, the subsequent numbers in the OID are
-  // each encoded as a byte.
-  // - However, a special rule is required for large numbers because one byte can only
-  // represent a number from 0-127.
-  // - The rule for large numbers states that only the lower 7 bits in the byte are used
-  // for holding the value (0-127).
-  // - The highest order bit(8th) is used as a flag to indicate that this number spans
-  // more than one byte. Therefore, any number over 127 must be encoded using more than
-  // one byte.
-  // - Example, the number 2680 in the OID '1.3.6.1.4.1.2680.1.2.7.3.2.0' cannot be
-  // encoded using a single byte.
-  // According to this rule, the number 2680 must be encoded as 0x94 0x78.
-  // Since the most significant bit is set in the first byte (0x94), it indicates
-  // that number spans to the next byte.
-  // Since the most significant bit is not set in the next byte (0x78), it indicates
-  // that the number ends at the second byte.
-  // The value is derived by appending 7 bits from each of the concatenated bytes
-  // i.e (0x14 *128^1) + (0x78 * 128^0) = 2680.
-  // default = 0.1
-  optional string object_identifier_value = 4;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueIpAddressValue ip_address_value = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueCounterValue counter_value = 6;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueTimeticksValue timeticks_value = 7;
-
-  // It contains the hex bytes of the value to be sent.  As of now it is restricted to
-  // 5000 bytes.
-  // default = 00
-  optional string arbitrary_value = 8;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueBigCounterValue big_counter_value = 9;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValue unsigned_integer_value = 10;
->>>>>>> master
 }
 
 // The frame size which overrides the total length of the packet
@@ -21138,7 +21139,612 @@ message PatternFlowMplsTimeToLive {
   repeated PatternFlowMplsTimeToLiveMetricTag metric_tags = 7;
 }
 
-<<<<<<< HEAD
+// integer counter pattern
+message PatternFlowSnmpv2cVersionCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Version
+message PatternFlowSnmpv2cVersion {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVersionCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVersionCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cPDURequestIdCounter {
+
+  // Description missing in models
+  // default = 0
+  optional int32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional int32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional int32 count = 3;
+}
+
+// Identifies a particular SNMP request.
+// This index is echoed back in the response from the SNMP agent,
+// allowing the SNMP manager to match an incoming response to the appropriate request.
+// 
+// - Encoding of this field follows ASN.1 X.690(section 8.3) specification.
+// Refer: http://www.itu.int/ITU-T/asn1/
+message PatternFlowSnmpv2cPDURequestId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional int32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated int32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cPDURequestIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cPDURequestIdCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cPDUErrorIndexCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// When Error Status is non-zero,  this field contains a pointer that specifies which
+// object generated the error.  Always zero in a request.
+message PatternFlowSnmpv2cPDUErrorIndex {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cPDUErrorIndexCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cPDUErrorIndexCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cBulkPDURequestIdCounter {
+
+  // Description missing in models
+  // default = 0
+  optional int32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional int32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional int32 count = 3;
+}
+
+// Identifies a particular SNMP request.
+// This index is echoed back in the response from the SNMP agent,
+// allowing the SNMP manager to match an incoming response to the appropriate request.
+// 
+// - Encoding of this field follows ASN.1 X.690(section 8.3) specification.
+// Refer: http://www.itu.int/ITU-T/asn1/
+message PatternFlowSnmpv2cBulkPDURequestId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional int32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated int32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cBulkPDURequestIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cBulkPDURequestIdCounter decrement = 6;
+}
+
+// One variable binding in the Response-PDU is requested for the first non_repeaters
+// variable bindings in the GetBulkRequest.
+message PatternFlowSnmpv2cBulkPDUNonRepeaters {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cBulkPDUMaxRepetitionsCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// A maximum of max_repetitions variable bindings are requested in the Response-PDU
+// for each of the remaining variable bindings in the GetBulkRequest after the non_repeaters
+// variable bindings.
+message PatternFlowSnmpv2cBulkPDUMaxRepetitions {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cBulkPDUMaxRepetitionsCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cBulkPDUMaxRepetitionsCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cVariableBindingValueIntegerValueCounter {
+
+  // Description missing in models
+  // default = 0
+  optional int32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional int32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional int32 count = 3;
+}
+
+// Integer value returned for the requested OID.
+message PatternFlowSnmpv2cVariableBindingValueIntegerValue {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional int32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated int32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueIntegerValueCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueIntegerValueCounter decrement = 6;
+}
+
+// ipv4 counter pattern
+message PatternFlowSnmpv2cVariableBindingValueIpAddressValueCounter {
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 0.0.0.1
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// IPv4 address returned for the requested OID.
+message PatternFlowSnmpv2cVariableBindingValueIpAddressValue {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['0.0.0.0']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueIpAddressValueCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueIpAddressValueCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cVariableBindingValueCounterValueCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Counter returned for the requested OID.
+message PatternFlowSnmpv2cVariableBindingValueCounterValue {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueCounterValueCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueCounterValueCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cVariableBindingValueTimeticksValueCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Timeticks returned for the requested OID.
+message PatternFlowSnmpv2cVariableBindingValueTimeticksValue {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueTimeticksValueCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueTimeticksValueCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cVariableBindingValueBigCounterValueCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint64 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint64 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint64 count = 3;
+}
+
+// Big counter returned for the requested OID.
+message PatternFlowSnmpv2cVariableBindingValueBigCounterValue {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint64 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint64 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueBigCounterValueCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueBigCounterValueCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValueCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Unsigned integer value returned for the requested OID.
+message PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValue {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValueCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValueCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv2cCommonRequestIdCounter {
+
+  // Description missing in models
+  // default = 0
+  optional int32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional int32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional int32 count = 3;
+}
+
+// Identifies a particular SNMP request.
+// This index is echoed back in the response from the SNMP agent,
+// allowing the SNMP manager to match an incoming response to the appropriate request.
+// 
+// - Encoding of this field follows ASN.1 X.690(section 8.3) specification.
+// Refer: http://www.itu.int/ITU-T/asn1/
+message PatternFlowSnmpv2cCommonRequestId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional int32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated int32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv2cCommonRequestIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv2cCommonRequestIdCounter decrement = 6;
+}
+
 // The one's complement of the one's complement sum of the message, with the checksum
 // field replaced by zero for the purpose of computing the checksum.   An all-zero value
 // means that no checksum was transmitted.
@@ -21360,10 +21966,6 @@ message PatternFlowRSVPPathSessionLspTunnelIpv4Reserved {
 
 // integer counter pattern
 message PatternFlowRSVPPathSessionLspTunnelIpv4TunnelIdCounter {
-=======
-// integer counter pattern
-message PatternFlowSnmpv2cVersionCounter {
->>>>>>> master
 
   // Description missing in models
   // default = 1
@@ -21378,14 +21980,9 @@ message PatternFlowSnmpv2cVersionCounter {
   optional uint32 count = 3;
 }
 
-<<<<<<< HEAD
 // A 16-bit identifier used in the SESSION that remains constant over the life of the
 // tunnel.
 message PatternFlowRSVPPathSessionLspTunnelIpv4TunnelId {
-=======
-// Version
-message PatternFlowSnmpv2cVersion {
->>>>>>> master
 
   message Choice {
     enum Enum {
@@ -21409,7 +22006,6 @@ message PatternFlowSnmpv2cVersion {
   repeated uint32 values = 3;
 
   // Description missing in models
-<<<<<<< HEAD
   PatternFlowRSVPPathSessionLspTunnelIpv4TunnelIdCounter increment = 5;
 
   // Description missing in models
@@ -21916,37 +22512,6 @@ message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pidCounter {
 // are used e.g. The default value of 2048 ( 0x0800 ) represents Ethertype for IPv4.
 // 
 message PatternFlowRSVPPathLabelRequestWithoutLabelRangeL3pid {
-=======
-  PatternFlowSnmpv2cVersionCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVersionCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cPDURequestIdCounter {
-
-  // Description missing in models
-  // default = 0
-  optional int32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional int32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional int32 count = 3;
-}
-
-// Identifies a particular SNMP request.
-// This index is echoed back in the response from the SNMP agent,
-// allowing the SNMP manager to match an incoming response to the appropriate request.
-// 
-// - Encoding of this field follows ASN.1 X.690(section 8.3) specification.
-// Refer: http://www.itu.int/ITU-T/asn1/
-message PatternFlowSnmpv2cPDURequestId {
->>>>>>> master
 
   message Choice {
     enum Enum {
@@ -21962,7 +22527,6 @@ message PatternFlowSnmpv2cPDURequestId {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-<<<<<<< HEAD
   // default = 2048
   optional uint32 value = 2;
 
@@ -21979,244 +22543,6 @@ message PatternFlowSnmpv2cPDURequestId {
 
 // ipv4 counter pattern
 message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Ipv4TunnelSenderAddressCounter {
-=======
-  // default = 0
-  optional int32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated int32 values = 3;
-
-  // Description missing in models
-  PatternFlowSnmpv2cPDURequestIdCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cPDURequestIdCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cPDUErrorIndexCounter {
-
-  // Description missing in models
-  // default = 0
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// When Error Status is non-zero,  this field contains a pointer that specifies which
-// object generated the error.  Always zero in a request.
-message PatternFlowSnmpv2cPDUErrorIndex {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowSnmpv2cPDUErrorIndexCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cPDUErrorIndexCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cBulkPDURequestIdCounter {
-
-  // Description missing in models
-  // default = 0
-  optional int32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional int32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional int32 count = 3;
-}
-
-// Identifies a particular SNMP request.
-// This index is echoed back in the response from the SNMP agent,
-// allowing the SNMP manager to match an incoming response to the appropriate request.
-// 
-// - Encoding of this field follows ASN.1 X.690(section 8.3) specification.
-// Refer: http://www.itu.int/ITU-T/asn1/
-message PatternFlowSnmpv2cBulkPDURequestId {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional int32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated int32 values = 3;
-
-  // Description missing in models
-  PatternFlowSnmpv2cBulkPDURequestIdCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cBulkPDURequestIdCounter decrement = 6;
-}
-
-// One variable binding in the Response-PDU is requested for the first non_repeaters
-// variable bindings in the GetBulkRequest.
-message PatternFlowSnmpv2cBulkPDUNonRepeaters {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated uint32 values = 3;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cBulkPDUMaxRepetitionsCounter {
-
-  // Description missing in models
-  // default = 0
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// A maximum of max_repetitions variable bindings are requested in the Response-PDU
-// for each of the remaining variable bindings in the GetBulkRequest after the non_repeaters
-// variable bindings.
-message PatternFlowSnmpv2cBulkPDUMaxRepetitions {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowSnmpv2cBulkPDUMaxRepetitionsCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cBulkPDUMaxRepetitionsCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cVariableBindingValueIntegerValueCounter {
-
-  // Description missing in models
-  // default = 0
-  optional int32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional int32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional int32 count = 3;
-}
-
-// Integer value returned for the requested OID.
-message PatternFlowSnmpv2cVariableBindingValueIntegerValue {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional int32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated int32 values = 3;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueIntegerValueCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueIntegerValueCounter decrement = 6;
-}
-
-// ipv4 counter pattern
-message PatternFlowSnmpv2cVariableBindingValueIpAddressValueCounter {
->>>>>>> master
 
   // Description missing in models
   // default = 0.0.0.0
@@ -22231,13 +22557,8 @@ message PatternFlowSnmpv2cVariableBindingValueIpAddressValueCounter {
   optional uint32 count = 3;
 }
 
-<<<<<<< HEAD
 // IPv4 address for a sender node.
 message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Ipv4TunnelSenderAddress {
-=======
-// IPv4 address returned for the requested OID.
-message PatternFlowSnmpv2cVariableBindingValueIpAddressValue {
->>>>>>> master
 
   message Choice {
     enum Enum {
@@ -22261,7 +22582,6 @@ message PatternFlowSnmpv2cVariableBindingValueIpAddressValue {
   repeated string values = 3;
 
   // Description missing in models
-<<<<<<< HEAD
   PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Ipv4TunnelSenderAddressCounter increment = 5;
 
   // Description missing in models
@@ -22270,16 +22590,6 @@ message PatternFlowSnmpv2cVariableBindingValueIpAddressValue {
 
 // integer counter pattern
 message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4ReservedCounter {
-=======
-  PatternFlowSnmpv2cVariableBindingValueIpAddressValueCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueIpAddressValueCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cVariableBindingValueCounterValueCounter {
->>>>>>> master
 
   // Description missing in models
   // default = 0
@@ -22294,13 +22604,8 @@ message PatternFlowSnmpv2cVariableBindingValueCounterValueCounter {
   optional uint32 count = 3;
 }
 
-<<<<<<< HEAD
 // Reserved field, MUST be zero.
 message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4Reserved {
-=======
-// Counter returned for the requested OID.
-message PatternFlowSnmpv2cVariableBindingValueCounterValue {
->>>>>>> master
 
   message Choice {
     enum Enum {
@@ -22324,7 +22629,6 @@ message PatternFlowSnmpv2cVariableBindingValueCounterValue {
   repeated uint32 values = 3;
 
   // Description missing in models
-<<<<<<< HEAD
   PatternFlowRSVPPathSenderTemplateLspTunnelIpv4ReservedCounter increment = 5;
 
   // Description missing in models
@@ -22381,16 +22685,6 @@ message PatternFlowRSVPPathSenderTemplateLspTunnelIpv4LspId {
 
 // integer counter pattern
 message PatternFlowRSVPPathSenderTspecIntServVersionCounter {
-=======
-  PatternFlowSnmpv2cVariableBindingValueCounterValueCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueCounterValueCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cVariableBindingValueTimeticksValueCounter {
->>>>>>> master
 
   // Description missing in models
   // default = 0
@@ -22405,13 +22699,8 @@ message PatternFlowSnmpv2cVariableBindingValueTimeticksValueCounter {
   optional uint32 count = 3;
 }
 
-<<<<<<< HEAD
 // Message format version number.
 message PatternFlowRSVPPathSenderTspecIntServVersion {
-=======
-// Timeticks returned for the requested OID.
-message PatternFlowSnmpv2cVariableBindingValueTimeticksValue {
->>>>>>> master
 
   message Choice {
     enum Enum {
@@ -22435,7 +22724,6 @@ message PatternFlowSnmpv2cVariableBindingValueTimeticksValue {
   repeated uint32 values = 3;
 
   // Description missing in models
-<<<<<<< HEAD
   PatternFlowRSVPPathSenderTspecIntServVersionCounter increment = 5;
 
   // Description missing in models
@@ -22444,63 +22732,6 @@ message PatternFlowSnmpv2cVariableBindingValueTimeticksValue {
 
 // integer counter pattern
 message PatternFlowRSVPPathSenderTspecIntServReserved1Counter {
-=======
-  PatternFlowSnmpv2cVariableBindingValueTimeticksValueCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueTimeticksValueCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cVariableBindingValueBigCounterValueCounter {
-
-  // Description missing in models
-  // default = 0
-  optional uint64 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint64 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint64 count = 3;
-}
-
-// Big counter returned for the requested OID.
-message PatternFlowSnmpv2cVariableBindingValueBigCounterValue {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional uint64 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated uint64 values = 3;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueBigCounterValueCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueBigCounterValueCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValueCounter {
->>>>>>> master
 
   // Description missing in models
   // default = 0
@@ -22515,13 +22746,8 @@ message PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValueCounter {
   optional uint32 count = 3;
 }
 
-<<<<<<< HEAD
 // Reserved.
 message PatternFlowRSVPPathSenderTspecIntServReserved1 {
-=======
-// Unsigned integer value returned for the requested OID.
-message PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValue {
->>>>>>> master
 
   message Choice {
     enum Enum {
@@ -22545,7 +22771,6 @@ message PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValue {
   repeated uint32 values = 3;
 
   // Description missing in models
-<<<<<<< HEAD
   PatternFlowRSVPPathSenderTspecIntServReserved1Counter increment = 5;
 
   // Description missing in models
@@ -22664,37 +22889,6 @@ message PatternFlowRSVPPathSenderTspecIntServZeroBitCounter {
 
 // MUST be 0.
 message PatternFlowRSVPPathSenderTspecIntServZeroBit {
-=======
-  PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValueCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cVariableBindingValueUnsignedIntegerValueCounter decrement = 6;
-}
-
-// integer counter pattern
-message PatternFlowSnmpv2cCommonRequestIdCounter {
-
-  // Description missing in models
-  // default = 0
-  optional int32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional int32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional int32 count = 3;
-}
-
-// Identifies a particular SNMP request.
-// This index is echoed back in the response from the SNMP agent,
-// allowing the SNMP manager to match an incoming response to the appropriate request.
-// 
-// - Encoding of this field follows ASN.1 X.690(section 8.3) specification.
-// Refer: http://www.itu.int/ITU-T/asn1/
-message PatternFlowSnmpv2cCommonRequestId {
->>>>>>> master
 
   message Choice {
     enum Enum {
@@ -22711,7 +22905,6 @@ message PatternFlowSnmpv2cCommonRequestId {
 
   // Description missing in models
   // default = 0
-<<<<<<< HEAD
   optional uint32 value = 2;
 
   // Description missing in models
@@ -23244,19 +23437,6 @@ message PatternFlowRSVPPathObjectsCustomType {
 
   // Description missing in models
   PatternFlowRSVPPathObjectsCustomTypeCounter decrement = 6;
-=======
-  optional int32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated int32 values = 3;
-
-  // Description missing in models
-  PatternFlowSnmpv2cCommonRequestIdCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowSnmpv2cCommonRequestIdCounter decrement = 6;
->>>>>>> master
 }
 
 // Version details

--- a/flow/packet-headers/header.yaml
+++ b/flow/packet-headers/header.yaml
@@ -51,9 +51,10 @@ components:
               x-field-uid: 18
             mpls:
               x-field-uid: 19
-            rsvp:
             snmpv2c:
               x-field-uid: 20
+            rsvp:
+              x-field-uid: 21
         custom:
           $ref: './custom.yaml#/components/schemas/Flow.Custom'
           x-field-uid: 2
@@ -111,8 +112,9 @@ components:
         mpls:
           $ref: './mpls.yaml#/components/schemas/Flow.Mpls'
           x-field-uid: 20
-        rsvp:
-          $ref: './rsvp.yaml#/components/schemas/Flow.Rsvp'
         snmpv2c:
           $ref: './snmpv2c.yaml#/components/schemas/Flow.Snmpv2c'
           x-field-uid: 21
+        rsvp:
+          $ref: './rsvp.yaml#/components/schemas/Flow.Rsvp'
+          x-field-uid: 22

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -340,6 +340,14 @@ components:
           x-field-uid: 1
     Flow.RSVP.PathObjectsClassExplicitRoute:
       description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassExplicitRouteCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsClassExplicitRouteCType:
+      description: >-
         Object for EXPLICIT_ROUTE class.
         Currently supported c-type is Type 1 Explicit Route (1).
       type: object
@@ -358,6 +366,25 @@ components:
       description: >-
         Type1 Explicit Route has subobjects.
         Currently supported subobjects are IPv4 prefix and 4-byte AS number.
+      type: object
+      properties:
+        subobjects:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/Flow.RSVP.Type1ExplicitRouteSubobjects'
+          x-field-uid: 1
+    Flow.RSVP.Type1ExplicitRouteSubobjects:
+      description: >-
+          Type is specific to a subobject.
+      type: object 
+      properties:
+        type: 
+          $ref: '#/components/schemas/Flow.RSVP.Type1ExplicitRouteSubobjectsType'
+          x-field-uid: 1 
+    Flow.RSVP.Type1ExplicitRouteSubobjectsType:
+      description: >- 
+        Currently supported subobjects are IPv4 address(1) and 4-byte AS number(5).
       type: object
       properties:
         choice:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -39,7 +39,7 @@ components:
               The IP time-to-live(TTL) value with which the message was sent.
             format: integer
             length: 8
-            default: 0
+            default: 64
             features: [count]
           x-field-uid: 4
         reserved:
@@ -106,7 +106,7 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: >-
-        "Path" message requires the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+        "Path" message requires the following list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
         1. SESSION
         2. RSVP_HOP
         3. TIME_VALUES
@@ -122,7 +122,6 @@ components:
           description: >-
             "Path" message requires atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
           type: array
-          minItems: 6
           items:
             $ref: '#/components/schemas/Flow.RSVP.PathObjects'
           x-field-uid: 1
@@ -318,7 +317,7 @@ components:
         as_ipv4:
           x-field-pattern:
             description: >-
-              IPv4 address of the egress node for the tunnel.
+              IPv4 address of the ingress endpoint for the tunnel.
             format: ipv4
             default: 0.0.0.0
             features: [count]
@@ -523,7 +522,7 @@ components:
           x-field-uid: 3
         prefix:
           description: >-
-            The prefix of the IPv4 address.
+            The prefix length of the IPv4 address.
           type: integer
           format: uint32
           minimum: 1
@@ -648,7 +647,7 @@ components:
           x-field-pattern:
             description: >-
               An identifier of the layer 3 protocol using this path. 
-              Standard Ethertype values are used.          
+              Standard Ethertype values are used e.g. The default value of 2048 ( 0x0800 ) represents Ethertype for IPv4.          
             format: integer
             default: 2048
             length: 16
@@ -1167,7 +1166,7 @@ components:
         prefix_length:
           x-field-pattern:
             description: >-
-              Prefix-length of ipv4 address.
+              Prefix-length of IPv4 address.
             format: integer
             length: 8
             default: 32
@@ -1218,7 +1217,7 @@ components:
             length: 8
             default: 0
           x-field-uid: 3
-        contents_of_label_obejct:
+        label:
           description: >-
             The contents of the Label Object. Copied from the Label Object.
           type: string

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -936,14 +936,6 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathRecordRouteType1:
       description: >-
-          C-Type of Type 1 Record Route.
-      type: object 
-      properties:
-        c_type: 
-          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1CType'
-          x-field-uid: 1 
-    Flow.RSVP.PathRecordRouteType1CType:
-      description: >-
         Type1 record route has list of subobjects.
         Currently supported subobjects are IPv4 address(1) and Label(3).
       type: object

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -284,7 +284,7 @@ components:
             description: >-
               A 16-bit identifier used in the SESSION that remains constant over the life of the tunnel.
             format: integer
-            default: 0
+            default: 1
             length: 16
             features: [count]
           x-field-uid: 3
@@ -903,7 +903,7 @@ components:
             description: >-
               A 16-bit identifier used in the SENDER_TEMPLATE that can be changed to allow a sender to share resources with itself.
             format: integer
-            default: 0
+            default: 1
             length: 16
             features: [count]
           x-field-uid: 3

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -290,15 +290,39 @@ components:
             features: [count]
           x-field-uid: 3
         extended_tunnel_id:
+          description: >-
+            A 32-bit identifier used in the SESSION that remains constant over the life of the tunnel. Normally set to all zeros.
+            Ingress nodes that wish to narrow the scope of a SESSION to the ingress-egress pair may place their IPv4 address here as a globally unique identifier.
+          $ref: '#/components/schemas/Flow.RSVP.PathSessionExtTunnelId'
+          x-field-uid: 4
+    Flow.RSVP.PathSessionExtTunnelId:
+      type: object
+      properties:
+        choice:
+          description: 32 bit integer or IPv4 address.
+          type: string
+          default: as_integer
+          x-field-uid: 1
+          x-enum:
+            as_integer:
+              x-field-uid: 1
+            as_ipv4:
+              x-field-uid: 2 
+        as_integer:
           x-field-pattern:
-            description: >-
-              A 32-bit identifier used in the SESSION that remains constant over the life of the tunnel. Normally set to all zeros.
-              Ingress nodes that wish to narrow the scope of a SESSION to the ingress-egress pair may place their IPv4 address here as a globally unique identifier.
             format: integer
             default: 0
             length: 32
+            features: [count] 
+          x-field-uid: 2
+        as_ipv4:
+          x-field-pattern:
+            description: >-
+              IPv4 address of the egress node for the tunnel.
+            format: ipv4
+            default: 0.0.0.0
             features: [count]
-          x-field-uid: 4
+          x-field-uid: 3
     Flow.RSVP.PathObjectsClassRsvpHop:
       description: >-
           C-Type is specific to a class num.

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -113,7 +113,7 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: >-
-        "Path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+        "Path" message requires the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
         1. SESSION
         2. RSVP_HOP
         3. TIME_VALUES
@@ -127,7 +127,7 @@ components:
       properties:
         objects:
           description: >-
-            "Path" message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
+            "Path" message requires atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
           type: array
           minItems: 6
           items:
@@ -182,7 +182,7 @@ components:
             The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 .
             Curently supported class numbers are for "Path" message type.
             "Path" message:
-            Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored in above options.
+            Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not supported in above options.
       type: object
       required:
         - choice
@@ -388,7 +388,7 @@ components:
             description: >-
               The refresh timeout period R used to generate this message;in milliseconds.
             format: integer
-            default: 0
+            default: 30000
             length: 32
             features: [count]
           x-field-uid: 1

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -551,15 +551,6 @@ components:
             The Length MUST be atleast 4, and MUST be a multiple of 4.
           $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
           x-field-uid: 2
-        reserved:
-          x-field-pattern:
-            description: >-
-              Reserved.
-            format: integer
-            default: 0
-            length: 8
-            features: [count]
-          x-field-uid: 3
         as_number:
           description: >-
             Autonomous System number to be set in the ERO sub-object that this LSP should traverse through.
@@ -568,7 +559,7 @@ components:
           format: uint32
           default: 0
           maximum: 65535
-          x-field-uid: 4
+          x-field-uid: 3
     Flow.RSVPExplicitRoute.Length:
       type: object
       properties:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -7,18 +7,23 @@ components:
       type: object
       properties:
         version:
-          x-field-pattern:
-            description: >-
-              RSVP Protocol Version. 
-            format: integer
-            length: 4
-            default: 1
-            features: [count]
+          description: >-
+              RSVP Protocol Version.
+          type: integer
+          format: uint32
+          default: 1
+          maximum: 15
           x-field-uid: 1
         flag:
           description: >-
               Flag, 0x01-0x08: Reserved.
-          $ref: '#/components/schemas/Flow.RSVP.Flag'
+          type: string
+          default: not_refresh_reduction_capable
+          x-enum:
+            not_refresh_reduction_capable:
+              x-field-uid: 1
+            refresh_reduction_capable:
+              x-field-uid: 2
           x-field-uid: 2
         rsvp_checksum:
           x-field-pattern:
@@ -58,18 +63,6 @@ components:
             Among these presently supported is "Path"(value: 1) message type.
           $ref: '#/components/schemas/Flow.RSVP.Message'
           x-field-uid: 7
-    Flow.RSVP.Flag:
-      type: object
-      properties:
-        choice:
-            type: string
-            default: not_refresh_reduction_capable
-            x-enum:
-              not_refresh_reduction_capable:
-                x-field-uid: 1
-              refresh_reduction_capable:
-                x-field-uid: 2
-            x-field-uid: 1
     Flow.RSVP.Length:
       type: object
       properties:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -912,6 +912,14 @@ components:
           x-field-uid: 15 
     Flow.RSVP.PathObjectsClassRecordRoute:
       description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsRecordRouteCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsRecordRouteCType:
+      description: >-
         Object for RECORD_ROUTE class.
         c-type is Type 1 Route Record (1).
       type: object
@@ -928,8 +936,35 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathRecordRouteType1:
       description: >-
-        Type1 record route has subobjects.
-        Currently supported subobjects are IPv4 address and Label.
+          C-Type of Type 1 Record Route.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1CType'
+          x-field-uid: 1 
+    Flow.RSVP.PathRecordRouteType1CType:
+      description: >-
+        Type1 record route has list of subobjects.
+        Currently supported subobjects are IPv4 address(1) and Label(3).
+      type: object
+      properties:
+        subobjects:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/Flow.RSVP.Type1RecordRouteSubobjects'
+          x-field-uid: 1
+    Flow.RSVP.Type1RecordRouteSubobjects:
+      description: >-
+          Type is specific to a subobject.
+      type: object 
+      properties:
+        type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsRecordRouteSubObjectType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsRecordRouteSubObjectType:
+      description: >- 
+        Currently supported subobjects are IPv4 address(1) and Label(3).
       type: object
       properties:
         choice:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -203,7 +203,6 @@ components:
         lsp_tunnel_ipv4:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionLspTunnelIpv4'
           x-field-uid: 2
-
     Flow.RSVP.PathObjectsSessionLspTunnelIpv4:
       description: >-
         Class = SESSION, LSP_TUNNEL_IPv4 C-Type = 7.
@@ -250,38 +249,752 @@ components:
         Object for RSVP_HOP class.
         Currently supported c-type is IPv4 (1).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: ipv4
+          x-enum:
+            ipv4:
+              x-field-uid: 1
+        ipv4:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRsvpHopIpv4'
+          x-field-uid: 2
+    Flow.RSVP.PathObjectsClassRsvpHopIpv4:
+      description: >-
+        IPv4 RSVP_HOP object: Class = 3, C-Type = 1
+      type: object
+      properties:
+        ipv4_next_previous_hop_address:
+          x-field-pattern:
+            description: >-
+              The IPv4 address of the interface through which the last RSVP-knowledgeable hop forwarded this message.
+            format: ipv4
+            default: 0.0.0.0
+            features: [count]
+          x-field-uid: 1
+        logical_interface_handle:
+          x-field-pattern:
+            description: >-
+              Logical Interface Handle (LIH) is used to distinguish logical outgoing interfaces.
+              A node receiving an LIH in a Path message saves its value and returns it in the HOP objects of subsequent Resv messages sent to the node that originated the LIH.
+              The LIH should be identically zero if there is no logical interface handle.
+            format: integer
+            default: 0
+            length: 32
+            features: [count]
+          x-field-uid: 2
     Flow.RSVP.PathObjectsClassTimeValues:
       description: >-
         Object for TIME_VALUES class.
         Currently supported c-type is Type 1 Time Value (1).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: type_1_time_value
+          x-enum:
+            type_1_time_value:
+              x-field-uid: 1
+        type_1_time_value:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassTimeValuesType1'
+          x-field-uid: 2
+    Flow.RSVP.PathObjectsClassTimeValuesType1:
+      description: >-
+        TIME_VALUES Object: Class = 5, C-Type = 1
+      type: object
+      properties:
+        refresh_period_r:
+          x-field-pattern:
+            description: >-
+              The refresh timeout period R used to generate this message;in milliseconds.
+            format: integer
+            default: 0
+            length: 32
+            features: [count]
+          x-field-uid: 1
     Flow.RSVP.PathObjectsClassExplicitRoute:
       description: >-
         Object for EXPLICIT_ROUTE class.
         Currently supported c-type is Type 1 Explicit Route (1).
       type: object
+      properties:
+        choice:
+          type: string
+          default: type_1_explicit_route
+          x-field-uid: 1
+          x-enum:
+            type_1_explicit_route:
+              x-field-uid: 1
+        type_1_explicit_route:
+          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1'
+          x-field-uid: 2
+    Flow.RSVP.PathExplicitRouteType1:
+      description: >-
+        Type1 Explicit Route has subobjects.
+        Currently supported subobjects are IPv4 prefix and 4-byte AS number.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: ipv4_prefix
+          x-enum:
+            ipv4_prefix:
+              x-field-uid: 1
+            four_byte_as_number:
+              x-field-uid: 2
+        ipv4_prefix:
+          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1Ipv4Prefix'
+          x-field-uid: 2
+        four_byte_as_number:
+          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1FourByteASNumber'
+          x-field-uid: 3
+    Flow.RSVP.PathExplicitRouteType1Ipv4Prefix:
+      description: >-
+        Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1
+        Subobject: IPv4 Prefix, C-Type: 1
+      type: object
+      properties:
+        l_bit:
+          x-field-pattern:
+            description: >-
+              The L bit is an attribute of the subobject.The L bit is set if the subobject represents a loose hop in the explicit route.
+              If the bit is not set, the subobject represents a strict hop in the explicit route.
+            format: integer
+            length: 1
+            default: 0
+            features: [count]
+          x-field-uid: 1
+        type:
+          x-field-pattern:
+            description: >-
+              Subobject type; 0x01  IPv4 address.
+            format: integer
+            length: 8
+            default: 1
+            features: [count]
+          x-field-uid: 2
+        length:
+          x-field-pattern:
+            description: >-
+              The Length contains the total length of the subobject in bytes,including the Type and Length fields.  
+              The Length is always 8.
+            format: integer
+            default: 8
+            length: 7
+            features: [count]
+          x-field-uid: 3
+        ipv4_address:
+          x-field-pattern:
+            description: >-
+              This IPv4 address is treated as a prefix based on the prefix length value below. 
+              Bits beyond the prefix are ignored on receipt and SHOULD be set to zero on transmission.
+            format: ipv4
+            default: 0.0.0.0
+            features: [count]
+          x-field-uid: 4
+        prefix:
+          description: >-
+            The prefix of the IPv4 address.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 32
+          default: 32
+          x-field-uid: 5
+    Flow.RSVP.PathExplicitRouteType1FourByteASNumber:
+      description: >-
+        Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1
+        Subobject: 4-byte AS number, C-Type: 32
+      type: object
+      properties:
+        l_bit:
+          x-field-pattern:
+            description: >-
+              The L bit is an attribute of the subobject.The L bit is set if the subobject represents a loose hop in the explicit route.
+              If the bit is not set, the subobject represents a strict hop in the explicit route.
+            format: integer
+            length: 1
+            default: 0
+            features: [count]
+          x-field-uid: 1
+        type:
+          x-field-pattern:
+            description: >-
+              Subobject type; 0x05  AS Number.
+            format: integer
+            length: 7
+            default: 1
+            features: [count]
+          x-field-uid: 2
+        length:
+          x-field-pattern:
+            description: >-
+              The Length contains the total length of the subobject in bytes,including the Type and Length fields.  
+              The Length is always 8.
+            format: integer
+            default: 8
+            length: 8
+            features: [count]
+          x-field-uid: 3
+        reserved:
+          x-field-pattern:
+            description: >-
+              Reserved.
+            format: integer
+            default: 0
+            length: 8
+            features: [count]
+          x-field-uid: 4
+        as_number:
+          description: >-
+            Autonomous System number to be set in the ERO sub-object that this LSP should traverse through.
+            This field is applicable only if the value of 'type' is set to 'as_number'.
+            Note that as per RFC3209, 4-byte AS encoding is not supported.
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 65535
+          x-field-uid: 5
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: >-
         Object for LABEL_REQUEST class.
         Currently supported c-type is Without Label Range (1).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: without_label_range
+          x-enum:
+            without_label_range:
+              x-field-uid: 1
+        without_label_range:
+          $ref: '#/components/schemas/Flow.RSVP.PathLabelRequestWithoutLabelRange'
+          x-field-uid: 2
+    Flow.RSVP.PathLabelRequestWithoutLabelRange:
+      description: >-
+        Class = LABEL_REQUEST, Without Label Range C-Type = 1
+      type: object
+      properties:
+        reserved:
+          x-field-pattern:
+            description: >-
+              This field is reserved.  
+              It MUST be set to zero on transmission and MUST be ignored on receipt.              
+            format: integer
+            default: 0
+            length: 16
+            features: [count]
+          x-field-uid: 1
+        l3pid:
+          x-field-pattern:
+            description: >-
+              An identifier of the layer 3 protocol using this path. 
+              Standard Ethertype values are used.             
+            format: integer
+            default: 0
+            length: 16
+            features: [count]
+          x-field-uid: 2
     Flow.RSVP.PathObjectsClassSessionAttribute:
       description: >-
         Object for SESSION_ATTRIBUTE class.
         Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: lsp_tunnel
+          x-enum:
+            lsp_tunnel:
+              x-field-uid: 1
+            lsp_tunnel_ra:
+              x-field-uid: 2
+        lsp_tunnel:
+          $ref: '#/components/schemas/Flow.RSVP.PathSessionAttributeLspTunnel'
+          x-field-uid: 2
+        lsp_tunnel_ra:
+          $ref: '#/components/schemas/Flow.RSVP.PathSessionAttributeLspTunnelRa'
+          x-field-uid: 3
+    Flow.RSVP.PathSessionAttributeLspTunnel:
+      description: >-
+        SESSION_ATTRIBUTE class = 207, LSP_TUNNEL_RA C-Type = 7, resource affinity information.
+      type: object
+      properties:
+        setup_priority:
+          description: >-
+            The priority of the session with respect to taking resources,in the range of 0 to 7. The value 0 is the highest priority.
+            The Setup Priority is used in deciding whether this session can preempt another session.
+          type: integer
+          format: uint32
+          default: 7
+          maximum: 7
+          x-field-uid: 1
+        holding_priority:
+          description: >-
+            The priority of the session with respect to holding resources,in the range of 0 to 7. The value 0 is the highest priority.
+            The Setup Priority is used in deciding whether this session can preempt another session.
+          type: integer
+          format: uint32
+          default: 7
+          maximum: 7
+          x-field-uid: 2
+        flags:
+          x-field-pattern:
+            x-constants:
+              local_protection_desired: 1
+              label_recording_desired: 2
+              se_style_desired: 3
+            description: >-
+              0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+            format: integer
+            length: 8
+            default: 1
+          x-field-uid: 3
+        name_length:
+          description: >-
+            The length of the display string before padding, in bytes.          
+          type: string
+          format : hex
+          default: '0'
+          maxLength: 2
+          x-field-uid: 4
+        session_name:
+          description: >-
+            A null padded string of characters.          
+          type: string
+          minLength: 0
+          maxLength: 254
+          x-field-uid: 5
+    Flow.RSVP.PathSessionAttributeLspTunnelRa:
+      description: >-
+        SESSION_ATTRIBUTE class = 207, LSP_TUNNEL_RA C-Type = 1, it carries resource affinity information.
+      type: object
+      properties:
+        exclude_any:
+          description: >-
+            A 32-bit vector representing a set of attribute filters associated with a tunnel any of which renders a link
+            unacceptable. A null set (all bits set to zero) doesn't render the link unacceptable.
+            The most significant byte in the hex-string is the farthest  to the left in the byte sequence. 
+            Leading zero bytes in the configured value may be omitted for brevity.           
+          type: string
+          format : hex
+          default: '0'
+          minLength: 0
+          maxLength: 8
+          x-field-uid: 1
+        include_any:
+          description: >-
+            A 32-bit vector representing a set of attribute filters associated with a tunnel any of which renders a link
+            acceptable. A null set (all bits set to zero) automatically passes.
+            The most significant byte in the hex-string is the farthest  to the left in the byte sequence. 
+            Leading zero bytes in the configured value may be omitted for brevity.     
+          type: string
+          format : hex
+          default: '0'
+          minLength: 0
+          maxLength: 8  
+          x-field-uid: 2
+        include_all:
+          description: >-
+            A 32-bit vector representing a set of attribute filters associated with a tunnel all of which must be present for a
+            link to be acceptable. A null set (all bits set to zero) automatically passes.
+            The most significant byte in the hex-string is the farthest  to the left in the byte sequence. 
+            Leading zero bytes in the configured value may be omitted for brevity.          
+          type: string
+          format : hex
+          default: '0'
+          minLength: 0
+          maxLength: 8
+          x-field-uid: 3
+        setup_priority:
+          description: >-
+            The priority of the session with respect to taking resources,in the range of 0 to 7. The value 0 is the highest priority.
+            The Setup Priority is used in deciding whether this session can preempt another session.
+          type: integer
+          format: uint32
+          default: 7
+          maximum: 7
+          x-field-uid: 4
+        holding_priority:
+          description: >-
+            The priority of the session with respect to holding resources,in the range of 0 to 7. The value 0 is the highest priority.
+            The Setup Priority is used in deciding whether this session can preempt another session.
+          type: integer
+          format: uint32
+          default: 7
+          maximum: 7
+          x-field-uid: 5
+        flags:
+          x-field-pattern:
+            x-constants:
+              local_protection_desired: 1
+              label_recording_desired: 2
+              se_style_desired: 4
+            description: >-
+              0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+            format: integer
+            length: 8
+            default: 1
+          x-field-uid: 6
+        name_length:
+          description: >-
+            The length of the display string before padding, in bytes.          
+          type: string
+          format : hex
+          default: '0'
+          maxLength: 2
+          x-field-uid: 7
+        session_name:
+          description: >-
+            A null padded string of characters.          
+          type: string
+          minLength: 0
+          maxLength: 254
+          x-field-uid: 8
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: >-
         Object for SENDER_TEMPLATE class.
         Currently supported c-type is LSP Tunnel IPv4 (7).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: lsp_tunnel_ipv4
+          x-enum:
+            lsp_tunnel_ipv4:
+              x-field-uid: 1
+        lsp_tunnel_ipv4:
+          $ref: '#/components/schemas/Flow.RSVP.PathSenderTemplateLspTunnelIpv4'
+          x-field-uid: 2
+    Flow.RSVP.PathSenderTemplateLspTunnelIpv4:
+      description: >-
+        Class = SENDER_TEMPLATE, LSP_TUNNEL_IPv4 C-Type = 7
+      type: object
+      properties:
+        ipv4_tunnel_sender_address:
+          x-field-pattern:
+            description: >-
+              IPv4 address for a sender node.
+            format: ipv4
+            default: 0.0.0.0
+            features: [count]
+          x-field-uid: 1
+        reserved:
+          x-field-pattern:
+            description: >-
+              Reserved field, MUST be zero.
+            format: integer
+            default: 0
+            length: 16
+            features: [count]
+          x-field-uid: 2
+        lsp_id:
+          x-field-pattern:
+            description: >-
+              A 16-bit identifier used in the SENDER_TEMPLATE that can be changed to allow a sender to share resources with itself.
+            format: integer
+            default: 0
+            length: 16
+            features: [count]
+          x-field-uid: 3
     Flow.RSVP.PathObjectsClassSenderTspec:
       description: >-
         Object for SENDER_TSPEC class.
         Currently supported c-type is int-serv (2).
       type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: int_serv
+          x-enum:
+            int_serv:
+              x-field-uid: 1
+        int_serv:
+          $ref: '#/components/schemas/Flow.RSVP.PathSenderTspecIntServ'
+          x-field-uid: 2
+    Flow.RSVP.PathSenderTspecIntServ:
+      description: >-
+        int-serv SENDER_TSPEC object: Class = 12, C-Type = 2
+      type: object
+      properties:
+        version:
+          x-field-pattern:
+            description: >-
+              Message format version number.
+            format: integer
+            length: 4
+            default: 0
+            features: [count]
+          x-field-uid: 1
+        reserved1:
+          x-field-pattern:
+            description: >-
+              Reserved.
+            format: integer
+            length: 12
+            default: 0
+            features: [count]
+          x-field-uid: 2
+        overall_length:
+          x-field-pattern:
+            description: >-
+              Overall length (7 words not including header).
+            format: integer
+            length: 16
+            default: 7
+            features: [count]
+          x-field-uid: 3
+        service_header:
+          x-field-pattern:
+            description: >-
+              Service header, service number - '1' (Generic information) if in a PATH message.
+            format: integer
+            length: 8
+            default: 1
+            features: [count]
+          x-field-uid: 4
+        zero_bit:
+          x-field-pattern:
+            description: >-
+              MUST be 0.
+            format: integer
+            length: 1
+            default: 0
+            features: [count]
+          x-field-uid: 5
+        reserved2:
+          x-field-pattern:
+            description: >-
+              Reserved.
+            format: integer
+            length: 7
+            default: 0
+            features: [count]
+          x-field-uid: 6
+        length_of_service_data:
+          x-field-pattern:
+            description: >-
+              Length of service data, 6 words not including per-service header.
+            format: integer
+            length: 16
+            default: 6
+            features: [count]
+          x-field-uid: 7
+        parameter_id_token_bucket_tspec:
+          x-field-pattern:
+            description: >-
+              Parameter ID, parameter 127 (Token Bucket TSpec)
+            format: integer
+            length: 8
+            default: 127
+            features: [count]
+          x-field-uid: 8
+        parameter_127_flag:
+          x-field-pattern:
+            description: >-
+              Parameter 127 flags (none set)
+            format: integer
+            length: 8
+            default: 0
+            features: [count]
+          x-field-uid: 9
+        parameter_127_length:
+          x-field-pattern:
+            description: >-
+              Parameter 127 length, 5 words not including per-service header
+            format: integer
+            length: 16
+            default: 0
+            features: [count]
+          x-field-uid: 10
+        token_bucket_rate:
+          description: >-
+            Token bucket rate is set to sender's view of its generated traffic.
+          type: number
+          format: float
+          default: 0
+          x-field-uid: 11
+        token_bucket_size:
+          description: >-
+            Token bucket size is set to sender's view of its generated traffic.
+          type: number
+          format: float
+          default: 0
+          x-field-uid: 12
+        peak_data_rate:
+          description: >-
+            The peak rate may be set to the sender's peak traffic generation rate (if known and controlled), the physical interface line rate (if known), or positive infinity (if no better value is available).
+          type: number
+          format: float
+          default: 0
+          x-field-uid: 13
+        minimum_policed_unit:
+          x-field-pattern:
+            description: >-
+              The minimum policed unit parameter should generally be set equal to the size of the smallest packet generated by the application.
+            format: integer
+            length: 32
+            default: 0
+            features: [count]
+          x-field-uid: 14
+        maximum_packet_size:
+          x-field-pattern:
+            description: >-
+              The maximum packet size parameter should be set to the size of the largest packet the application might wish to generate.
+              This value must, by definition, be equal to or larger than the value of The minimum policed unit.
+            format: integer
+            length: 32
+            default: 0
+            features: [count]
+          x-field-uid: 15 
     Flow.RSVP.PathObjectsClassRecordRoute:
       description: >-
         Object for RECORD_ROUTE class.
-        Currently supported c-type is Type 1 Route Record (1)
+        c-type is Type 1 Route Record (1).
       type: object
+      properties:
+        choice:
+          type: string
+          default: type_1_route_record
+          x-field-uid: 1
+          x-enum:
+            type_1_route_record:
+              x-field-uid: 1
+        type_1_route_record:
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1'
+          x-field-uid: 2
+    Flow.RSVP.PathRecordRouteType1:
+      description: >-
+        Type1 record route has subobjects.
+        Currently supported subobjects are IPv4 address and Label.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: ipv4_address
+          x-enum:
+            ipv4_address:
+              x-field-uid: 1
+            label:
+              x-field-uid: 2
+        ipv4_address:
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1Ipv4Address'
+          x-field-uid: 2
+        label:
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1Label'
+          x-field-uid: 3
+    Flow.RSVP.PathRecordRouteType1Ipv4Address:
+      description: >-
+        Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1
+        Subobject: IPv4 Address, C-Type: 1
+      type: object
+      properties:
+        type:
+          x-field-pattern:
+            x-constants:
+              ipv4_address: 1
+            description: >-
+              0x01  IPv4 address
+            format: integer
+            length: 8
+            default: 1
+            features: [count]
+          x-field-uid: 1
+        length:
+          x-field-pattern:
+            description: >-
+              The Length contains the total length of the subobject in bytes, including the Type and Length fields.  The Length is always 8.
+            format: integer
+            length: 8
+            default: 8
+            features: [count]
+          x-field-uid: 2
+        ipv4_address:
+          x-field-pattern:
+            description: >-
+              A 32-bit unicast, host address.  Any network-reachable interface address is allowed here.
+              Illegal addresses, such as certain loopback addresses, SHOULD NOT be used.
+            format: ipv4
+            default: 0.0.0.0
+            features: [count]
+          x-field-uid: 3
+        prefix_length:
+          x-field-pattern:
+            description: >-
+              Prefix-length of ipv4 address.
+            format: integer
+            length: 8
+            default: 32
+            features: [count]
+          x-field-uid: 4
+        flags:
+          x-field-pattern:
+            x-constants:
+              local_protection_available: 1
+              local_protection_in_use: 2
+            description: >-
+              0x01  local_protection_available, 0x02  local_protection_in_use
+            format: integer
+            length: 8
+            default: 1
+          x-field-uid: 5
+    Flow.RSVP.PathRecordRouteType1Label:
+      description: >-
+        Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1
+        Subobject: Label, C-Type: 3
+      type: object
+      properties:
+        type:
+          x-field-pattern:
+            x-constants:
+              label: 3
+            description: >-
+              0x03  Label
+            format: integer
+            length: 8
+            default: 3
+            features: [count]
+          x-field-uid: 1
+        length:
+          x-field-pattern:
+            description: >-
+              The Length contains the total length of the subobject in bytes, including the Type and Length fields.  
+            format: integer
+            length: 8
+            default: 8
+            features: [count]
+          x-field-uid: 2
+        flags:
+          x-field-pattern:
+            x-constants:
+              local_protection_available: 1
+              local_protection_in_use: 2
+            description: >-
+              0x01 = Global label. This flag indicates that the label will be understood if received on any interface.
+            format: integer
+            length: 8
+            default: 1
+          x-field-uid: 3 
+        c_type:
+          x-field-pattern:
+            description: >-
+              The C-Type of the included Label Object. Copied from the Label object.
+            format: integer
+            length: 8
+            default: 0
+          x-field-uid: 4
+        contents_of_label_obejct:
+          description: >-
+            The contents of the Label Object. Copied from the Label Object.
+          type: string
+          format: hex
+          default: "00"
+          x-field-uid: 5

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -484,6 +484,14 @@ components:
           x-field-uid: 5
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsLabelRequestCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsLabelRequestCType:
+      description: >-
         Object for LABEL_REQUEST class.
         Currently supported c-type is Without Label Range (1).
       type: object
@@ -524,6 +532,14 @@ components:
             features: [count]
           x-field-uid: 2
     Flow.RSVP.PathObjectsClassSessionAttribute:
+      description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionAttributeCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsSessionAttributeCType:
       description: >-
         Object for SESSION_ATTRIBUTE class.
         Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
@@ -682,6 +698,14 @@ components:
           x-field-uid: 8
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSenderTemplateCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsSenderTemplateCType:
+      description: >-
         Object for SENDER_TEMPLATE class.
         Currently supported c-type is LSP Tunnel IPv4 (7).
       type: object
@@ -728,6 +752,14 @@ components:
             features: [count]
           x-field-uid: 3
     Flow.RSVP.PathObjectsClassSenderTspec:
+      description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSenderTspecCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsSenderTspecCType:
       description: >-
         Object for SENDER_TSPEC class.
         Currently supported c-type is int-serv (2).

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -452,7 +452,7 @@ components:
     Flow.RSVP.PathExplicitRouteType1:
       description: >-
         Type1 Explicit Route has subobjects.
-        Currently supported subobjects are IPv4 prefix and 4-byte AS number.
+        Currently supported subobjects are IPv4 prefix and Autonomous system number.
       type: object
       properties:
         subobjects:
@@ -471,7 +471,7 @@ components:
           x-field-uid: 1 
     Flow.RSVP.Type1ExplicitRouteSubobjectsType:
       description: >- 
-        Currently supported subobjects are IPv4 address(1) and 4-byte AS number(5).
+        Currently supported subobjects are IPv4 address(1) and Autonomous system number(32).
       type: object
       properties:
         choice:
@@ -487,7 +487,7 @@ components:
           $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1Ipv4Prefix'
           x-field-uid: 2
         four_byte_as_number:
-          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1FourByteASNumber'
+          $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1ASNumber'
           x-field-uid: 3
     Flow.RSVP.PathExplicitRouteType1Ipv4Prefix:
       description: >-
@@ -529,10 +529,10 @@ components:
           maximum: 32
           default: 32
           x-field-uid: 4
-    Flow.RSVP.PathExplicitRouteType1FourByteASNumber:
+    Flow.RSVP.PathExplicitRouteType1ASNumber:
       description: >-
         Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1
-        Subobject: 4-byte AS number, C-Type: 32
+        Subobject: Autonomous system number, C-Type: 32
       type: object
       properties:
         l_bit:
@@ -564,7 +564,6 @@ components:
           description: >-
             Autonomous System number to be set in the ERO sub-object that this LSP should traverse through.
             This field is applicable only if the value of 'type' is set to 'as_number'.
-            Note that as per RFC3209, 4-byte AS encoding is not supported.
           type: integer
           format: uint32
           default: 0

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -1215,7 +1215,7 @@ components:
               The C-Type of the included Label Object. Copied from the Label object.
             format: integer
             length: 8
-            default: 0
+            default: 1
           x-field-uid: 3
         label:
           description: >-

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -481,12 +481,12 @@ components:
           x-enum:
             ipv4_prefix:
               x-field-uid: 1
-            four_byte_as_number:
+            as_number:
               x-field-uid: 2
         ipv4_prefix:
           $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1Ipv4Prefix'
           x-field-uid: 2
-        four_byte_as_number:
+        as_number:
           $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1ASNumber'
           x-field-uid: 3
     Flow.RSVP.PathExplicitRouteType1Ipv4Prefix:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -131,16 +131,10 @@ components:
         Every RSVP object encapsulated in an RSVP message consists of a 32-bit word header and the object's contents.
       type: object
       properties:
-        length:
-          description: >-
-            A 16-bit field containing the total object length in bytes. 
-            Must always be a multiple of 4 or at least 4.
-          $ref: '#/components/schemas/Flow.RSVPPathObject.Length'
-          x-field-uid: 1
         class_num:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClass'
-          x-field-uid: 2
-    Flow.RSVPPathObject.Length:
+          x-field-uid: 1
+    Flow.RSVPObject.Length:
       type: object
       properties:
         choice:
@@ -239,9 +233,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsSessionCType:
       description: >-
           The body of an object corresponding to the class number and c-type.
@@ -304,9 +304,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsRsvpHopCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsRsvpHopCType: 
       description: >-
         Object for RSVP_HOP class.
@@ -352,9 +358,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsTimeValuesCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsTimeValuesCType:
       description: >-
         Object for TIME_VALUES class.
@@ -390,9 +402,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassExplicitRouteCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsClassExplicitRouteCType:
       description: >-
         Object for EXPLICIT_ROUTE class and c-type is Type 1 Explicit Route (1).
@@ -562,9 +580,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsLabelRequestCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsLabelRequestCType:
       description: >-
         Object for LABEL_REQUEST class.
@@ -611,9 +635,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionAttributeCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsSessionAttributeCType:
       description: >-
         Object for SESSION_ATTRIBUTE class.
@@ -776,9 +806,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSenderTemplateCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsSenderTemplateCType:
       description: >-
         Object for SENDER_TEMPLATE class.
@@ -831,9 +867,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsSenderTspecCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsSenderTspecCType:
       description: >-
         Object for SENDER_TSPEC class.
@@ -990,9 +1032,15 @@ components:
           C-Type is specific to a class num.
       type: object 
       properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
+          x-field-uid: 1
         c_type: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsRecordRouteCType'
-          x-field-uid: 1 
+          x-field-uid: 2 
     Flow.RSVP.PathObjectsRecordRouteCType:
       description: >-
         Object for RECORD_ROUTE class.
@@ -1174,7 +1222,7 @@ components:
             features: [count]
           x-field-uid: 1
         length:
-          $ref: '#/components/schemas/Flow.RSVP.ObjectOptionsCustom.Length'
+          $ref: '#/components/schemas/Flow.RSVPObject.Length'
           x-field-uid: 2
         bytes:
           description: >-
@@ -1184,32 +1232,4 @@ components:
             This packet header can be used in multiple places in the packet.
           type: string
           pattern: '^[A-Fa-f0-9: ]+$'
-          x-field-uid: 3
-    Flow.RSVP.ObjectOptionsCustom.Length:
-      description: >-
-        Length for custom options.
-      type: object
-      properties:
-        choice:
-          description: auto or configured value.
-          type: string
-          default: auto
-          x-field-uid: 1
-          x-enum:
-            auto:
-              x-field-uid: 1
-            value:
-              x-field-uid: 2
-        auto:
-          description: >-
-            OTG will provide a system generated value for this property. 
-            If OTG is unable to generate a value the default value must be used.
-          type: integer
-          format: uint32
-          default: 4
-          x-field-uid: 2
-        value:
-          type: integer
-          format: uint32
-          default: 4
           x-field-uid: 3

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -133,7 +133,7 @@ components:
             The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 .
             Curently supported class numbers are for "path" message type.
             "path" message:
-            Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21.
+            Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored in above options.
       type: object
       required:
         - choice
@@ -160,6 +160,8 @@ components:
               x-field-uid: 8
             record_route: 
               x-field-uid: 9
+            custom:
+              x-field-uid: 10
         session:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSession'
           x-field-uid: 2
@@ -187,6 +189,9 @@ components:
         record_route: 
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRecordRoute'
           x-field-uid: 10
+        custom:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsCustom'
+          x-field-uid: 11
     Flow.RSVP.PathObjectsClassSession:
       description: >-
           C-Type is specific to a class num.
@@ -418,15 +423,6 @@ components:
             default: 0
             features: [count]
           x-field-uid: 1
-        type:
-          x-field-pattern:
-            description: >-
-              Subobject type; 0x01  IPv4 address.
-            format: integer
-            length: 8
-            default: 1
-            features: [count]
-          x-field-uid: 2
         length:
           x-field-pattern:
             description: >-
@@ -471,15 +467,6 @@ components:
             default: 0
             features: [count]
           x-field-uid: 1
-        type:
-          x-field-pattern:
-            description: >-
-              Subobject type; 0x05  AS Number.
-            format: integer
-            length: 7
-            default: 1
-            features: [count]
-          x-field-uid: 2
         length:
           x-field-pattern:
             description: >-
@@ -1007,17 +994,6 @@ components:
         Subobject: IPv4 Address, C-Type: 1
       type: object
       properties:
-        type:
-          x-field-pattern:
-            x-constants:
-              ipv4_address: 1
-            description: >-
-              0x01  IPv4 address
-            format: integer
-            length: 8
-            default: 1
-            features: [count]
-          x-field-uid: 1
         length:
           x-field-pattern:
             description: >-
@@ -1062,17 +1038,6 @@ components:
         Subobject: Label, C-Type: 3
       type: object
       properties:
-        type:
-          x-field-pattern:
-            x-constants:
-              label: 3
-            description: >-
-              0x03  Label
-            format: integer
-            length: 8
-            default: 3
-            features: [count]
-          x-field-uid: 1
         length:
           x-field-pattern:
             description: >-
@@ -1108,3 +1073,57 @@ components:
           format: hex
           default: "00"
           x-field-uid: 5
+    Flow.RSVP.PathObjectsCustom:
+      type: object
+      description: Custom packet header
+      required: [bytes]
+      properties:
+        type:
+          x-field-pattern:
+            description: >-
+              User defined object type.
+            format: integer
+            length: 8
+            default: 0
+            features: [count]
+          x-field-uid: 1
+        length:
+          $ref: '#/components/schemas/Flow.RSVP.ObjectOptionsCustom.Length'
+          x-field-uid: 2
+        bytes:
+          description: >-
+            A custom packet header defined as a string of hex bytes.
+            The string MUST contain sequence of valid hex bytes.
+            Spaces or colons can be part of the bytes but will be discarded.
+            This packet header can be used in multiple places in the packet.
+          type: string
+          pattern: '^[A-Fa-f0-9: ]+$'
+          x-field-uid: 3
+    Flow.RSVP.ObjectOptionsCustom.Length:
+      description: >-
+        Length for custom options.
+      type: object
+      properties:
+        choice:
+          description: auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+        auto:
+          description: >-
+            The OTG implementation can provide a system generated value for this property.
+            If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          default: 4
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          default: 4
+          x-field-uid: 3

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -89,23 +89,16 @@ components:
             If the OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
+          maximum: 65535
           default: 0
           x-field-uid: 2
         value:
           type: integer
           format: uint32
+          maximum: 65535
           default: 0
           x-field-uid: 3     
     Flow.RSVP.Message:
-      description: >-
-          RSVP Message type.
-          Currently only "path" message type is supported.
-      type: object 
-      properties:
-        message_type: 
-          $ref: '#/components/schemas/Flow.RSVP.MessageType'
-          x-field-uid: 1 
-    Flow.RSVP.MessageType:
       type: object
       properties:
         choice:
@@ -124,7 +117,7 @@ components:
         1. SESSION
         2. RSVP_HOP
         3. TIME_VALUES
-        4. EXPLICIT ROUTE [optional]
+        4. EXPLICIT_ROUTE [optional]
         5. LABEL_REQUEST
         6. SESSION_ATTRIBUTE [optional]
         7. SENDER_TEMPLATE
@@ -134,9 +127,9 @@ components:
       properties:
         objects:
           description: >-
-            "path" message required atleast SESSION, RSVP_HOP and TIME_VALUES objects.
+            "path" message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
           type: array
-          minItems: 3
+          minItems: 6
           items:
             $ref: '#/components/schemas/Flow.RSVP.PathObjects'
           x-field-uid: 1
@@ -146,18 +139,44 @@ components:
       type: object
       properties:
         length:
-          x-field-pattern:
-            description: >-
-              Contains the total length of the object including the object's header, measured in bytes. 
-              Objects must be aligned to 32-bit words. 
-            format: integer
-            length: 16
-            default: 4
-            features: [count]
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4, and at least 4.
+          $ref: '#/components/schemas/Flow.RSVPPathObject.Length'
           x-field-uid: 1
         class_num:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClass'
           x-field-uid: 2
+    Flow.RSVPPathObject.Length:
+      type: object
+      properties:
+        choice:
+          description: auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+        auto:
+          description: >-
+            The OTG implementation can provide a system generated value for this property.
+            If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          minimum: 4
+          maximum: 65535
+          default: 4
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          minimum: 4
+          maximum: 65535
+          default: 4
+          x-field-uid: 3 
     Flow.RSVP.PathObjectsClass:
       description: >-
             The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 .
@@ -244,9 +263,9 @@ components:
             lsp_tunnel_ipv4:
               x-field-uid: 1
         lsp_tunnel_ipv4:
-          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionLspTunnelIpv4'
+          $ref: '#/components/schemas/Flow.RSVP.PathSessionLspTunnelIpv4'
           x-field-uid: 2
-    Flow.RSVP.PathObjectsSessionLspTunnelIpv4:
+    Flow.RSVP.PathSessionLspTunnelIpv4:
       description: >-
         Class = SESSION, LSP_TUNNEL_IPv4 C-Type = 7.
       type: object
@@ -309,9 +328,9 @@ components:
             ipv4:
               x-field-uid: 1
         ipv4:
-          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRsvpHopIpv4'
+          $ref: '#/components/schemas/Flow.RSVP.PathRsvpHopIpv4'
           x-field-uid: 2
-    Flow.RSVP.PathObjectsClassRsvpHopIpv4:
+    Flow.RSVP.PathRsvpHopIpv4:
       description: >-
         IPv4 RSVP_HOP object: Class = 3, C-Type = 1
       type: object
@@ -357,9 +376,9 @@ components:
             type_1_time_value:
               x-field-uid: 1
         type_1_time_value:
-          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassTimeValuesType1'
+          $ref: '#/components/schemas/Flow.RSVP.PathTimeValuesType1'
           x-field-uid: 2
-    Flow.RSVP.PathObjectsClassTimeValuesType1:
+    Flow.RSVP.PathTimeValuesType1:
       description: >-
         TIME_VALUES Object: Class = 5, C-Type = 1
       type: object
@@ -383,8 +402,7 @@ components:
           x-field-uid: 1 
     Flow.RSVP.PathObjectsClassExplicitRouteCType:
       description: >-
-        Object for EXPLICIT_ROUTE class.
-        Currently supported c-type is Type 1 Explicit Route (1).
+        Object for EXPLICIT_ROUTE class and c-type is Type 1 Explicit Route (1).
       type: object
       properties:
         choice:
@@ -454,15 +472,11 @@ components:
             features: [count]
           x-field-uid: 1
         length:
-          x-field-pattern:
-            description: >-
-              The Length contains the total length of the subobject in bytes,including the Type and Length fields.  
-              The Length is always 8.
-            format: integer
-            default: 8
-            length: 7
-            features: [count]
-          x-field-uid: 3
+          description: >-
+            The Length contains the total length of the subobject in bytes,including L ,Type and Length fields.  
+            The Length MUST be atleast 4, and MUST be a multiple of 4.
+          $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
+          x-field-uid: 2
         ipv4_address:
           x-field-pattern:
             description: >-
@@ -471,7 +485,7 @@ components:
             format: ipv4
             default: 0.0.0.0
             features: [count]
-          x-field-uid: 4
+          x-field-uid: 3
         prefix:
           description: >-
             The prefix of the IPv4 address.
@@ -480,7 +494,7 @@ components:
           minimum: 1
           maximum: 32
           default: 32
-          x-field-uid: 5
+          x-field-uid: 4
     Flow.RSVP.PathExplicitRouteType1FourByteASNumber:
       description: >-
         Class = EXPLICIT_ROUTE, Type1 ROUTE_RECORD C-Type = 1
@@ -498,15 +512,11 @@ components:
             features: [count]
           x-field-uid: 1
         length:
-          x-field-pattern:
-            description: >-
-              The Length contains the total length of the subobject in bytes,including the Type and Length fields.  
-              The Length is always 8.
-            format: integer
-            default: 8
-            length: 8
-            features: [count]
-          x-field-uid: 3
+          description: >-
+            The Length contains the total length of the subobject in bytes,including L ,Type and Length fields.  
+            The Length MUST be atleast 4, and MUST be a multiple of 4.
+          $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
+          x-field-uid: 2
         reserved:
           x-field-pattern:
             description: >-
@@ -515,7 +525,7 @@ components:
             default: 0
             length: 8
             features: [count]
-          x-field-uid: 4
+          x-field-uid: 3
         as_number:
           description: >-
             Autonomous System number to be set in the ERO sub-object that this LSP should traverse through.
@@ -525,7 +535,35 @@ components:
           format: uint32
           default: 0
           maximum: 65535
-          x-field-uid: 5
+          x-field-uid: 4
+    Flow.RSVPExplicitRoute.Length:
+      type: object
+      properties:
+        choice:
+          description: auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+        auto:
+          description: >-
+            The OTG implementation can provide a system generated value for this property.
+            If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 8
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 8
+          x-field-uid: 3 
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: >-
           C-Type is specific to a class num.
@@ -628,16 +666,9 @@ components:
           maximum: 7
           x-field-uid: 2
         flags:
-          x-field-pattern:
-            x-constants:
-              local_protection_desired: 1
-              label_recording_desired: 2
-              se_style_desired: 3
-            description: >-
+          description: >-
               0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
-            format: integer
-            length: 8
-            default: 1
+          $ref: '#/components/schemas/Flow.RSVPLspTunnel.Flag'
           x-field-uid: 3
         name_length:
           description: >-
@@ -714,16 +745,9 @@ components:
           maximum: 7
           x-field-uid: 5
         flags:
-          x-field-pattern:
-            x-constants:
-              local_protection_desired: 1
-              label_recording_desired: 2
-              se_style_desired: 4
-            description: >-
+          description: >-
               0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
-            format: integer
-            length: 8
-            default: 1
+          $ref: '#/components/schemas/Flow.RSVPLspTunnel.Flag'
           x-field-uid: 6
         name_length:
           description: >-
@@ -740,6 +764,20 @@ components:
           minLength: 0
           maxLength: 254
           x-field-uid: 8
+    Flow.RSVPLspTunnel.Flag:
+      type: object
+      properties:
+        choice:
+            type: string
+            default: local_protection_desired
+            x-enum:
+              local_protection_desired:
+                x-field-uid: 1
+              label_recording_desired:
+                x-field-uid: 2
+              se_style_desired:
+                x-field-uid: 3
+            x-field-uid: 1
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: >-
           C-Type is specific to a class num.
@@ -1025,14 +1063,11 @@ components:
       type: object
       properties:
         length:
-          x-field-pattern:
-            description: >-
-              The Length contains the total length of the subobject in bytes, including the Type and Length fields.  The Length is always 8.
-            format: integer
-            length: 8
-            default: 8
-            features: [count]
-          x-field-uid: 2
+          description: >-
+              The Length contains the total length of the subobject in bytes, including the Type and Length fields.  
+              The Length MUST be atleast 4, and MUST be a multiple of 4.
+          $ref: '#/components/schemas/Flow.RSVPRouteRecord.Length'
+          x-field-uid: 1
         ipv4_address:
           x-field-pattern:
             description: >-
@@ -1041,7 +1076,7 @@ components:
             format: ipv4
             default: 0.0.0.0
             features: [count]
-          x-field-uid: 3
+          x-field-uid: 2
         prefix_length:
           x-field-pattern:
             description: >-
@@ -1050,18 +1085,24 @@ components:
             length: 8
             default: 32
             features: [count]
-          x-field-uid: 4
+          x-field-uid: 3
         flags:
-          x-field-pattern:
-            x-constants:
-              local_protection_available: 1
-              local_protection_in_use: 2
-            description: >-
+          description: >-
               0x01  local_protection_available, 0x02  local_protection_in_use
-            format: integer
-            length: 8
-            default: 1
-          x-field-uid: 5
+          $ref: '#/components/schemas/Flow.RSVPRecordRouteIPv4.Flag'
+          x-field-uid: 4
+    Flow.RSVPRecordRouteIPv4.Flag:
+      type: object
+      properties:
+        choice:
+            type: string
+            default: local_protection_available
+            x-enum:
+              local_protection_available:
+                x-field-uid: 1
+              local_protection_in_use:
+                x-field-uid: 2
+            x-field-uid: 1   
     Flow.RSVP.PathRecordRouteType1Label:
       description: >-
         Class = RECORD_ROUTE, Type1 ROUTE_RECORD C-Type = 1
@@ -1069,25 +1110,19 @@ components:
       type: object
       properties:
         length:
-          x-field-pattern:
-            description: >-
+          description: >-
               The Length contains the total length of the subobject in bytes, including the Type and Length fields.  
-            format: integer
-            length: 8
-            default: 8
-            features: [count]
-          x-field-uid: 2
+              The Length MUST be atleast 4, and MUST be a multiple of 4.
+          $ref: '#/components/schemas/Flow.RSVPRouteRecord.Length'
+          x-field-uid: 1
         flags:
           x-field-pattern:
-            x-constants:
-              local_protection_available: 1
-              local_protection_in_use: 2
             description: >-
               0x01 = Global label. This flag indicates that the label will be understood if received on any interface.
             format: integer
             length: 8
             default: 1
-          x-field-uid: 3 
+          x-field-uid: 2 
         c_type:
           x-field-pattern:
             description: >-
@@ -1095,14 +1130,42 @@ components:
             format: integer
             length: 8
             default: 0
-          x-field-uid: 4
+          x-field-uid: 3
         contents_of_label_obejct:
           description: >-
             The contents of the Label Object. Copied from the Label Object.
           type: string
           format: hex
           default: "00"
-          x-field-uid: 5
+          x-field-uid: 4
+    Flow.RSVPRouteRecord.Length:
+      type: object
+      properties:
+        choice:
+          description: auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+        auto:
+          description: >-
+            The OTG implementation can provide a system generated value for this property.
+            If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 8
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 8
+          x-field-uid: 3 
     Flow.RSVP.PathObjectsCustom:
       type: object
       description: Custom packet header

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -191,35 +191,95 @@ components:
       description: >-
         Object for SESSION class.
       type: object 
+      properties:
+        c_type:
+          description: >-
+            Currently supported c-type is LSP Tunnel IPv4 (7).
+          type: string
+          default: lsp_tunnel_ipv4
+          x-enum:
+            lsp_tunnel_ipv4:
+              $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionLspTunnelIpv4'
+              x-field-uid: 1
+          x-field-uid: 1
+    Flow.RSVP.PathObjectsSessionLspTunnelIpv4:
+      description: >-
+        Class = SESSION, LSP_TUNNEL_IPv4 C-Type = 7.
+      type: object
+      properties:
+        ipv4_tunnel_end_point_address:
+          x-field-pattern:
+            description: >-
+              IPv4 address of the egress node for the tunnel.
+            format: ipv4
+            default: 0.0.0.0
+            features: [count]
+          x-field-uid: 1
+        reserved:
+          x-field-pattern:
+            description: >-
+              Reserved field, MUST be zero.
+            format: integer
+            default: 0
+            length: 16
+            features: [count]
+          x-field-uid: 2
+        tunnel_id:
+          x-field-pattern:
+            description: >-
+              A 16-bit identifier used in the SESSION that remains constant over the life of the tunnel.
+            format: integer
+            default: 0
+            length: 16
+            features: [count]
+          x-field-uid: 3
+        extended_tunnel_id:
+          x-field-pattern:
+            description: >-
+              A 32-bit identifier used in the SESSION that remains constant over the life of the tunnel. Normally set to all zeros.
+              Ingress nodes that wish to narrow the scope of a SESSION to the ingress-egress pair may place their IPv4 address here as a globally unique identifier.
+            format: integer
+            default: 0
+            length: 32
+            features: [count]
+          x-field-uid: 4
     Flow.RSVP.PathObjectsClassRsvpHop: 
       description: >-
         Object for RSVP_HOP class.
+        Currently supported c-type is IPv4 (1).
       type: object
     Flow.RSVP.PathObjectsClassTimeValues:
       description: >-
         Object for TIME_VALUES class.
+        Currently supported c-type is Type 1 Time Value (1).
       type: object
     Flow.RSVP.PathObjectsClassExplicitRoute:
       description: >-
         Object for EXPLICIT_ROUTE class.
+        Currently supported c-type is Type 1 Explicit Route (1).
       type: object
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: >-
         Object for LABEL_REQUEST class.
+        Currently supported c-type is Without Label Range (1).
       type: object
     Flow.RSVP.PathObjectsClassSessionAttribute:
       description: >-
         Object for SESSION_ATTRIBUTE class.
+        Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
       type: object
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: >-
         Object for SENDER_TEMPLATE class.
+        Currently supported c-type is LSP Tunnel IPv4 (7).
       type: object
     Flow.RSVP.PathObjectsClassSenderTspec:
       description: >-
         Object for SENDER_TSPEC class.
+        Currently supported c-type is int-serv (2).
       type: object
     Flow.RSVP.PathObjectsClassRecordRoute:
       description: >-
         Object for RECORD_ROUTE class.
+        Currently supported c-type is Type 1 Route Record (1)
       type: object

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -3,7 +3,7 @@ components:
     Flow.Rsvp:
       description: >-
         RSVP packet header as defined in RFC2205 and RFC3209.
-        Currently only supported message type is "path".
+        Currently only supported message type is "path" with mandatory objects and sub-objects.
       type: object
       properties:
         version:
@@ -47,13 +47,9 @@ components:
             features: [count]
           x-field-uid: 5
         rsvp_length:
-          x-field-pattern:
-            description: >-
-              The sum of the lengths of the common header and all objects included in the message.
-            format: integer
-            default: auto
-            length: 16
-            features: [auto, count]
+          description: >-
+            The sum of the lengths of the common header and all objects included in the message.
+          $ref: '#/components/schemas/Flow.RSVP.Length'
           x-field-uid: 6
         message_type:
           description: >-
@@ -62,7 +58,6 @@ components:
             Among Those we are presently supporting "path"(value: 1) message type.
           $ref: '#/components/schemas/Flow.RSVP.Message'
           x-field-uid: 7
-          
     Flow.RSVP.Flag:
       type: object
       properties:
@@ -75,7 +70,42 @@ components:
               refresh_reduction_capable:
                 x-field-uid: 2
             x-field-uid: 1
+    Flow.RSVP.Length:
+      type: object
+      properties:
+        choice:
+          description: auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+        auto:
+          description: >-
+            The OTG implementation can provide a system generated value for this property.
+            If the OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 3     
     Flow.RSVP.Message:
+      description: >-
+          RSVP Message type.
+          Currently only "path" message type is supported.
+      type: object 
+      properties:
+        message_type: 
+          $ref: '#/components/schemas/Flow.RSVP.MessageType'
+          x-field-uid: 1 
+    Flow.RSVP.MessageType:
       type: object
       properties:
         choice:
@@ -90,16 +120,16 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: >-
-        "path" message required the follwoing list of objects in order:
+        "path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
         1. SESSION
         2. RSVP_HOP
         3. TIME_VALUES
-        4. EXPLICIT ROUTE 
+        4. EXPLICIT ROUTE [optional]
         5. LABEL_REQUEST
-        6. SESSION_ATTRIBUTE
+        6. SESSION_ATTRIBUTE [optional]
         7. SENDER_TEMPLATE
         8. SENDER_TSPEC
-        9. RECORD_ROUTE
+        9. RECORD_ROUTE [optional]
       type: object
       properties:
         objects:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -624,9 +624,9 @@ components:
           x-field-pattern:
             description: >-
               An identifier of the layer 3 protocol using this path. 
-              Standard Ethertype values are used.             
+              Standard Ethertype values are used.          
             format: integer
-            default: 0
+            default: 2048
             length: 16
             features: [count]
           x-field-uid: 2
@@ -696,10 +696,7 @@ components:
         name_length:
           description: >-
             The length of the display string before padding, in bytes.          
-          type: string
-          format : hex
-          default: '0'
-          maxLength: 2
+          $ref: '#/components/schemas/Flow.RSVPSessionAttributeName.Length'
           x-field-uid: 4
         session_name:
           description: >-
@@ -775,10 +772,7 @@ components:
         name_length:
           description: >-
             The length of the display string before padding, in bytes.          
-          type: string
-          format : hex
-          default: '0'
-          maxLength: 2
+          $ref: '#/components/schemas/Flow.RSVPSessionAttributeName.Length'
           x-field-uid: 7
         session_name:
           description: >-
@@ -801,6 +795,34 @@ components:
               se_style_desired:
                 x-field-uid: 3
             x-field-uid: 1
+    Flow.RSVPSessionAttributeName.Length:
+      type: object
+      properties:
+        choice:
+          description: auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+        auto:
+          description: >-
+            OTG will provide a system generated value for this property. 
+            If OTG is unable to generate a value the default value must be used.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 3  
     Flow.RSVP.PathObjectsClassSenderTemplate:
       description: >-
           C-Type is specific to a class num.

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -1019,7 +1019,7 @@ components:
               Parameter 127 length, 5 words not including per-service header
             format: integer
             length: 16
-            default: 0
+            default: 5
             features: [count]
           x-field-uid: 10
         token_bucket_rate:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -1232,7 +1232,6 @@ components:
     Flow.RSVP.PathObjectsCustom:
       type: object
       description: Custom packet header
-      required: [bytes]
       properties:
         type:
           x-field-pattern:
@@ -1251,7 +1250,12 @@ components:
             A custom packet header defined as a string of hex bytes.
             The string MUST contain sequence of valid hex bytes.
             Spaces or colons can be part of the bytes but will be discarded.
-            This packet header can be used in multiple places in the packet.
+            Value of the this field should not excced 65525 bytes since maximum 65528 bytes can be added as object-contents in RSVP header.
+            For type and length requires 3 bytes, hence maximum of 65524 bytes are expected.
+            Maximum length of this attribute is 131050 (65525 * 2 hex character per byte).
           type: string
-          pattern: '^[A-Fa-f0-9: ]+$'
+          format: hex
+          minLength: 1
+          maxLength: 131050
+          default: '0000'
           x-field-uid: 3

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -660,7 +660,7 @@ components:
     Flow.RSVP.PathObjectsSessionAttributeCType:
       description: >-
         Object for SESSION_ATTRIBUTE class.
-        Currently supported c-type is LSP_Tunnel (1) and LSP_Tunnel (7).
+        Currently supported c-type is LSP_Tunnel_RA (1) and LSP_Tunnel (7).
       type: object
       properties:
         choice:
@@ -715,6 +715,7 @@ components:
           description: >-
             A null padded string of characters.          
           type: string
+          default: ""
           minLength: 0
           maxLength: 254
           x-field-uid: 5
@@ -791,6 +792,7 @@ components:
           description: >-
             A null padded string of characters.          
           type: string
+          default: ""
           minLength: 0
           maxLength: 254
           x-field-uid: 8

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -189,10 +189,18 @@ components:
           x-field-uid: 10
     Flow.RSVP.PathObjectsClassSession:
       description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsSessionCType:
+      description: >-
           The body of an object corresponding to the class number and c-type.
           Currently supported c-type for SESSION object is LSP Tunnel IPv4 (7).
       type: object 
-      properties:
+      properties: 
         choice:
           type: string
           x-field-uid: 1
@@ -244,7 +252,15 @@ components:
             length: 32
             features: [count]
           x-field-uid: 4
-    Flow.RSVP.PathObjectsClassRsvpHop: 
+    Flow.RSVP.PathObjectsClassRsvpHop:
+      description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsRsvpHopCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsRsvpHopCType: 
       description: >-
         Object for RSVP_HOP class.
         Currently supported c-type is IPv4 (1).
@@ -285,6 +301,14 @@ components:
             features: [count]
           x-field-uid: 2
     Flow.RSVP.PathObjectsClassTimeValues:
+      description: >-
+          C-Type is specific to a class num.
+      type: object 
+      properties:
+        c_type: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsTimeValuesCType'
+          x-field-uid: 1 
+    Flow.RSVP.PathObjectsTimeValuesCType:
       description: >-
         Object for TIME_VALUES class.
         Currently supported c-type is Type 1 Time Value (1).

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -1220,10 +1220,36 @@ components:
         label:
           description: >-
             The contents of the Label Object. Copied from the Label Object.
+          $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteLabel'
+          x-field-uid: 4
+    Flow.RSVP.PathRecordRouteLabel:
+      type: object
+      properties:
+        choice:
+          description: 32 bit integer or hex value.
+          type: string
+          default: as_integer
+          x-field-uid: 1
+          x-enum:
+            as_integer:
+              x-field-uid: 1
+            as_hex:
+              x-field-uid: 2 
+        as_integer:
+          type: integer
+          format: uint32
+          default: 16
+          maximum: 1048575
+          x-field-uid: 2
+        as_hex:
+          description: >-
+            Value of the this field should not excced 4 bytes.
+            Maximum length of this attribute is 8 (4 * 2 hex character per byte).
           type: string
           format: hex
-          default: "00"
-          x-field-uid: 4
+          default: "10"
+          maxLength: 8
+          x-field-uid: 3
     Flow.RSVPRouteRecord.Length:
       type: object
       properties:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -18,13 +18,7 @@ components:
         flag:
           description: >-
               Flag, 0x01-0x08: Reserved.
-          type: string
-          default: not_refresh_reduction_capable
-          x-enum:
-            not_refresh_reduction_capable:
-              x-field-uid: 1
-            refresh_reduction_capable:
-              x-field-uid: 2
+          $ref: '#/components/schemas/Flow.RSVP.Flag'
           x-field-uid: 2
         rsvp_checksum:
           x-field-pattern:
@@ -63,12 +57,169 @@ components:
           x-field-uid: 6
         message_type:
           description: >-
-              An 8-bit number that identifies the function of the RSVP message.
-              There are aound 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 .
-              Among Those we are presently supporting "path"(value: 1) and "hello" (value: 20) message type.
+            An 8-bit number that identifies the function of the RSVP message.
+            There are aound 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 .
+            Among Those we are presently supporting "path"(value: 1) message type.
+          $ref: '#/components/schemas/Flow.RSVP.Message'
+          x-field-uid: 7
+          
+    Flow.RSVP.Flag:
+      type: object
+      properties:
+        choice:
+            type: string
+            default: not_refresh_reduction_capable
+            x-enum:
+              not_refresh_reduction_capable:
+                x-field-uid: 1
+              refresh_reduction_capable:
+                x-field-uid: 2
+            x-field-uid: 1
+    Flow.RSVP.Message:
+      type: object
+      properties:
+        choice:
           type: string
           default: path
           x-enum:
             path:
               x-field-uid: 1
+          x-field-uid: 1
+        path:
+          $ref: '#/components/schemas/Flow.RSVP.PathMessage'
+          x-field-uid: 2
+    Flow.RSVP.PathMessage:
+      description: >-
+        "path" message required the follwoing list of objects in order:
+        1. SESSION
+        2. RSVP_HOP
+        3. TIME_VALUES
+        4. EXPLICIT ROUTE 
+        5. LABEL_REQUEST
+        6. SESSION_ATTRIBUTE
+        7. SENDER_TEMPLATE
+        8. SENDER_TSPEC
+        9. RECORD_ROUTE
+      type: object
+      properties:
+        objects:
+          description: >-
+            "path" message required atleast SESSION, RSVP_HOP and TIME_VALUES objects.
+          type: array
+          minItems: 3
+          items:
+            $ref: '#/components/schemas/Flow.RSVP.PathObjects'
+          x-field-uid: 1
+    Flow.RSVP.PathObjects:
+      description: >-
+        Every RSVP object encapsulated in an RSVP message consists of a 32-bit word header and the object's contents.
+      type: object
+      properties:
+        length:
+          x-field-pattern:
+            description: >-
+              Contains the total length of the object including the object's header, measured in bytes. 
+              Objects must be aligned to 32-bit words. 
+            format: integer
+            length: 16
+            default: 4
+            features: [count]
+          x-field-uid: 1
+        class_num:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClass'
+          x-field-uid: 2
+    Flow.RSVP.PathObjectsClass:
+      description: >-
+            The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 .
+            Curently supported class numbers are for "path" message type.
+            "path" message:
+            Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21.
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          x-enum:
+              session:
+                x-field-uid: 1
+              rsvp_hop:
+                x-field-uid: 2
+              time_values:
+                x-field-uid: 3
+              explicit_route:
+                x-field-uid: 4
+              label_request:
+                x-field-uid: 5
+              session_attribute:
+                x-field-uid: 6
+              sender_template:
+                x-field-uid: 7
+              sender_tspec:
+                x-field-uid: 8
+              record_route: 
+                x-field-uid: 9
+        session:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSession'
+          x-field-uid: 2
+        rsvp_hop:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRsvpHop'
+          x-field-uid: 3
+        time_values:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassTimeValues'
+          x-field-uid: 4
+        explicit_route:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassExplicitRoute'
+          x-field-uid: 5
+        label_request:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassLabelRequest'
+          x-field-uid: 6
+        session_attribute:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSessionAttribute'
           x-field-uid: 7
+        sender_template:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSenderTemplate'
+          x-field-uid: 8
+        sender_tspec:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSenderTspec'
+          x-field-uid: 9
+        record_route: 
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassRecordRoute'
+          x-field-uid: 10
+    Flow.RSVP.PathObjectsClassSession:
+      description: >-
+        Object for SESSION class.
+      type: object 
+    Flow.RSVP.PathObjectsClassRsvpHop: 
+      description: >-
+        Object for RSVP_HOP class.
+      type: object
+    Flow.RSVP.PathObjectsClassTimeValues:
+      description: >-
+        Object for TIME_VALUES class.
+      type: object
+    Flow.RSVP.PathObjectsClassExplicitRoute:
+      description: >-
+        Object for EXPLICIT_ROUTE class.
+      type: object
+    Flow.RSVP.PathObjectsClassLabelRequest:
+      description: >-
+        Object for LABEL_REQUEST class.
+      type: object
+    Flow.RSVP.PathObjectsClassSessionAttribute:
+      description: >-
+        Object for SESSION_ATTRIBUTE class.
+      type: object
+    Flow.RSVP.PathObjectsClassSenderTemplate:
+      description: >-
+        Object for SENDER_TEMPLATE class.
+      type: object
+    Flow.RSVP.PathObjectsClassSenderTspec:
+      description: >-
+        Object for SENDER_TSPEC class.
+      type: object
+    Flow.RSVP.PathObjectsClassRecordRoute:
+      description: >-
+        Object for RECORD_ROUTE class.
+      type: object

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -334,7 +334,7 @@ components:
         IPv4 RSVP_HOP object: Class = 3, C-Type = 1
       type: object
       properties:
-        ipv4_next_previous_hop_address:
+        ipv4_address:
           x-field-pattern:
             description: >-
               The IPv4 address of the interface through which the last RSVP-knowledgeable hop forwarded this message.
@@ -376,11 +376,11 @@ components:
         choice:
           type: string
           x-field-uid: 1
-          default: type_1_time_value
+          default: type_1
           x-enum:
-            type_1_time_value:
+            type_1:
               x-field-uid: 1
-        type_1_time_value:
+        type_1:
           $ref: '#/components/schemas/Flow.RSVP.PathTimeValuesType1'
           x-field-uid: 2
     Flow.RSVP.PathTimeValuesType1:
@@ -418,12 +418,12 @@ components:
       properties:
         choice:
           type: string
-          default: type_1_explicit_route
+          default: type_1
           x-field-uid: 1
           x-enum:
-            type_1_explicit_route:
+            type_1:
               x-field-uid: 1
-        type_1_explicit_route:
+        type_1:
           $ref: '#/components/schemas/Flow.RSVP.PathExplicitRouteType1'
           x-field-uid: 2
     Flow.RSVP.PathExplicitRouteType1:
@@ -1049,12 +1049,12 @@ components:
       properties:
         choice:
           type: string
-          default: type_1_route_record
+          default: type_1
           x-field-uid: 1
           x-enum:
-            type_1_route_record:
+            type_1:
               x-field-uid: 1
-        type_1_route_record:
+        type_1:
           $ref: '#/components/schemas/Flow.RSVP.PathRecordRouteType1'
           x-field-uid: 2
     Flow.RSVP.PathRecordRouteType1:

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -142,24 +142,24 @@ components:
           type: string
           x-field-uid: 1
           x-enum:
-              session:
-                x-field-uid: 1
-              rsvp_hop:
-                x-field-uid: 2
-              time_values:
-                x-field-uid: 3
-              explicit_route:
-                x-field-uid: 4
-              label_request:
-                x-field-uid: 5
-              session_attribute:
-                x-field-uid: 6
-              sender_template:
-                x-field-uid: 7
-              sender_tspec:
-                x-field-uid: 8
-              record_route: 
-                x-field-uid: 9
+            session:
+              x-field-uid: 1
+            rsvp_hop:
+              x-field-uid: 2
+            time_values:
+              x-field-uid: 3
+            explicit_route:
+              x-field-uid: 4
+            label_request:
+              x-field-uid: 5
+            session_attribute:
+              x-field-uid: 6
+            sender_template:
+              x-field-uid: 7
+            sender_tspec:
+              x-field-uid: 8
+            record_route: 
+              x-field-uid: 9
         session:
           $ref: '#/components/schemas/Flow.RSVP.PathObjectsClassSession'
           x-field-uid: 2
@@ -189,19 +189,21 @@ components:
           x-field-uid: 10
     Flow.RSVP.PathObjectsClassSession:
       description: >-
-        Object for SESSION class.
+          The body of an object corresponding to the class number and c-type.
+          Currently supported c-type for SESSION object is LSP Tunnel IPv4 (7).
       type: object 
       properties:
-        c_type:
-          description: >-
-            Currently supported c-type is LSP Tunnel IPv4 (7).
+        choice:
           type: string
+          x-field-uid: 1
           default: lsp_tunnel_ipv4
           x-enum:
             lsp_tunnel_ipv4:
-              $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionLspTunnelIpv4'
               x-field-uid: 1
-          x-field-uid: 1
+        lsp_tunnel_ipv4:
+          $ref: '#/components/schemas/Flow.RSVP.PathObjectsSessionLspTunnelIpv4'
+          x-field-uid: 2
+
     Flow.RSVP.PathObjectsSessionLspTunnelIpv4:
       description: >-
         Class = SESSION, LSP_TUNNEL_IPv4 C-Type = 7.

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -3,13 +3,13 @@ components:
     Flow.Rsvp:
       description: >-
         RSVP packet header as defined in RFC2205 and RFC3209.
-        Currently only supported message type is "path" with mandatory objects and sub-objects.
+        Currently only supported message type is "Path" with mandatory objects and sub-objects.
       type: object
       properties:
         version:
           x-field-pattern:
             description: >-
-              Protocol Version number. 
+              RSVP Protocol Version. 
             format: integer
             length: 4
             default: 1
@@ -54,8 +54,8 @@ components:
         message_type:
           description: >-
             An 8-bit number that identifies the function of the RSVP message.
-            There are aound 20 message types is defined https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 .
-            Among Those we are presently supporting "path"(value: 1) message type.
+            There are aound 20 message types defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-2 .
+            Among these presently supported is "Path"(value: 1) message type.
           $ref: '#/components/schemas/Flow.RSVP.Message'
           x-field-uid: 7
     Flow.RSVP.Flag:
@@ -85,8 +85,8 @@ components:
               x-field-uid: 2
         auto:
           description: >-
-            The OTG implementation can provide a system generated value for this property.
-            If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property. 
+            If OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
           maximum: 65535
@@ -113,7 +113,7 @@ components:
           x-field-uid: 2
     Flow.RSVP.PathMessage:
       description: >-
-        "path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+        "Path" message required the follwoing list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
         1. SESSION
         2. RSVP_HOP
         3. TIME_VALUES
@@ -127,7 +127,7 @@ components:
       properties:
         objects:
           description: >-
-            "path" message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
+            "Path" message required atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
           type: array
           minItems: 6
           items:
@@ -141,7 +141,7 @@ components:
         length:
           description: >-
             A 16-bit field containing the total object length in bytes. 
-            Must always be a multiple of 4, and at least 4.
+            Must always be a multiple of 4 or at least 4.
           $ref: '#/components/schemas/Flow.RSVPPathObject.Length'
           x-field-uid: 1
         class_num:
@@ -162,8 +162,8 @@ components:
               x-field-uid: 2
         auto:
           description: >-
-            The OTG implementation can provide a system generated value for this property.
-            If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property. 
+            If OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
           minimum: 4
@@ -180,8 +180,8 @@ components:
     Flow.RSVP.PathObjectsClass:
       description: >-
             The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 .
-            Curently supported class numbers are for "path" message type.
-            "path" message:
+            Curently supported class numbers are for "Path" message type.
+            "Path" message:
             Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not suppored in above options.
       type: object
       required:
@@ -464,7 +464,7 @@ components:
         l_bit:
           x-field-pattern:
             description: >-
-              The L bit is an attribute of the subobject.The L bit is set if the subobject represents a loose hop in the explicit route.
+              The L bit is an attribute of the subobject. The L bit is set if the subobject represents a loose hop in the explicit route.
               If the bit is not set, the subobject represents a strict hop in the explicit route.
             format: integer
             length: 1
@@ -473,7 +473,7 @@ components:
           x-field-uid: 1
         length:
           description: >-
-            The Length contains the total length of the subobject in bytes,including L ,Type and Length fields.  
+            The Length contains the total length of the subobject in bytes,including L,Type and Length fields.  
             The Length MUST be atleast 4, and MUST be a multiple of 4.
           $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
           x-field-uid: 2
@@ -504,7 +504,7 @@ components:
         l_bit:
           x-field-pattern:
             description: >-
-              The L bit is an attribute of the subobject.The L bit is set if the subobject represents a loose hop in the explicit route.
+              The L bit is an attribute of the subobject. The L bit is set if the subobject represents a loose hop in the explicit route.
               If the bit is not set, the subobject represents a strict hop in the explicit route.
             format: integer
             length: 1
@@ -513,7 +513,7 @@ components:
           x-field-uid: 1
         length:
           description: >-
-            The Length contains the total length of the subobject in bytes,including L ,Type and Length fields.  
+            The Length contains the total length of the subobject in bytes,including L, Type and Length fields.  
             The Length MUST be atleast 4, and MUST be a multiple of 4.
           $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
           x-field-uid: 2
@@ -551,8 +551,8 @@ components:
               x-field-uid: 2
         auto:
           description: >-
-            The OTG implementation can provide a system generated value for this property.
-            If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property. 
+            If OTG is unable to generate a value the default value must be used. 
           type: integer
           format: uint32
           maximum: 256
@@ -667,7 +667,7 @@ components:
           x-field-uid: 2
         flags:
           description: >-
-              0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+              0x01 Local protection desired, 0x02 Label recording desired, 0x04 SE Style desired
           $ref: '#/components/schemas/Flow.RSVPLspTunnel.Flag'
           x-field-uid: 3
         name_length:
@@ -718,7 +718,7 @@ components:
           description: >-
             A 32-bit vector representing a set of attribute filters associated with a tunnel all of which must be present for a
             link to be acceptable. A null set (all bits set to zero) automatically passes.
-            The most significant byte in the hex-string is the farthest  to the left in the byte sequence. 
+            The most significant byte in the hex-string is the farthest to the left in the byte sequence. 
             Leading zero bytes in the configured value may be omitted for brevity.          
           type: string
           format : hex
@@ -746,7 +746,7 @@ components:
           x-field-uid: 5
         flags:
           description: >-
-              0x01  Local protection desired, 0x02  Label recording desired, 0x04  SE Style desired
+              0x01 Local protection desired, 0x02 Label recording desired, 0x04 SE Style desired
           $ref: '#/components/schemas/Flow.RSVPLspTunnel.Flag'
           x-field-uid: 6
         name_length:
@@ -1153,8 +1153,8 @@ components:
               x-field-uid: 2
         auto:
           description: >-
-            The OTG implementation can provide a system generated value for this property.
-            If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property. 
+            If OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
           maximum: 256
@@ -1209,8 +1209,8 @@ components:
               x-field-uid: 2
         auto:
           description: >-
-            The OTG implementation can provide a system generated value for this property.
-            If the OTG is unable to generate a value the default value must be used.
+            OTG will provide a system generated value for this property. 
+            If OTG is unable to generate a value the default value must be used.
           type: integer
           format: uint32
           default: 4


### PR DESCRIPTION
Redocly link:
[ReDoc Interactive Demo](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-rsvp-path/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config)

( New object at : set_config/flows/packet/rsvp )

RFCs and RSVP Parameter list:
[RFC2205](https://www.rfc-editor.org/rfc/rfc2205.html#page-4)
[RFC3209](https://www.rfc-editor.org/rfc/rfc3209.html#page-3)
[RSVP parameters](https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml)

Objective:
User needs to define RSVP data plane packet to emulate DDoS like scenario by flooding DUT with specific types of control packets from test port . In current scope of the PR we are only supporting "path" message with a subset of objects and sub-objects.

Example:

```
	srcIP := "10.10.0.1"
	dstIP := "10.10.0.2"

	config := gosnappi.NewConfig()
	// add ports
	p1 := config.Ports().Add().SetName("p1").SetLocation("eth1")
	p2 := config.Ports().Add().SetName("p2").SetLocation("eth2")

	f1 := config.Flows().Items()[0]
	f1.SetName("f1:p1->p2").
		TxRx().Port().SetTxName(p1.Name()).SetRxName(p2.Name())
	f1.Duration().FixedPackets().SetPackets(100)
	f1.Rate().SetPps(10)

	f1.Packet().Add().Ethernet()
	ip := f1.Packet().Add().Ipv4()

	ip.Src().SetValue(srcIP)
	ip.Dst().SetValue(dstIP)

	// Sample of router_alert option:
	ip.Options().Add().SetChoice("router_alert")

       //RSVP Header
	rsvp := f1.Packet().Add().Rsvp()
	
	//Path message
	rsvpPathMsg := rsvp.MessageType()

	//Path message
	rsvpPathMsg := rsvp.MessageType().Path()

	//SESSION Object
	session := rsvpPathMsg.Objects().Add().ClassNum().Session().CType().LspTunnelIpv4()
	session.Ipv4TunnelEndPointAddress().SetValue("2.2.2.2")
	tunnelId := session.TunnelId().Increment()
	//Emulates 10 tunnels with tunnel id as 1000, 1010,...,1090
	tunnelId.SetStart(1000).SetStep(10).SetCount(10)
	session.ExtendedTunnelId().AsIpv4().SetValue("1.1.1.1")

	//RSVP_HOP Object
	rsvpHop := rsvpPathMsg.Objects().Add().ClassNum().RsvpHop().CType().Ipv4()
	rsvpHop.Ipv4Address().SetValue("1.1.2.1")

	//TIME_VALUES Object
	rsvpPathMsg.Objects().Add().ClassNum().TimeValues()

	//EXPLICIT_ROUTE Object
	ero := rsvpPathMsg.Objects().Add().ClassNum().ExplicitRoute().CType().Type1()
	//Adding 1st sub-object of type ipv4_prefix
	ero.Subobjects().Add().Type().Ipv4Prefix().Ipv4Address().SetValue("1.1.3.1")
	//Adding 2nd sub-object of type ipv4_prefix
	ero.Subobjects().Add().Type().Ipv4Prefix().Ipv4Address().SetValue("1.1.4.1")

	//LABEL_REQUEST Object
	rsvpPathMsg.Objects().Add().ClassNum().LabelRequest()

	//SESSION_ATTRIBUTE Object
	sessionAttribute := rsvpPathMsg.Objects().Add().ClassNum().SessionAttribute().CType().LspTunnel()
	sessionAttribute.SetSessionName("otg_test_port")

	//SENDER_TEMPLATE Object
	sessionTemplate := rsvpPathMsg.Objects().Add().ClassNum().SenderTemplate().CType().LspTunnelIpv4()
	sessionTemplate.Ipv4TunnelSenderAddress().SetValue("1.1.1.1")

	//SENDER_TSPEC Object
	senderTspec := rsvpPathMsg.Objects().Add().ClassNum().SenderTspec().CType().IntServ()
	senderTspec.MaximumPacketSize().SetValue(1500)
	senderTspec.SetPeakDataRate(1e+10)

	//RECORD_ROUTE Object
	rro := rsvpPathMsg.Objects().Add().ClassNum().RecordRoute().CType().Type1()
	//Adding 1st sub-object of type ipv4_address
	rro.Subobjects().Add().Type().Ipv4Address().Ipv4Address().SetValue("1.1.1.1")
	//Adding 2nd sub-object of type ipv4_address
	rro.Subobjects().Add().Type().Ipv4Address().Ipv4Address().SetValue("1.1.2.1")

```