### PR TITLE
Add L1 Speed option for 800 Gbps

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -976,6 +976,8 @@ components:
               x-field-uid: 11
             speed_400_gbps:
               x-field-uid: 12
+            speed_800_gbps:
+              x-field-uid: 13
           enum:
           - speed_10_fd_mbps
           - speed_10_hd_mbps
@@ -989,6 +991,7 @@ components:
           - speed_100_gbps
           - speed_200_gbps
           - speed_400_gbps
+          - speed_800_gbps
         media:
           description: |-
             Set the type of media for test interface if supported. When no media

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -509,6 +509,7 @@ message Layer1 {
       speed_100_gbps = 10;
       speed_200_gbps = 11;
       speed_400_gbps = 12;
+      speed_800_gbps = 13;
     }
   }
   // Set the speed if supported. When no speed is explicitly set, the current

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -47,6 +47,8 @@ components:
               x-field-uid: 11
             speed_400_gbps:
               x-field-uid: 12
+            speed_800_gbps:
+              x-field-uid: 13
         media:
           description: |-
             Set the type of media for test interface if supported. When no media


### PR DESCRIPTION
At present, Layer1 speed options are available up to 400Gbps. A new option is added for 800Gbps in the model, to support hardware with 800G speed.

**Redocly View:**
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-800g/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config)