### PR TITLE
Update on RSVP Path message object 

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8738,7 +8738,7 @@ components:
         length:
           description: |-
             The Length contains the total length of the subobject in bytes,including L, Type and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
-          $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
+          $ref: '#/components/schemas/Flow.RSVPExplicitRouteASNumber.Length'
           x-field-uid: 2
         as_number:
           description: |-
@@ -8778,6 +8778,37 @@ components:
           format: uint32
           maximum: 256
           default: 8
+          x-field-uid: 3
+    Flow.RSVPExplicitRouteASNumber.Length:
+      type: object
+      properties:
+        choice:
+          description: |-
+            auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        auto:
+          description: "OTG will provide a system generated value for this property.\
+            \  If OTG is unable to generate a value the default value must be used. "
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 4
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 4
           x-field-uid: 3
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: |-

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6597,7 +6597,7 @@ message FlowRSVPPathExplicitRouteType1ASNumber {
 
   // The Length contains the total length of the subobject in bytes,including L, Type
   // and Length fields.   The Length MUST be atleast 4, and MUST be a multiple of 4.
-  FlowRSVPExplicitRouteLength length = 2;
+  FlowRSVPExplicitRouteASNumberLength length = 2;
 
   // Autonomous System number to be set in the ERO sub-object that this LSP should traverse
   // through. This field is applicable only if the value of 'type' is set to 'as_number'.
@@ -6626,6 +6626,30 @@ message FlowRSVPExplicitRouteLength {
 
   // Description missing in models
   // default = 8
+  optional uint32 value = 3;
+}
+
+// Description missing in models
+message FlowRSVPExplicitRouteASNumberLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // auto or configured value.
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // OTG will provide a system generated value for this property.  If OTG is unable to
+  // generate a value the default value must be used.
+  // default = 4
+  optional uint32 auto = 2;
+
+  // Description missing in models
+  // default = 4
   optional uint32 value = 3;
 }
 

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -549,7 +549,7 @@ components:
           description: >-
             The Length contains the total length of the subobject in bytes,including L, Type and Length fields.  
             The Length MUST be atleast 4, and MUST be a multiple of 4.
-          $ref: '#/components/schemas/Flow.RSVPExplicitRoute.Length'
+          $ref: '#/components/schemas/Flow.RSVPExplicitRouteASNumber.Length'
           x-field-uid: 2
         as_number:
           description: >-
@@ -587,6 +587,34 @@ components:
           format: uint32
           maximum: 256
           default: 8
+          x-field-uid: 3 
+    Flow.RSVPExplicitRouteASNumber.Length:
+      type: object
+      properties:
+        choice:
+          description: auto or configured value.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+        auto:
+          description: >-
+            OTG will provide a system generated value for this property. 
+            If OTG is unable to generate a value the default value must be used. 
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 4
+          x-field-uid: 2
+        value:
+          type: integer
+          format: uint32
+          maximum: 256
+          default: 4
           x-field-uid: 3 
     Flow.RSVP.PathObjectsClassLabelRequest:
       description: >-


### PR DESCRIPTION
Redocly link:
1. Fix default `length` value for ERO sub-object AS Number .