### PR TITLE
Support for SR Policy AFI/SAFI and Tunnel Encapsulation attribute in BGP Update Replay 

### DIFF
--- a/api/info.yaml
+++ b/api/info.yaml
@@ -8,7 +8,7 @@ info:
     Contributions can be made in the following ways:
     - [open an issue](https://github.com/open-traffic-generator/models/issues) in the models repository
     - [fork the models repository](https://github.com/open-traffic-generator/models) and submit a PR
-  version: 1.0.2
+  version: 1.1.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -5611,83 +5611,68 @@ components:
           format: uint32
           default: 1
           x-field-uid: 1
-    Bgp.OneIpv4SrPolicyNLRIPrefix:
+    Bgp.Ipv4SrPolicyNLRIPrefix:
       description: |-
-        One IPv4 Segment Routing Policy NLRI Prefix.
+        IPv4 Segment Routing Policy NLRI Prefix.
       type: object
       properties:
-        address:
-          description: |-
-            The IPv4 address of the network.
-          type: string
-          format: ipv4
-          x-field-uid: 1
-        prefix:
-          description: "The IPv4 network prefix length to be applied to the address. "
+        distinguisher:
+          description: "The 4-octet value uniquely identifying the policy in the context\
+            \ of <color, endpoint> tuple.  The distinguisher has no semantic value\
+            \ and is solely used by the SR Policy originator to make unique (from\
+            \ an NLRI perspective)  both for multiple candidate paths of the same\
+            \ SR Policy as well as candidate paths of different SR Policies  (i.e.\
+            \ with different segment lists) with the same Color and Endpoint but meant\
+            \ for different headends. "
           type: integer
           format: uint32
-          default: 24
-          maximum: 32
+          default: 1
+          x-field-uid: 1
+        color:
+          description: |-
+            4-octet value identifying (with the endpoint) the policy. The color is used to match the color of the destination  prefixes to steer traffic into the SR Policy as specified in section 8 of RFC9256.
+          type: integer
+          format: uint32
+          default: 1
           x-field-uid: 2
-        path_id:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixPathId'
+        endpoint:
+          description: |-
+            Identifies the endpoint of a policy.  The Endpoint is an IPv4 address and can be either a unicast or an unspecified address (0.0.0.0) as specified in section 2.1 of RFC9256.
+          type: string
+          format: ipv4
+          default: 0.0.0.0
           x-field-uid: 3
-        segment_routing_distinguisher:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingDistinguisher'
-          x-field-uid: 4
-        segment_routing_color:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingColor'
-          x-field-uid: 5
-    Bgp.OneIpv6SrPolicyNLRIPrefix:
+    Bgp.Ipv6SrPolicyNLRIPrefix:
       description: |-
         One IPv6 Segment Routing Policy NLRI Prefix.
       type: object
       properties:
-        address:
+        distinguisher:
+          description: "The 4-octet value uniquely identifying the policy in the context\
+            \ of <color, endpoint> tuple.  The distinguisher has no semantic value\
+            \ and is solely used by the SR Policy originator to make unique (from\
+            \ an NLRI perspective)  both for multiple candidate paths of the same\
+            \ SR Policy as well as candidate paths of different SR Policies  (i.e.\
+            \ with different segment lists) with the same Color and Endpoint but meant\
+            \ for different headends. "
+          type: integer
+          format: uint32
+          default: 1
+          x-field-uid: 1
+        color:
           description: |-
-            The IPv6 address of the network.
+            4-octet value identifying (with the endpoint) the policy. The color is used to match the color of the destination  prefixes to steer traffic into the SR Policy as specified in section 8 of RFC9256.
+          type: integer
+          format: uint32
+          default: 1
+          x-field-uid: 2
+        endpoint:
+          description: |-
+            Identifies the endpoint of a policy.  The Endpoint may represent a single node or a set of nodes (e.g., an anycast address). The Endpoint is an IPv6 address and can be either a unicast or an unspecified address (0::0) as specified in section 2.1 of RFC9256.
           type: string
           format: ipv6
-          x-field-uid: 1
-        prefix:
-          description: "The IPv6 network prefix length to be applied to the address. "
-          type: integer
-          format: uint32
-          default: 64
-          maximum: 128
-          x-field-uid: 2
-        path_id:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixPathId'
+          default: 0::0
           x-field-uid: 3
-        segment_routing_distinguisher:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingDistinguisher'
-          x-field-uid: 4
-        segment_routing_color:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingColor'
-          x-field-uid: 5
-    Bgp.NLRIPrefixSegmentRoutingDistinguisher:
-      description: |-
-        Optional field in the NLRI carrying the distinguisher for Segment Routing Policy NLRI with SAFI 73.
-      type: object
-      properties:
-        value:
-          description: "The value of the optional Segment Routing distinguisher of\
-            \ the prefix. "
-          type: integer
-          format: uint32
-          default: 1
-          x-field-uid: 1
-    Bgp.NLRIPrefixSegmentRoutingColor:
-      description: |-
-        Optional field in the NLRI carrying color for Segment Routing Policy NLRI with SAFI 73.
-      type: object
-      properties:
-        value:
-          description: "The value of the optional Segment Routing color of the prefix. "
-          type: integer
-          format: uint32
-          default: 1
-          x-field-uid: 1
     Bgp.Attributes:
       description: |-
         Attributes carried in the Update packet alongwith the reach/unreach prefixes.
@@ -6244,17 +6229,13 @@ components:
           x-field-uid: 4
         ipv4_srpolicy:
           description: |-
-            List of IPv4 prefixes with Segment Routing Policy being sent in the IPv4 MPREACH_NLRI .
-          type: array
-          items:
-            $ref: '#/components/schemas/Bgp.OneIpv4SrPolicyNLRIPrefix'
+            IPv4 endpoint with Segment Routing Policy being sent in the IPv4 MPREACH_NLRI .
+          $ref: '#/components/schemas/Bgp.Ipv4SrPolicyNLRIPrefix'
           x-field-uid: 5
         ipv6_srpolicy:
-          description: "List of IPv6 prefixes with Segment Routing Policy being sent\
-            \ in the IPv6 MPREACH_NLRI .            "
-          type: array
-          items:
-            $ref: '#/components/schemas/Bgp.OneIpv6SrPolicyNLRIPrefix'
+          description: "IPv6 endpoint with Segment Routing Policy being sent in the\
+            \ IPv6 MPREACH_NLRI .          "
+          $ref: '#/components/schemas/Bgp.Ipv6SrPolicyNLRIPrefix'
           x-field-uid: 6
     Bgp.Attributes.MpUnreachNlri:
       description: "The MP_UNREACH attribute is an optional attribute which can be\
@@ -6293,8 +6274,6 @@ components:
           x-field-uid: 2
         ipv6_unicast:
           description: |-
-            SAFI of the NLRI being sent in the Update.
-                   description: >-
             List of IPv6 prefixes being sent in the IPv6 Unicast MPUNREACH_NLRI .
           type: array
           items:
@@ -6302,17 +6281,13 @@ components:
           x-field-uid: 3
         ipv4_srpolicy:
           description: |-
-            List of IPv4 prefixes with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI .
-          type: array
-          items:
-            $ref: '#/components/schemas/Bgp.OneIpv4SrPolicyNLRIPrefix'
+            IPv4 endpoint with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI .
+          $ref: '#/components/schemas/Bgp.Ipv4SrPolicyNLRIPrefix'
           x-field-uid: 4
         ipv6_srpolicy:
-          description: "List of IPv6 prefixes with Segment Routing Policy being sent\
-            \ in the IPv6 MPUNREACH_NLRI .            "
-          type: array
-          items:
-            $ref: '#/components/schemas/Bgp.OneIpv6SrPolicyNLRIPrefix'
+          description: "IPv6 endpoint with Segment Routing Policy being sent in the\
+            \ IPv4 MPUNREACH_NLRI .          "
+          $ref: '#/components/schemas/Bgp.Ipv6SrPolicyNLRIPrefix'
           x-field-uid: 5
     Bgp.Attributes.MultiExitDiscriminator:
       description: "Optional MULTI_EXIT_DISCRIMINATOR attribute sent to the peer to\
@@ -7238,6 +7213,18 @@ components:
           maximum: 128
           default: 0
           x-field-uid: 4
+    Bgp.NLRIPrefixSegmentRoutingDistinguisher:
+      description: |-
+        Optional field in the NLRI carrying the distinguisher for Segment Routing Policy NLRI with SAFI 73.
+      type: object
+      properties:
+        value:
+          description: "The value of the optional Segment Routing distinguisher of\
+            \ the prefix. "
+          type: integer
+          format: uint32
+          default: 1
+          x-field-uid: 1
     Bgp.V6Peer:
       description: |-
         Configuration for BGPv6 peer settings and routes.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -6185,8 +6185,9 @@ components:
         \ in the attributes of a BGP Update message as defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3.\n\
         The following AFI / SAFI combinations are supported:\n- IPv4 Unicast with\
         \ AFI as 1 and SAFI as 1 \n- IPv6 Unicast with AFI as 2 and SAFI as 1 \n-\
-        \ Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73\n-\
-        \ Segment Routing Policy for IPv6 Unicast with AFI as 2 and SAFI as 73"
+        \ Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73 ( draft-ietf-idr-sr-policy-safi-02\
+        \ Section 2.1 )\n- Segment Routing Policy for IPv6 Unicast with AFI as 2 and\
+        \ SAFI as 73"
       type: object
       required:
       - choice
@@ -6242,8 +6243,9 @@ components:
         \ included in the attributes of a BGP Update message as defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3.\n\
         The following AFI / SAFI combinations are supported:\n- IPv4 Unicast with\
         \ AFI as 1 and SAFI as 1 \n- IPv6 Unicast with AFI as 2 and SAFI as 1 \n-\
-        \ Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73\n-\
-        \ Segment Routing Policy for IPv6 Unicast with AFI as 2 and SAFI as 73"
+        \ Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73 (draft-ietf-idr-sr-policy-safi-02\
+        \ Section 2.1)\n- Segment Routing Policy for IPv6 Unicast with AFI as 2 and\
+        \ SAFI as 73"
       type: object
       properties:
         choice:
@@ -6345,50 +6347,53 @@ components:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy'
           x-field-uid: 2
     Bgp.Attributes.SegmentRoutingPolicy:
-      description: "Optional Segment Routing Policy information as defined in draft-ietf-idr-segment-routing-te-policy.\n\
+      description: "Optional Segment Routing Policy information as defined in draft-ietf-idr-sr-policy-safi-02.\n\
         This information is carried in TUNNEL_ENCAPSULATION attribute with type set\
-        \ to  SR Policy (15).\n- [From .proto :\n  message PaPolicy {\n    optional\
-        \ PaBindingSegmentIdentifier bsid = 1;\n    optional PaPreference preference\
-        \ = 2;\n    repeated PaSegmentList segment_lists = 3;\n    optional PaPriority\
-        \ priority = 4;\n    optional PaPolicyName policy_name = 5;\n    optional\
-        \ PaExplicitNullLabelPolicy explicit_null_label_policy = 6;\n  } \n ] "
+        \ to  SR Policy (15). "
       type: object
       properties:
         binding_segment_identifier:
-          description: "When the active candidate path has a specified Binding Segment\
-            \ Identifier, \nthe SR Policy uses that BSID if this value (label in MPLS,\
-            \ IPv6 address in SRv6) is available.\nThe format of the sub-TLV is defined\
-            \ in draft-ietf-idr-segment-routing-te-policy\nSection 2.4.2 .\n- [.proto:\n\
-            \  message PaBindingSegmentIdentifier {\n    optional bool specified_bsid_only\
-            \ = 1;  // S-flag.\n    optional bool drop_upon_invalid = 2;    // I-flag.\
-            \ \n    oneof sid {\n      PaSegment.MPLS mpls = 4;\n      monitoring.raven.IPAddressProto\
-            \ ipv6 = 5;\n    }\n  }\n]"
           $ref: '#/components/schemas/Bgp.Attributes.Bsid'
           x-field-uid: 1
-        prerefence:
-          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.Preference'
+        srv6_binding_segment_identifier:
+          description: "The SRv6 Binding SID sub-TLV is an optional sub-TLV of type\
+            \ 20 that is used to signal the SRv6 Binding SID\nrelated information\
+            \ of an SR Policy candidate path. \n  - More than one SRv6 Binding SID\
+            \ sub-TLVs MAY be signaled in the same SR Policy encoding to indicate\
+            \ one\n    or more SRv6 SIDs, each with potentially different SRv6 Endpoint\
+            \ Behaviors to be instantiated.\n  - The format of the sub-TLV is defined\
+            \ in draft-ietf-idr-sr-policy-safi-02 Section 2.4.3 .       "
+          type: array
+          items:
+            $ref: '#/components/schemas/Bgp.Attributes.Srv6Bsid'
           x-field-uid: 2
+        preference:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.Preference'
+          x-field-uid: 3
         priority:
           $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.Priority'
-          x-field-uid: 3
+          x-field-uid: 4
         policy_name:
           $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.PolicyName'
-          x-field-uid: 4
-        explicit_null_policy:
-          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.ExplicitNullPolicy'
           x-field-uid: 5
+        policy_candidate_name:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.PolicyCandidateName'
+          x-field-uid: 6
+        explicit_null_label_policy:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.ExplicitNullPolicy'
+          x-field-uid: 7
         segment_list:
           $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.SegmentList'
-          x-field-uid: 6
+          x-field-uid: 8
     Bgp.Attributes.Bsid:
-      description: "When the active candidate path has a specified Binding Segment\
-        \ Identifier, the SR Policy uses that \nBSID if this value (label in MPLS,\
-        \ IPv6 address in SRv6) is available.\n- The format of the sub-TLV is defined\
-        \ in draft-ietf-idr-segment-routing-te-policy Section 2.4.2 .\n- [.proto:\n\
-        \      message PaBindingSegmentIdentifier {\n        optional bool specified_bsid_only\
-        \ = 1;  // S-flag.\n        optional bool drop_upon_invalid = 2;    // I-flag.\
-        \ \n        oneof sid {\n          PaSegment.MPLS mpls = 4;\n          monitoring.raven.IPAddressProto\
-        \ ipv6 = 5;\n        }\n      }\n    ]"
+      description: "The Binding Segment Identifier is an optional sub-tlv of type\
+        \ 13 that can be sent with a SR Policy \nTunnel Encapsulation attribute.\n\
+        When the active candidate path has a specified Binding Segment Identifier,\
+        \ the SR Policy uses that \nBSID if this value (label in MPLS, IPv6 address\
+        \ in SRv6) is available.\n- The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02\
+        \ Section 2.4.2 . \n- It is recommended that if SRv6 Binding SID is desired\
+        \ to be signalled, the SRv6 Binding SID sub-TLV that enables \n  the specification\
+        \ of the SRv6 Endpoint Behavior should be used."
       type: object
       required:
       - choice
@@ -6414,8 +6419,8 @@ components:
     Bgp.Attributes.Bsid.Mpls:
       description: "When the active candidate path has a specified Binding Segment\
         \ Identifier, the SR Policy uses that BSID defined \nas a MPLS label.The format\
-        \ of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy  Section\
-        \ 2.4.2 ."
+        \ of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02  Section 2.4.2\
+        \ ."
       type: object
       properties:
         flag_specified_bsid_only:
@@ -6436,8 +6441,37 @@ components:
     Bgp.Attributes.Bsid.Srv6:
       description: "When the active candidate path has a specified Binding Segment\
         \ Identifier, the SR Policy uses that BSID defined \nas an IPv6 Address.The\
-        \ format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy\
-        \ Section 2.4.2 ."
+        \ format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02 Section\
+        \ 2.4.2 ."
+      type: object
+      properties:
+        flag_specified_bsid_only:
+          description: "S-Flag: This flag encodes the \"Specified-BSID-only\" behavior.\
+            \ It's usage is \ndescribed in section 6.2.3 in [RFC9256]."
+          type: boolean
+          default: false
+          x-field-uid: 1
+        flag_drop_upon_invalid:
+          description: "I-Flag: This flag encodes the \"Drop Upon Invalid\" behavior.\
+            \ \nIt's usage is described in section 8.2 in [RFC9256]."
+          type: boolean
+          default: false
+          x-field-uid: 2
+        ipv6_addr:
+          description: |-
+            IPv6 address denoting the SRv6 SID.
+          type: string
+          format: ipv6
+          default: 0::0
+          x-field-uid: 3
+    Bgp.Attributes.Srv6Bsid:
+      description: "The SRv6 Binding SID sub-TLV is an optional sub-TLV of type 20\
+        \ that is used to signal the SRv6 Binding SID\nrelated information of an SR\
+        \ Policy candidate path. \n  - More than one SRv6 Binding SID sub-TLVs MAY\
+        \ be signaled in the same SR Policy encoding to indicate one or\n    more\
+        \ SRv6 SIDs, each with potentially different SRv6 Endpoint Behaviors to be\
+        \ instantiated.\n  - The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02\
+        \ Section 2.4.3 ."
       type: object
       properties:
         flag_specified_bsid_only:
@@ -6455,7 +6489,7 @@ components:
         flag_srv6_endpoint_behavior:
           description: "B-Flag: This flag, when set, indicates the presence of the\
             \ SRv6 Endpoint Behavior \nand SID Structure encoding specified in Section\
-            \ 2.4.4.2.4 of draft-ietf-idr-segment-routing-te-policy."
+            \ 2.4.4.2.4 of draft-ietf-idr-sr-policy-safi-02."
           type: boolean
           default: false
           x-field-uid: 3
@@ -6466,14 +6500,13 @@ components:
           format: ipv6
           default: 0::0
           x-field-uid: 4
+        srv6_endpoint_behavior:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
+          x-field-uid: 5
     Bgp.Attributes.Sid.Mpls:
       description: "This carries a 20 bit Multi Protocol Label Switching alongwith\
         \ 3 bits traffic class, 1 bit indicating presence\nor absence of Bottom-Of-Stack\
-        \ and 8 bits carrying the Time to Live value. \n- [.proto : \n    // Segment\
-        \ identified by MPLS label.\n  message MPLS {\n    optional uint32 label =\
-        \ 1;          // 20 bits.\n    optional uint32 traffic_class = 2;  // 3 bits\
-        \ (TC).\n    optional bool bottom_of_stack = 3;  // 1 bit (S).\n    optional\
-        \ uint32 time_to_live = 4;   // 8 bits (TTL).\n  }\n]"
+        \ and 8 bits carrying the Time to Live value. "
       type: object
       properties:
         label:
@@ -6506,9 +6539,20 @@ components:
           default: 63
           maximum: 63
           x-field-uid: 4
+    Bgp.Attributes.Sid.Srv6:
+      description: |-
+        An IPv6 address denoting a SRv6 SID.
+      type: object
+      properties:
+        ip:
+          type: string
+          format: ipv6
+          default: 0::0
+          x-field-uid: 1
     Bgp.Attributes.SrPolicy.Preference:
       description: |
-        Optional Preference sub-tlv used to select the best candidate path for an SR Policy.
+        Optional Preference sub-tlv (Type 12) is used to select the best candidate path for an SR Policy.
+        It is defined in Section 2.4.1 of draft-ietf-idr-sr-policy-safi-02 .
       type: object
       properties:
         value:
@@ -6519,8 +6563,9 @@ components:
           default: 0
           x-field-uid: 1
     Bgp.Attributes.SrPolicy.Priority:
-      description: |
-        Optional Priority sub-tlv used to select the order in which policies should be re-computed.
+      description: |-
+        Optional Priority sub-tlv (Type 15) used to select the order in which policies should be re-computed.
+        - It is defined in Section 2.4.6 of draft-ietf-idr-sr-policy-safi-02 .
       type: object
       properties:
         value:
@@ -6530,9 +6575,26 @@ components:
           maximum: 255
           default: 0
           x-field-uid: 1
+    Bgp.Attributes.SrPolicy.PolicyCandidateName:
+      description: "Optional Policy Candidate Path Name sub-tlv (Type 129) which carries\
+        \ the symbolic name for the SR Policy candidate path \nfor debugging.    \n\
+        - It is defined in Section 2.4.7 of draft-ietf-idr-sr-policy-safi-02 ."
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          description: |-
+            Value of the symbolic Policy Candidate Path Name carried in the Policy Candidate Path Name sub-tlv.
+            It is recommended that the size of the name is limited to 255 bytes.
+          type: string
+          maxLength: 500
+          x-field-uid: 1
     Bgp.Attributes.SrPolicy.PolicyName:
-      description: "Optional Policy Name sub-tlv which carries the symbolic name for\
-        \ the SR Policy candidate path for debugging.    "
+      description: "Optional Policy Name sub-tlv (Type 130) which carries the symbolic\
+        \ name for the SR Policy for which the \ncandidate path is being advertised\
+        \ for debugging.    \n- It is defined in Section 2.4.8 of draft-ietf-idr-sr-policy-safi-02\
+        \ ."
       type: object
       required:
       - value
@@ -6545,9 +6607,10 @@ components:
           maxLength: 500
           x-field-uid: 1
     Bgp.Attributes.SrPolicy.ExplicitNullPolicy:
-      description: "This is an optional sub-tlv . \nIf included , it Indicates whether\
-        \ an Explicit NULL Label must be pushed on an unlabeled IP\npacket before\
-        \ other labels for IPv4 or IPv6 flows."
+      description: |-
+        This is an optional sub-tlv (Type 14) which indicates whether an Explicit NULL Label must be pushed on an unlabeled IP
+        packet before other labels for IPv4 or IPv6 flows.
+        - It is defined in Section 2.4.5 of draft-ietf-idr-sr-policy-safi-02.
       properties:
         choice:
           description: |-
@@ -6574,13 +6637,10 @@ components:
           - donot_push
     Bgp.Attributes.SrPolicy.SegmentList:
       description: "One optional SEGMENT_LIST sub-tlv encoded with type of 128.\n\
-        One sub-tlv encodes a single explicit path towards the endpoint as described\
-        \ in \nsection 5.1 of [RFC9256]. \nThe Segment List sub-TLV includes the elements\
-        \ of the paths (i.e., segments) as well \nas an optional Weight sub-TLV.\n\
-        - [.proto :\n  // Contains one \"segment (label) stack\" with its weight.\
-        \ The weight is used for\n  // weighted multipath.\n  message PaSegmentList\
-        \ {\n    message Weight {\n      optional uint32 value = 1;\n    }\n    optional\
-        \ Weight weight = 1;\n    repeated PaSegment segments = 2;\n  }\n]"
+        One sub-tlv (Type 128) encodes a single explicit path towards the endpoint\
+        \ as described in \nsection 5.1 of [RFC9256]. \nThe Segment List sub-TLV includes\
+        \ the elements of the paths (i.e., segments) as well \nas an optional Weight\
+        \ sub-TLV."
       type: object
       properties:
         weight:
@@ -6593,7 +6653,7 @@ components:
           x-field-uid: 2
     Bgp.Attributes.SegmentRoutingPolicy.SegmentList.Weight:
       description: |-
-        The optional Weight sub-TLV specifies the weight associated with a given segment list. The weight is used for weighted multipath.
+        The optional Weight sub-TLV (Type 9) specifies the weight associated with a given segment list. The weight is used for weighted multipath.
       type: object
       properties:
         value:
@@ -6604,127 +6664,11 @@ components:
           default: 0
           x-field-uid: 1
     Bgp.Attributes.SegmentRoutingPolicy.SegmentList.Segment:
-      description: |-
-        A Segment sub-TLV describes a single segment in a segment list  i.e., a single
-        element of the explicit path. The Segment sub-TLVs are optional.
-        - [.proto :
-          // This defines one segment. The distinction between a "segment" and a "segment
-          // identifier" (SID) is basically non-existent; these objects can be seen as
-          // either.
-          message PaSegment {
-            message Flags {  // 8 bits in total.
-              // V-flag. Indicates verification is enabled. See section 5,
-              // https://tools.ietf.org/html/draft-ietf-spring-segment-routing-policy-01
-              optional bool verification = 1;
-              // A-flag. Indicates presence of SR Algorithm field applicable to Segment
-              // Types 3, 4, and 9.
-              optional bool algorithm = 2;
-            }
-            // Segment identified by MPLS label.
-            message MPLS {
-              optional uint32 label = 1;          // 20 bits.
-              optional uint32 traffic_class = 2;  // 3 bits (TC).
-              optional bool bottom_of_stack = 3;  // 1 bit (S).
-              optional uint32 time_to_live = 4;   // 8 bits (TTL).
-            }
-            // SID only, in the form of MPLS Label.
-            message Type1 {
-              optional Flags flags = 1;
-              optional MPLS sid = 2;
-            }
-            // SID only, in the form of IPv6 address.
-            message Type2 {
-              optional Flags flags = 1;
-              optional monitoring.raven.IPAddressProto sid = 2;
-            }
-            // IPv4 Node Address with optional SID.
-            message Type3 {
-              optional Flags flags = 1;
-              optional PaAlgorithm algorithm = 2;
-              optional monitoring.raven.IPAddressProto node_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv6 Node Address with optional SID for SR MPLS.
-            message Type4 {
-              optional Flags flags = 1;
-              optional PaAlgorithm algorithm = 2;
-              optional monitoring.raven.IPAddressProto node_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv4 Address + index with optional SID.
-            message Type5 {
-              optional Flags flags = 1;
-              optional uint32 local_interface_id = 2;
-              optional monitoring.raven.IPAddressProto node_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv4 Local and Remote addresses with optional SID.
-            message Type6 {
-              optional Flags flags = 1;
-              optional monitoring.raven.IPAddressProto local_address = 2;
-              optional monitoring.raven.IPAddressProto remote_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv6 Address + index for local and remote pair with optional SID for SR
-            // MPLS.
-            message Type7 {
-              optional Flags flags = 1;
-              optional uint32 local_interface_id = 2;
-              optional monitoring.raven.IPAddressProto local_node_address = 3;
-              // `remote_interface_id` and `remote_node_address` pair is optional. Both
-              // must be present or both must be absent.
-              optional uint32 remote_interface_id = 4;
-              optional monitoring.raven.IPAddressProto remote_node_address = 5;
-              optional MPLS sid = 6;
-            }
-            // IPv6 Local and Remote addresses with optional SID for SR MPLS.
-            message Type8 {
-              optional Flags flags = 1;
-              optional monitoring.raven.IPAddressProto local_address = 2;
-              optional monitoring.raven.IPAddressProto remote_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv6 Node Address with optional SID for SRv6.
-            message Type9 {
-              optional Flags flags = 1;
-              optional PaAlgorithm algorithm = 2;
-              optional monitoring.raven.IPAddressProto node_address = 3;
-              optional monitoring.raven.IPAddressProto sid = 4;
-            }
-            // IPv6 Address + index for local and remote pair with optional SID for SRv6.
-            message Type10 {
-              optional Flags flags = 1;
-              optional uint32 local_interface_id = 2;
-              optional monitoring.raven.IPAddressProto local_node_address = 3;
-              // `remote_interface_id` and `remote_node_address` pair is optional. Both
-              // must be present or both must be absent.
-              optional uint32 remote_interface_id = 4;
-              optional monitoring.raven.IPAddressProto remote_node_address = 5;
-              optional monitoring.raven.IPAddressProto sid = 6;
-            }
-            // IPv6 Local and Remote addresses for SRv6.
-            message Type11 {
-              optional Flags flags = 1;
-              optional monitoring.raven.IPAddressProto local_address = 2;
-              optional monitoring.raven.IPAddressProto remote_address = 3;
-              optional monitoring.raven.IPAddressProto sid = 4;
-            }
-
-            oneof segment {
-              Type1 type1 = 1;
-              Type2 type2 = 2;
-              Type3 type3 = 3;
-              Type4 type4 = 4;
-              Type5 type5 = 5;
-              Type6 type6 = 6;
-              Type7 type7 = 7;
-              Type8 type8 = 8;
-              Type9 type9 = 9;
-              Type10 type10 = 10;
-              Type11 type11 = 11;
-            }
-          }
-        ]
+      description: "A Segment sub-TLV describes a single segment in a segment list\
+        \  i.e., a single\nelement of the explicit path. The Segment sub-TLVs are\
+        \ optional.\nSegment Types A and B are defined as described in 2.4.4.2.\n\
+        Segment Types C upto K are defined as described in in draft-ietf-idr-bgp-sr-segtypes-ext-03\
+        \  .      "
       type: object
       required:
       - choice
@@ -6734,15 +6678,15 @@ components:
             Specify one of the segment types as defined in ietf-idr-segment-routing-te-policy
             - Type  A: SID only, in the form of MPLS Label.
             - Type  B: SID only, in the form of IPv6 Address.
-            - Type  C: IPv4 Node Address with optional SID.
-            - Type  D: IPv6 Node Address with optional SID for SR MPLS.
-            - Type  E: IPv4 Address and index with optional SID.
-            - Type  F: IPv4 Local and Remote addresses with optional SID.
-            - Type  G: IPv6 Address and index for local and remote pair with optional SID for SR MPLS.
-            - Type  H: IPv6 Local and Remote addresses with optional SID for SR MPLS.
-            - Type  I: IPv6 Node Address with optional SID for SRv6.
-            - Type  J: IPv6 Address and index for local and remote pair with optional SID for SRv6.
-            - Type  K: IPv6 Local and Remote addresses for SRv6.
+            - Type  C: IPv4 Prefix with optional SR Algorithm.
+            - Type  D: IPv6 Global Prefix with optional SR Algorithm for SR-MPLS.
+            - Type  E: IPv4 Prefix with Local Interface ID.
+            - Type  F: IPv4 Addresses for link endpoints as Local, Remote pair.
+            - Type  G: IPv6 Prefix and Interface ID for link endpoints as Local, Remote pair for SR-MPLS.
+            - Type  H: IPv6 Addresses for link endpoints as Local, Remote pair for SR-MPLS.
+            - Type  I: IPv6 Global Prefix with optional SR Algorithm for SRv6.
+            - Type  J: IPv6 Prefix and Interface ID for link endpoints as Local, Remote pair for SRv6.
+            - Type  K: IPv6 Addresses for link endpoints as Local, Remote pair for SRv6.
           type: string
           x-field-uid: 1
           x-enum:
@@ -6815,7 +6759,7 @@ components:
           x-field-uid: 12
     Bgp.Attributes.SegmentRoutingPolicy.TypeA:
       description: |-
-        Type  A: SID only, in the form of MPLS Label.
+        Type A: SID only, in the form of MPLS Label.
         It is encoded as a Segment of Type 1 in the SEGMENT_LIST sub-tlv.
       type: object
       properties:
@@ -6828,7 +6772,7 @@ components:
     Bgp.Attributes.SegmentRoutingPolicy.TypeB:
       description: |-
         Type B: SID only, in the form of IPv6 address.
-        It is encoded as a Segment of Type 2 in the SEGMENT_LIST sub-tlv.
+        It is encoded as a Segment of Type 13 in the SEGMENT_LIST sub-tlv.
       type: object
       properties:
         flags:
@@ -6929,8 +6873,8 @@ components:
           $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
           x-field-uid: 4
     Bgp.Attributes.SegmentRoutingPolicy.TypeF:
-      description: "Type F: IPv4 Local and Remote addresses with optional SID.\nIt\
-        \ is encoded as a Segment of Type 6 in the SEGMENT_LIST sub-tlv. "
+      description: "Type F: IPv4 Local and Remote addresses with optional SR-MPLS\
+        \ SID.\nIt is encoded as a Segment of Type 6 in the SEGMENT_LIST sub-tlv. "
       type: object
       properties:
         flags:
@@ -7025,8 +6969,8 @@ components:
           $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
           x-field-uid: 6
     Bgp.Attributes.SegmentRoutingPolicy.TypeI:
-      description: "Type I: IPv6 Node Address with optional SRv6 SID.\nIt is encoded\
-        \ as a Segment of Type 9 in the SEGMENT_LIST sub-tlv. "
+      description: "Type I: IPv6 Node Address with optional SR Algorithm and optional\
+        \ SRv6 SID.\nIt is encoded as a Segment of Type 14 in the SEGMENT_LIST sub-tlv. "
       type: object
       properties:
         flags:
@@ -7048,18 +6992,14 @@ components:
           default: 0::0
           x-field-uid: 3
         srv6_sid:
-          description: |-
-            Optional SRv6 SID.
-          type: string
-          format: ipv6
-          default: 0::0
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Srv6'
           x-field-uid: 4
         srv6_endpoint_behavior:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
           x-field-uid: 5
     Bgp.Attributes.SegmentRoutingPolicy.TypeJ:
       description: "Type J: IPv6 Address, Interface ID for local and remote pair for\
-        \ SRv6 with optional SID.\nIt is encoded as a Segment of Type 10 in the SEGMENT_LIST\
+        \ SRv6 with optional SID.\nIt is encoded as a Segment of Type 15 in the SEGMENT_LIST\
         \ sub-tlv. "
       type: object
       properties:
@@ -7103,58 +7043,55 @@ components:
           default: 0::0
           x-field-uid: 6
         srv6_sid:
-          description: |-
-            Optional SRv6 SID.
-          type: string
-          format: ipv6
-          default: 0::0
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Srv6'
           x-field-uid: 7
         srv6_endpoint_behavior:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
           x-field-uid: 8
     Bgp.Attributes.SegmentRoutingPolicy.TypeK:
       description: "Type K: IPv6 Local and Remote addresses for SRv6 with optional\
-        \ SID.\nIt is encoded as a Segment of Type 11 in the SEGMENT_LIST sub-tlv. "
+        \ SID.\nIt is encoded as a Segment of Type 16 in the SEGMENT_LIST sub-tlv. "
       type: object
       properties:
         flags:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
           x-field-uid: 1
+        sr_algorithm:
+          description: |-
+            SR Algorithm identifier when A-Flag in on. If A-flag is not enabled, it should be set to 0 on transmission and ignored on receipt.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
         local_ipv6_address:
           description: |-
             Local IPv6 Address.
           type: string
           format: ipv6
           default: 0::0
-          x-field-uid: 2
+          x-field-uid: 3
         remote_ipv6_address:
           description: |-
             Remote IPv6 Address.
           type: string
           format: ipv6
           default: 0::0
-          x-field-uid: 3
-        srv6_sid:
-          description: |-
-            Optional SRv6 SID.
-          type: string
-          format: ipv6
-          default: 0::0
           x-field-uid: 4
+        srv6_sid:
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Srv6'
+          x-field-uid: 5
         srv6_endpoint_behavior:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
-          x-field-uid: 5
+          x-field-uid: 6
     Bgp.Attributes.SegmentRoutingPolicy.TypeFlags:
-      description: "Flags for each Segment in SEGMENT_LIST sub-tlv.\n- V-flag. Indicates\
-        \ verification is enabled. See section 5, of https://datatracker.ietf.org/doc/html/rfc9256\n\
-        - A-flag. Indicates presence of SR Algorithm field applicable to Segment Types\
-        \ 3, 4, and 9.\n- B-Flag. Indicates presence of SRv6 Endpoint Behavior and\
-        \ SID Structure encoding.  \n- [.proto:\n    message Flags {  // 8 bits in\
-        \ total.\n      // V-flag. Indicates verification is enabled. See section\
-        \ 5,\n      // https://tools.ietf.org/html/draft-ietf-spring-segment-routing-policy-01\n\
-        \      optional bool verification = 1;\n      // A-flag. Indicates presence\
-        \ of SR Algorithm field applicable to Segment\n      // Types 3, 4, and 9.\n\
-        \      optional bool algorithm = 2;\n}]"
+      description: |-
+        Flags for each Segment in SEGMENT_LIST sub-tlv.
+        - V-flag. Indicates verification is enabled. See section 5, of https://datatracker.ietf.org/doc/html/rfc9256
+        - A-flag. Indicates presence of SR Algorithm field applicable to Segment Types C, D , I , J and K .
+        - B-Flag. Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding applicable to Segment Types B , I , J and K .
+        - S-Flag: This flag, when set, indicates the presence of the SR-MPLS or SRv6 SID depending on the segment type. (draft-ietf-idr-bgp-sr-segtypes-ext-03 Section 2.10).
+                  This flag is applicable for Segment Types C, D, E, F, G, H, I, J, and K.
       type: object
       properties:
         v_flag:
@@ -7169,18 +7106,36 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-        b_flag:
-          description: "Indicates presence of SRv6 Endpoint Behavior and SID Structure\
-            \ encoding specified in Section 2.4.4.2.4\nof draft-ietf-idr-segment-routing-te-policy.\
-            \         "
+        s_flag:
+          description: |-
+            This flag, when set, indicates the presence of the SR-MPLS or SRv6 SID depending on the segment type.
           type: boolean
           default: false
           x-field-uid: 3
+        b_flag:
+          description: "Indicates presence of SRv6 Endpoint Behavior and SID Structure\
+            \ encoding specified in Section 2.4.4.2.4\nof draft-ietf-idr-sr-policy-safi-02.\
+            \         "
+          type: boolean
+          default: false
+          x-field-uid: 4
     Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure:
       description: |-
-        Configuration for optional SRv6 Endpoint Behavior and SID Structure. Summation of lengths for Locator Block, Locator Node,  Function, and Argument MUST be less than or equal to 128. - This is specified in draft-ietf-idr-segment-routing-te-policy Section 2.4.4.2.4
+        Configuration for optional SRv6 Endpoint Behavior and SID Structure. Summation of lengths for Locator Block, Locator Node,  Function, and Argument MUST be less than or equal to 128. - This is specified in draft-ietf-idr-sr-policy-safi-02 Section 2.4.4.2.4
       type: object
       properties:
+        endpoint_behaviour:
+          description: "This is a 2-octet field that is used to specify the SRv6 Endpoint\
+            \ Behavior code point for the SRv6 SID as defined \nin section 9.2 of\
+            \ [RFC8986]. When set with the value 0xFFFF (i.e., Opaque), the choice\
+            \ of SRv6 Endpoint Behavior is \nleft to the headend. Well known 16-bit\
+            \ values for this field are available at \nhttps://www.iana.org/assignments/segment-routing/segment-routing.xhtml\
+            \ ."
+          type: string
+          format: hex
+          default: ffff
+          maxLength: 4
+          x-field-uid: 1
         lb_length:
           description: |-
             SRv6 SID Locator Block length in bits.
@@ -7188,7 +7143,7 @@ components:
           format: uint32
           maximum: 128
           default: 0
-          x-field-uid: 1
+          x-field-uid: 2
         ln_length:
           description: |-
             SRv6 SID Locator Node length in bits.
@@ -7196,7 +7151,7 @@ components:
           format: uint32
           maximum: 128
           default: 0
-          x-field-uid: 2
+          x-field-uid: 3
         func_length:
           description: |-
             SRv6 SID Function length in bits.
@@ -7204,7 +7159,7 @@ components:
           format: uint32
           maximum: 128
           default: 0
-          x-field-uid: 3
+          x-field-uid: 4
         arg_length:
           description: |-
             SRv6 SID Arguments length in bits.
@@ -7212,7 +7167,7 @@ components:
           format: uint32
           maximum: 128
           default: 0
-          x-field-uid: 4
+          x-field-uid: 5
     Bgp.NLRIPrefixSegmentRoutingDistinguisher:
       description: |-
         Optional field in the NLRI carrying the distinguisher for Segment Routing Policy NLRI with SAFI 73.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.0.2
+  version: 1.1.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.0.2
+/* Open Traffic Generator API 1.1.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -4505,7 +4505,8 @@ message BgpAttributesNextHopIpv6TwoAddresses {
 // The following AFI / SAFI combinations are supported:
 // - IPv4 Unicast with AFI as 1 and SAFI as 1
 // - IPv6 Unicast with AFI as 2 and SAFI as 1
-// - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73
+// - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73 ( draft-ietf-idr-sr-policy-safi-02
+// Section 2.1 )
 // - Segment Routing Policy for IPv6 Unicast with AFI as 2 and SAFI as 73
 message BgpAttributesMpReachNlri {
 
@@ -4544,7 +4545,8 @@ message BgpAttributesMpReachNlri {
 // The following AFI / SAFI combinations are supported:
 // - IPv4 Unicast with AFI as 1 and SAFI as 1
 // - IPv6 Unicast with AFI as 2 and SAFI as 1
-// - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73
+// - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73 (draft-ietf-idr-sr-policy-safi-02
+// Section 2.1)
 // - Segment Routing Policy for IPv6 Unicast with AFI as 2 and SAFI as 73
 message BgpAttributesMpUnreachNlri {
 
@@ -4628,69 +4630,55 @@ message BgpAttributesTunnelEncapsulation {
   BgpAttributesSegmentRoutingPolicy sr_policy = 2;
 }
 
-// Optional Segment Routing Policy information as defined in draft-ietf-idr-segment-routing-te-policy.
+// Optional Segment Routing Policy information as defined in draft-ietf-idr-sr-policy-safi-02.
 // This information is carried in TUNNEL_ENCAPSULATION attribute with type set to  SR
 // Policy (15).
-// - [From .proto :
-// message PaPolicy {
-// optional PaBindingSegmentIdentifier bsid = 1;
-// optional PaPreference preference = 2;
-// repeated PaSegmentList segment_lists = 3;
-// optional PaPriority priority = 4;
-// optional PaPolicyName policy_name = 5;
-// optional PaExplicitNullLabelPolicy explicit_null_label_policy = 6;
-// }
-// ]
 message BgpAttributesSegmentRoutingPolicy {
 
-  // When the active candidate path has a specified Binding Segment Identifier,
-  // the SR Policy uses that BSID if this value (label in MPLS, IPv6 address in SRv6)
-  // is available.
-  // The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy
-  // Section 2.4.2 .
-  // - [.proto:
-  // message PaBindingSegmentIdentifier {
-  // optional bool specified_bsid_only = 1;  // S-flag.
-  // optional bool drop_upon_invalid = 2;    // I-flag.
-  // oneof sid {
-  // PaSegment.MPLS mpls = 4;
-  // monitoring.raven.IPAddressProto ipv6 = 5;
-  // }
-  // }
-  // ]
+  // Description missing in models
   BgpAttributesBsid binding_segment_identifier = 1;
 
-  // Description missing in models
-  BgpAttributesSrPolicyPreference prerefence = 2;
+  // The SRv6 Binding SID sub-TLV is an optional sub-TLV of type 20 that is used to signal
+  // the SRv6 Binding SID
+  // related information of an SR Policy candidate path.
+  // - More than one SRv6 Binding SID sub-TLVs MAY be signaled in the same SR Policy
+  // encoding to indicate one
+  // or more SRv6 SIDs, each with potentially different SRv6 Endpoint Behaviors to
+  // be instantiated.
+  // - The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02 Section
+  // 2.4.3 .
+  repeated BgpAttributesSrv6Bsid srv6_binding_segment_identifier = 2;
 
   // Description missing in models
-  BgpAttributesSrPolicyPriority priority = 3;
+  BgpAttributesSrPolicyPreference preference = 3;
 
   // Description missing in models
-  BgpAttributesSrPolicyPolicyName policy_name = 4;
+  BgpAttributesSrPolicyPriority priority = 4;
 
   // Description missing in models
-  BgpAttributesSrPolicyExplicitNullPolicy explicit_null_policy = 5;
+  BgpAttributesSrPolicyPolicyName policy_name = 5;
 
   // Description missing in models
-  BgpAttributesSrPolicySegmentList segment_list = 6;
+  BgpAttributesSrPolicyPolicyCandidateName policy_candidate_name = 6;
+
+  // Description missing in models
+  BgpAttributesSrPolicyExplicitNullPolicy explicit_null_label_policy = 7;
+
+  // Description missing in models
+  BgpAttributesSrPolicySegmentList segment_list = 8;
 }
 
+// The Binding Segment Identifier is an optional sub-tlv of type 13 that can be sent
+// with a SR Policy
+// Tunnel Encapsulation attribute.
 // When the active candidate path has a specified Binding Segment Identifier, the SR
 // Policy uses that
 // BSID if this value (label in MPLS, IPv6 address in SRv6) is available.
-// - The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy
-// Section 2.4.2 .
-// - [.proto:
-// message PaBindingSegmentIdentifier {
-// optional bool specified_bsid_only = 1;  // S-flag.
-// optional bool drop_upon_invalid = 2;    // I-flag.
-// oneof sid {
-// PaSegment.MPLS mpls = 4;
-// monitoring.raven.IPAddressProto ipv6 = 5;
-// }
-// }
-// ]
+// - The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02 Section
+// 2.4.2 .
+// - It is recommended that if SRv6 Binding SID is desired to be signalled, the SRv6
+// Binding SID sub-TLV that enables
+// the specification of the SRv6 Endpoint Behavior should be used.
 message BgpAttributesBsid {
 
   message Choice {
@@ -4713,7 +4701,7 @@ message BgpAttributesBsid {
 
 // When the active candidate path has a specified Binding Segment Identifier, the SR
 // Policy uses that BSID defined
-// as a MPLS label.The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy
+// as a MPLS label.The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02
 // Section 2.4.2 .
 message BgpAttributesBsidMpls {
 
@@ -4733,7 +4721,7 @@ message BgpAttributesBsidMpls {
 
 // When the active candidate path has a specified Binding Segment Identifier, the SR
 // Policy uses that BSID defined
-// as an IPv6 Address.The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy
+// as an IPv6 Address.The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02
 // Section 2.4.2 .
 message BgpAttributesBsidSrv6 {
 
@@ -4747,29 +4735,49 @@ message BgpAttributesBsidSrv6 {
   // default = False
   optional bool flag_drop_upon_invalid = 2;
 
+  // IPv6 address denoting the SRv6 SID.
+  // default = 0::0
+  optional string ipv6_addr = 3;
+}
+
+// The SRv6 Binding SID sub-TLV is an optional sub-TLV of type 20 that is used to signal
+// the SRv6 Binding SID
+// related information of an SR Policy candidate path.
+// - More than one SRv6 Binding SID sub-TLVs MAY be signaled in the same SR Policy
+// encoding to indicate one or
+// more SRv6 SIDs, each with potentially different SRv6 Endpoint Behaviors to be
+// instantiated.
+// - The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02 Section
+// 2.4.3 .
+message BgpAttributesSrv6Bsid {
+
+  // S-Flag: This flag encodes the Specified-BSID-only behavior. It's usage is
+  // described in section 6.2.3 in [RFC9256].
+  // default = False
+  optional bool flag_specified_bsid_only = 1;
+
+  // I-Flag: This flag encodes the Drop Upon Invalid behavior.
+  // It's usage is described in section 8.2 in [RFC9256].
+  // default = False
+  optional bool flag_drop_upon_invalid = 2;
+
   // B-Flag: This flag, when set, indicates the presence of the SRv6 Endpoint Behavior
   // 
-  // and SID Structure encoding specified in Section 2.4.4.2.4 of draft-ietf-idr-segment-routing-te-policy.
+  // and SID Structure encoding specified in Section 2.4.4.2.4 of draft-ietf-idr-sr-policy-safi-02.
   // default = False
   optional bool flag_srv6_endpoint_behavior = 3;
 
   // IPv6 address denoting the SRv6 SID.
   // default = 0::0
   optional string ipv6_addr = 4;
+
+  // Description missing in models
+  BgpAttributesSegmentRoutingPolicySRv6SIDEndpointBehaviorAndStructure srv6_endpoint_behavior = 5;
 }
 
 // This carries a 20 bit Multi Protocol Label Switching alongwith 3 bits traffic class,
 // 1 bit indicating presence
 // or absence of Bottom-Of-Stack and 8 bits carrying the Time to Live value.
-// - [.proto :
-// // Segment identified by MPLS label.
-// message MPLS {
-// optional uint32 label = 1;          // 20 bits.
-// optional uint32 traffic_class = 2;  // 3 bits (TC).
-// optional bool bottom_of_stack = 3;  // 1 bit (S).
-// optional uint32 time_to_live = 4;   // 8 bits (TTL).
-// }
-// ]
 message BgpAttributesSidMpls {
 
   // 20 bit MPLS Label value.
@@ -4789,7 +4797,17 @@ message BgpAttributesSidMpls {
   optional uint32 ttl = 4;
 }
 
-// Optional Preference sub-tlv used to select the best candidate path for an SR Policy.
+// An IPv6 address denoting a SRv6 SID.
+message BgpAttributesSidSrv6 {
+
+  // Description missing in models
+  // default = 0::0
+  optional string ip = 1;
+}
+
+// Optional Preference sub-tlv (Type 12) is used to select the best candidate path for
+// an SR Policy.
+// It is defined in Section 2.4.1 of draft-ietf-idr-sr-policy-safi-02 .
 // 
 message BgpAttributesSrPolicyPreference {
 
@@ -4798,8 +4816,9 @@ message BgpAttributesSrPolicyPreference {
   optional uint32 value = 1;
 }
 
-// Optional Priority sub-tlv used to select the order in which policies should be re-computed.
-// 
+// Optional Priority sub-tlv (Type 15) used to select the order in which policies should
+// be re-computed.
+// - It is defined in Section 2.4.6 of draft-ietf-idr-sr-policy-safi-02 .
 message BgpAttributesSrPolicyPriority {
 
   // Value to be carried in the Priority sub-tlv.
@@ -4807,8 +4826,23 @@ message BgpAttributesSrPolicyPriority {
   optional uint32 value = 1;
 }
 
-// Optional Policy Name sub-tlv which carries the symbolic name for the SR Policy candidate
-// path for debugging.
+// Optional Policy Candidate Path Name sub-tlv (Type 129) which carries the symbolic
+// name for the SR Policy candidate path
+// for debugging.
+// - It is defined in Section 2.4.7 of draft-ietf-idr-sr-policy-safi-02 .
+message BgpAttributesSrPolicyPolicyCandidateName {
+
+  // Value of the symbolic Policy Candidate Path Name carried in the Policy Candidate
+  // Path Name sub-tlv.
+  // It is recommended that the size of the name is limited to 255 bytes.
+  // required = true
+  optional string value = 1;
+}
+
+// Optional Policy Name sub-tlv (Type 130) which carries the symbolic name for the SR
+// Policy for which the
+// candidate path is being advertised for debugging.
+// - It is defined in Section 2.4.8 of draft-ietf-idr-sr-policy-safi-02 .
 message BgpAttributesSrPolicyPolicyName {
 
   // Value of the symbolic policy name carried in the Policy Name sub-tlv.
@@ -4817,10 +4851,10 @@ message BgpAttributesSrPolicyPolicyName {
   optional string value = 1;
 }
 
-// This is an optional sub-tlv .
-// If included , it Indicates whether an Explicit NULL Label must be pushed on an unlabeled
-// IP
+// This is an optional sub-tlv (Type 14) which indicates whether an Explicit NULL Label
+// must be pushed on an unlabeled IP
 // packet before other labels for IPv4 or IPv6 flows.
+// - It is defined in Section 2.4.5 of draft-ietf-idr-sr-policy-safi-02.
 message BgpAttributesSrPolicyExplicitNullPolicy {
 
   message Choice {
@@ -4839,22 +4873,12 @@ message BgpAttributesSrPolicyExplicitNullPolicy {
 }
 
 // One optional SEGMENT_LIST sub-tlv encoded with type of 128.
-// One sub-tlv encodes a single explicit path towards the endpoint as described in
+// One sub-tlv (Type 128) encodes a single explicit path towards the endpoint as described
+// in
 // section 5.1 of [RFC9256].
 // The Segment List sub-TLV includes the elements of the paths (i.e., segments) as well
 // 
 // as an optional Weight sub-TLV.
-// - [.proto :
-// // Contains one segment (label) stack with its weight. The weight is used for
-// // weighted multipath.
-// message PaSegmentList {
-// message Weight {
-// optional uint32 value = 1;
-// }
-// optional Weight weight = 1;
-// repeated PaSegment segments = 2;
-// }
-// ]
 message BgpAttributesSrPolicySegmentList {
 
   // Description missing in models
@@ -4864,8 +4888,8 @@ message BgpAttributesSrPolicySegmentList {
   repeated BgpAttributesSegmentRoutingPolicySegmentListSegment segments = 2;
 }
 
-// The optional Weight sub-TLV specifies the weight associated with a given segment
-// list. The weight is used for weighted multipath.
+// The optional Weight sub-TLV (Type 9) specifies the weight associated with a given
+// segment list. The weight is used for weighted multipath.
 message BgpAttributesSegmentRoutingPolicySegmentListWeight {
 
   // Value of the weight.
@@ -4875,124 +4899,9 @@ message BgpAttributesSegmentRoutingPolicySegmentListWeight {
 
 // A Segment sub-TLV describes a single segment in a segment list  i.e., a single
 // element of the explicit path. The Segment sub-TLVs are optional.
-// - [.proto :
-// // This defines one segment. The distinction between a segment and a segment
-// // identifier (SID) is basically non-existent; these objects can be seen as
-// // either.
-// message PaSegment {
-// message Flags {  // 8 bits in total.
-// // V-flag. Indicates verification is enabled. See section 5,
-// // https://tools.ietf.org/html/draft-ietf-spring-segment-routing-policy-01
-// optional bool verification = 1;
-// // A-flag. Indicates presence of SR Algorithm field applicable to Segment
-// // Types 3, 4, and 9.
-// optional bool algorithm = 2;
-// }
-// // Segment identified by MPLS label.
-// message MPLS {
-// optional uint32 label = 1;          // 20 bits.
-// optional uint32 traffic_class = 2;  // 3 bits (TC).
-// optional bool bottom_of_stack = 3;  // 1 bit (S).
-// optional uint32 time_to_live = 4;   // 8 bits (TTL).
-// }
-// // SID only, in the form of MPLS Label.
-// message Type1 {
-// optional Flags flags = 1;
-// optional MPLS sid = 2;
-// }
-// // SID only, in the form of IPv6 address.
-// message Type2 {
-// optional Flags flags = 1;
-// optional monitoring.raven.IPAddressProto sid = 2;
-// }
-// // IPv4 Node Address with optional SID.
-// message Type3 {
-// optional Flags flags = 1;
-// optional PaAlgorithm algorithm = 2;
-// optional monitoring.raven.IPAddressProto node_address = 3;
-// optional MPLS sid = 4;
-// }
-// // IPv6 Node Address with optional SID for SR MPLS.
-// message Type4 {
-// optional Flags flags = 1;
-// optional PaAlgorithm algorithm = 2;
-// optional monitoring.raven.IPAddressProto node_address = 3;
-// optional MPLS sid = 4;
-// }
-// // IPv4 Address + index with optional SID.
-// message Type5 {
-// optional Flags flags = 1;
-// optional uint32 local_interface_id = 2;
-// optional monitoring.raven.IPAddressProto node_address = 3;
-// optional MPLS sid = 4;
-// }
-// // IPv4 Local and Remote addresses with optional SID.
-// message Type6 {
-// optional Flags flags = 1;
-// optional monitoring.raven.IPAddressProto local_address = 2;
-// optional monitoring.raven.IPAddressProto remote_address = 3;
-// optional MPLS sid = 4;
-// }
-// // IPv6 Address + index for local and remote pair with optional SID for SR
-// // MPLS.
-// message Type7 {
-// optional Flags flags = 1;
-// optional uint32 local_interface_id = 2;
-// optional monitoring.raven.IPAddressProto local_node_address = 3;
-// // `remote_interface_id` and `remote_node_address` pair is optional. Both
-// // must be present or both must be absent.
-// optional uint32 remote_interface_id = 4;
-// optional monitoring.raven.IPAddressProto remote_node_address = 5;
-// optional MPLS sid = 6;
-// }
-// // IPv6 Local and Remote addresses with optional SID for SR MPLS.
-// message Type8 {
-// optional Flags flags = 1;
-// optional monitoring.raven.IPAddressProto local_address = 2;
-// optional monitoring.raven.IPAddressProto remote_address = 3;
-// optional MPLS sid = 4;
-// }
-// // IPv6 Node Address with optional SID for SRv6.
-// message Type9 {
-// optional Flags flags = 1;
-// optional PaAlgorithm algorithm = 2;
-// optional monitoring.raven.IPAddressProto node_address = 3;
-// optional monitoring.raven.IPAddressProto sid = 4;
-// }
-// // IPv6 Address + index for local and remote pair with optional SID for SRv6.
-// message Type10 {
-// optional Flags flags = 1;
-// optional uint32 local_interface_id = 2;
-// optional monitoring.raven.IPAddressProto local_node_address = 3;
-// // `remote_interface_id` and `remote_node_address` pair is optional. Both
-// // must be present or both must be absent.
-// optional uint32 remote_interface_id = 4;
-// optional monitoring.raven.IPAddressProto remote_node_address = 5;
-// optional monitoring.raven.IPAddressProto sid = 6;
-// }
-// // IPv6 Local and Remote addresses for SRv6.
-// message Type11 {
-// optional Flags flags = 1;
-// optional monitoring.raven.IPAddressProto local_address = 2;
-// optional monitoring.raven.IPAddressProto remote_address = 3;
-// optional monitoring.raven.IPAddressProto sid = 4;
-// }
-// 
-// oneof segment {
-// Type1 type1 = 1;
-// Type2 type2 = 2;
-// Type3 type3 = 3;
-// Type4 type4 = 4;
-// Type5 type5 = 5;
-// Type6 type6 = 6;
-// Type7 type7 = 7;
-// Type8 type8 = 8;
-// Type9 type9 = 9;
-// Type10 type10 = 10;
-// Type11 type11 = 11;
-// }
-// }
-// ]
+// Segment Types A and B are defined as described in 2.4.4.2.
+// Segment Types C upto K are defined as described in in draft-ietf-idr-bgp-sr-segtypes-ext-03
+// .
 message BgpAttributesSegmentRoutingPolicySegmentListSegment {
 
   message Choice {
@@ -5014,17 +4923,17 @@ message BgpAttributesSegmentRoutingPolicySegmentListSegment {
   // Specify one of the segment types as defined in ietf-idr-segment-routing-te-policy
   // - Type  A: SID only, in the form of MPLS Label.
   // - Type  B: SID only, in the form of IPv6 Address.
-  // - Type  C: IPv4 Node Address with optional SID.
-  // - Type  D: IPv6 Node Address with optional SID for SR MPLS.
-  // - Type  E: IPv4 Address and index with optional SID.
-  // - Type  F: IPv4 Local and Remote addresses with optional SID.
-  // - Type  G: IPv6 Address and index for local and remote pair with optional SID for
-  // SR MPLS.
-  // - Type  H: IPv6 Local and Remote addresses with optional SID for SR MPLS.
-  // - Type  I: IPv6 Node Address with optional SID for SRv6.
-  // - Type  J: IPv6 Address and index for local and remote pair with optional SID for
-  // SRv6.
-  // - Type  K: IPv6 Local and Remote addresses for SRv6.
+  // - Type  C: IPv4 Prefix with optional SR Algorithm.
+  // - Type  D: IPv6 Global Prefix with optional SR Algorithm for SR-MPLS.
+  // - Type  E: IPv4 Prefix with Local Interface ID.
+  // - Type  F: IPv4 Addresses for link endpoints as Local, Remote pair.
+  // - Type  G: IPv6 Prefix and Interface ID for link endpoints as Local, Remote pair
+  // for SR-MPLS.
+  // - Type  H: IPv6 Addresses for link endpoints as Local, Remote pair for SR-MPLS.
+  // - Type  I: IPv6 Global Prefix with optional SR Algorithm for SRv6.
+  // - Type  J: IPv6 Prefix and Interface ID for link endpoints as Local, Remote pair
+  // for SRv6.
+  // - Type  K: IPv6 Addresses for link endpoints as Local, Remote pair for SRv6.
   // required = true
   optional Choice.Enum choice = 1;
 
@@ -5062,7 +4971,7 @@ message BgpAttributesSegmentRoutingPolicySegmentListSegment {
   BgpAttributesSegmentRoutingPolicyTypeK type_k = 12;
 }
 
-// Type  A: SID only, in the form of MPLS Label.
+// Type A: SID only, in the form of MPLS Label.
 // It is encoded as a Segment of Type 1 in the SEGMENT_LIST sub-tlv.
 message BgpAttributesSegmentRoutingPolicyTypeA {
 
@@ -5074,7 +4983,7 @@ message BgpAttributesSegmentRoutingPolicyTypeA {
 }
 
 // Type B: SID only, in the form of IPv6 address.
-// It is encoded as a Segment of Type 2 in the SEGMENT_LIST sub-tlv.
+// It is encoded as a Segment of Type 13 in the SEGMENT_LIST sub-tlv.
 message BgpAttributesSegmentRoutingPolicyTypeB {
 
   // Description missing in models
@@ -5147,7 +5056,7 @@ message BgpAttributesSegmentRoutingPolicyTypeE {
   BgpAttributesSidMpls sr_mpls_sid = 4;
 }
 
-// Type F: IPv4 Local and Remote addresses with optional SID.
+// Type F: IPv4 Local and Remote addresses with optional SR-MPLS SID.
 // It is encoded as a Segment of Type 6 in the SEGMENT_LIST sub-tlv.
 message BgpAttributesSegmentRoutingPolicyTypeF {
 
@@ -5216,8 +5125,8 @@ message BgpAttributesSegmentRoutingPolicyTypeH {
   BgpAttributesSidMpls sr_mpls_sid = 6;
 }
 
-// Type I: IPv6 Node Address with optional SRv6 SID.
-// It is encoded as a Segment of Type 9 in the SEGMENT_LIST sub-tlv.
+// Type I: IPv6 Node Address with optional SR Algorithm and optional SRv6 SID.
+// It is encoded as a Segment of Type 14 in the SEGMENT_LIST sub-tlv.
 message BgpAttributesSegmentRoutingPolicyTypeI {
 
   // Description missing in models
@@ -5232,9 +5141,8 @@ message BgpAttributesSegmentRoutingPolicyTypeI {
   // default = 0::0
   optional string ipv6_node_address = 3;
 
-  // Optional SRv6 SID.
-  // default = 0::0
-  optional string srv6_sid = 4;
+  // Description missing in models
+  BgpAttributesSidSrv6 srv6_sid = 4;
 
   // Description missing in models
   BgpAttributesSegmentRoutingPolicySRv6SIDEndpointBehaviorAndStructure srv6_endpoint_behavior = 5;
@@ -5242,7 +5150,7 @@ message BgpAttributesSegmentRoutingPolicyTypeI {
 
 // Type J: IPv6 Address, Interface ID for local and remote pair for SRv6 with optional
 // SID.
-// It is encoded as a Segment of Type 10 in the SEGMENT_LIST sub-tlv.
+// It is encoded as a Segment of Type 15 in the SEGMENT_LIST sub-tlv.
 message BgpAttributesSegmentRoutingPolicyTypeJ {
 
   // Description missing in models
@@ -5272,52 +5180,49 @@ message BgpAttributesSegmentRoutingPolicyTypeJ {
   // default = 0::0
   optional string remote_ipv6_node_address = 6;
 
-  // Optional SRv6 SID.
-  // default = 0::0
-  optional string srv6_sid = 7;
+  // Description missing in models
+  BgpAttributesSidSrv6 srv6_sid = 7;
 
   // Description missing in models
   BgpAttributesSegmentRoutingPolicySRv6SIDEndpointBehaviorAndStructure srv6_endpoint_behavior = 8;
 }
 
 // Type K: IPv6 Local and Remote addresses for SRv6 with optional SID.
-// It is encoded as a Segment of Type 11 in the SEGMENT_LIST sub-tlv.
+// It is encoded as a Segment of Type 16 in the SEGMENT_LIST sub-tlv.
 message BgpAttributesSegmentRoutingPolicyTypeK {
 
   // Description missing in models
   BgpAttributesSegmentRoutingPolicyTypeFlags flags = 1;
 
+  // SR Algorithm identifier when A-Flag in on. If A-flag is not enabled, it should be
+  // set to 0 on transmission and ignored on receipt.
+  // default = 0
+  optional uint32 sr_algorithm = 2;
+
   // Local IPv6 Address.
   // default = 0::0
-  optional string local_ipv6_address = 2;
+  optional string local_ipv6_address = 3;
 
   // Remote IPv6 Address.
   // default = 0::0
-  optional string remote_ipv6_address = 3;
-
-  // Optional SRv6 SID.
-  // default = 0::0
-  optional string srv6_sid = 4;
+  optional string remote_ipv6_address = 4;
 
   // Description missing in models
-  BgpAttributesSegmentRoutingPolicySRv6SIDEndpointBehaviorAndStructure srv6_endpoint_behavior = 5;
+  BgpAttributesSidSrv6 srv6_sid = 5;
+
+  // Description missing in models
+  BgpAttributesSegmentRoutingPolicySRv6SIDEndpointBehaviorAndStructure srv6_endpoint_behavior = 6;
 }
 
 // Flags for each Segment in SEGMENT_LIST sub-tlv.
 // - V-flag. Indicates verification is enabled. See section 5, of https://datatracker.ietf.org/doc/html/rfc9256
-// - A-flag. Indicates presence of SR Algorithm field applicable to Segment Types 3,
-// 4, and 9.
-// - B-Flag. Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding.
-// 
-// - [.proto:
-// message Flags {  // 8 bits in total.
-// // V-flag. Indicates verification is enabled. See section 5,
-// // https://tools.ietf.org/html/draft-ietf-spring-segment-routing-policy-01
-// optional bool verification = 1;
-// // A-flag. Indicates presence of SR Algorithm field applicable to Segment
-// // Types 3, 4, and 9.
-// optional bool algorithm = 2;
-// }]
+// - A-flag. Indicates presence of SR Algorithm field applicable to Segment Types C,
+// D , I , J and K .
+// - B-Flag. Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding
+// applicable to Segment Types B , I , J and K .
+// - S-Flag: This flag, when set, indicates the presence of the SR-MPLS or SRv6 SID
+// depending on the segment type. (draft-ietf-idr-bgp-sr-segtypes-ext-03 Section 2.10).
+// This flag is applicable for Segment Types C, D, E, F, G, H, I, J, and K.
 message BgpAttributesSegmentRoutingPolicyTypeFlags {
 
   // Indicates verification of segment data in is enabled.
@@ -5329,34 +5234,48 @@ message BgpAttributesSegmentRoutingPolicyTypeFlags {
   // default = False
   optional bool a_flag = 2;
 
+  // This flag, when set, indicates the presence of the SR-MPLS or SRv6 SID depending
+  // on the segment type.
+  // default = False
+  optional bool s_flag = 3;
+
   // Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding specified
   // in Section 2.4.4.2.4
-  // of draft-ietf-idr-segment-routing-te-policy.
+  // of draft-ietf-idr-sr-policy-safi-02.
   // default = False
-  optional bool b_flag = 3;
+  optional bool b_flag = 4;
 }
 
 // Configuration for optional SRv6 Endpoint Behavior and SID Structure. Summation of
 // lengths for Locator Block, Locator Node,  Function, and Argument MUST be less than
-// or equal to 128. - This is specified in draft-ietf-idr-segment-routing-te-policy
-// Section 2.4.4.2.4
+// or equal to 128. - This is specified in draft-ietf-idr-sr-policy-safi-02 Section
+// 2.4.4.2.4
 message BgpAttributesSegmentRoutingPolicySRv6SIDEndpointBehaviorAndStructure {
+
+  // This is a 2-octet field that is used to specify the SRv6 Endpoint Behavior code point
+  // for the SRv6 SID as defined
+  // in section 9.2 of [RFC8986]. When set with the value 0xFFFF (i.e., Opaque), the choice
+  // of SRv6 Endpoint Behavior is
+  // left to the headend. Well known 16-bit values for this field are available at
+  // https://www.iana.org/assignments/segment-routing/segment-routing.xhtml .
+  // default = ffff
+  optional string endpoint_behaviour = 1;
 
   // SRv6 SID Locator Block length in bits.
   // default = 0
-  optional uint32 lb_length = 1;
+  optional uint32 lb_length = 2;
 
   // SRv6 SID Locator Node length in bits.
   // default = 0
-  optional uint32 ln_length = 2;
+  optional uint32 ln_length = 3;
 
   // SRv6 SID Function length in bits.
   // default = 0
-  optional uint32 func_length = 3;
+  optional uint32 func_length = 4;
 
   // SRv6 SID Arguments length in bits.
   // default = 0
-  optional uint32 arg_length = 4;
+  optional uint32 arg_length = 5;
 }
 
 // Optional field in the NLRI carrying the distinguisher for Segment Routing Policy

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -4064,62 +4064,55 @@ message BgpNLRIPrefixPathId {
   optional uint32 value = 1;
 }
 
-// One IPv4 Segment Routing Policy NLRI Prefix.
-message BgpOneIpv4SrPolicyNLRIPrefix {
+// IPv4 Segment Routing Policy NLRI Prefix.
+message BgpIpv4SrPolicyNLRIPrefix {
 
-  // The IPv4 address of the network.
-  optional string address = 1;
+  // The 4-octet value uniquely identifying the policy in the context of <color, endpoint>
+  // tuple.  The distinguisher has no semantic value and is solely used by the SR Policy
+  // originator to make unique (from an NLRI perspective)  both for multiple candidate
+  // paths of the same SR Policy as well as candidate paths of different SR Policies
+  // (i.e. with different segment lists) with the same Color and Endpoint but meant for
+  // different headends.
+  // default = 1
+  optional uint32 distinguisher = 1;
 
-  // The IPv4 network prefix length to be applied to the address.
-  // default = 24
-  optional uint32 prefix = 2;
+  // 4-octet value identifying (with the endpoint) the policy. The color is used to match
+  // the color of the destination  prefixes to steer traffic into the SR Policy as specified
+  // in section 8 of RFC9256.
+  // default = 1
+  optional uint32 color = 2;
 
-  // Description missing in models
-  BgpNLRIPrefixPathId path_id = 3;
-
-  // Description missing in models
-  BgpNLRIPrefixSegmentRoutingDistinguisher segment_routing_distinguisher = 4;
-
-  // Description missing in models
-  BgpNLRIPrefixSegmentRoutingColor segment_routing_color = 5;
+  // Identifies the endpoint of a policy.  The Endpoint is an IPv4 address and can be
+  // either a unicast or an unspecified address (0.0.0.0) as specified in section 2.1
+  // of RFC9256.
+  // default = 0.0.0.0
+  optional string endpoint = 3;
 }
 
 // One IPv6 Segment Routing Policy NLRI Prefix.
-message BgpOneIpv6SrPolicyNLRIPrefix {
+message BgpIpv6SrPolicyNLRIPrefix {
 
-  // The IPv6 address of the network.
-  optional string address = 1;
-
-  // The IPv6 network prefix length to be applied to the address.
-  // default = 64
-  optional uint32 prefix = 2;
-
-  // Description missing in models
-  BgpNLRIPrefixPathId path_id = 3;
-
-  // Description missing in models
-  BgpNLRIPrefixSegmentRoutingDistinguisher segment_routing_distinguisher = 4;
-
-  // Description missing in models
-  BgpNLRIPrefixSegmentRoutingColor segment_routing_color = 5;
-}
-
-// Optional field in the NLRI carrying the distinguisher for Segment Routing Policy
-// NLRI with SAFI 73.
-message BgpNLRIPrefixSegmentRoutingDistinguisher {
-
-  // The value of the optional Segment Routing distinguisher of the prefix.
+  // The 4-octet value uniquely identifying the policy in the context of <color, endpoint>
+  // tuple.  The distinguisher has no semantic value and is solely used by the SR Policy
+  // originator to make unique (from an NLRI perspective)  both for multiple candidate
+  // paths of the same SR Policy as well as candidate paths of different SR Policies
+  // (i.e. with different segment lists) with the same Color and Endpoint but meant for
+  // different headends.
   // default = 1
-  optional uint32 value = 1;
-}
+  optional uint32 distinguisher = 1;
 
-// Optional field in the NLRI carrying color for Segment Routing Policy NLRI with SAFI
-// 73.
-message BgpNLRIPrefixSegmentRoutingColor {
-
-  // The value of the optional Segment Routing color of the prefix.
+  // 4-octet value identifying (with the endpoint) the policy. The color is used to match
+  // the color of the destination  prefixes to steer traffic into the SR Policy as specified
+  // in section 8 of RFC9256.
   // default = 1
-  optional uint32 value = 1;
+  optional uint32 color = 2;
+
+  // Identifies the endpoint of a policy.  The Endpoint may represent a single node or
+  // a set of nodes (e.g., an anycast address). The Endpoint is an IPv6 address and can
+  // be either a unicast or an unspecified address (0::0) as specified in section 2.1
+  // of RFC9256.
+  // default = 0::0
+  optional string endpoint = 3;
 }
 
 // Attributes carried in the Update packet alongwith the reach/unreach prefixes.
@@ -4538,13 +4531,12 @@ message BgpAttributesMpReachNlri {
   // List of IPv6 prefixes being sent in the IPv6 Unicast MPREACH_NLRI .
   repeated BgpOneIpv6NLRIPrefix ipv6_unicast = 4;
 
-  // List of IPv4 prefixes with Segment Routing Policy being sent in the IPv4 MPREACH_NLRI
-  // .
-  repeated BgpOneIpv4SrPolicyNLRIPrefix ipv4_srpolicy = 5;
+  // IPv4 endpoint with Segment Routing Policy being sent in the IPv4 MPREACH_NLRI .
+  BgpIpv4SrPolicyNLRIPrefix ipv4_srpolicy = 5;
 
-  // List of IPv6 prefixes with Segment Routing Policy being sent in the IPv6 MPREACH_NLRI
-  // .
-  repeated BgpOneIpv6SrPolicyNLRIPrefix ipv6_srpolicy = 6;
+  // IPv6 endpoint with Segment Routing Policy being sent in the IPv6 MPREACH_NLRI .
+  // 
+  BgpIpv6SrPolicyNLRIPrefix ipv6_srpolicy = 6;
 }
 
 // The MP_UNREACH attribute is an optional attribute which can be included in the attributes
@@ -4571,18 +4563,15 @@ message BgpAttributesMpUnreachNlri {
   // List of IPv4 prefixes being sent in the IPv4 Unicast MPUNREACH_NLRI .
   repeated BgpOneIpv4NLRIPrefix ipv4_unicast = 2;
 
-  // SAFI of the NLRI being sent in the Update.
-  // description: >-
   // List of IPv6 prefixes being sent in the IPv6 Unicast MPUNREACH_NLRI .
   repeated BgpOneIpv6NLRIPrefix ipv6_unicast = 3;
 
-  // List of IPv4 prefixes with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI
-  // .
-  repeated BgpOneIpv4SrPolicyNLRIPrefix ipv4_srpolicy = 4;
+  // IPv4 endpoint with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI .
+  BgpIpv4SrPolicyNLRIPrefix ipv4_srpolicy = 4;
 
-  // List of IPv6 prefixes with Segment Routing Policy being sent in the IPv6 MPUNREACH_NLRI
-  // .
-  repeated BgpOneIpv6SrPolicyNLRIPrefix ipv6_srpolicy = 5;
+  // IPv6 endpoint with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI .
+  // 
+  BgpIpv6SrPolicyNLRIPrefix ipv6_srpolicy = 5;
 }
 
 // Optional MULTI_EXIT_DISCRIMINATOR attribute sent to the peer to help in the route
@@ -5368,6 +5357,15 @@ message BgpAttributesSegmentRoutingPolicySRv6SIDEndpointBehaviorAndStructure {
   // SRv6 SID Arguments length in bits.
   // default = 0
   optional uint32 arg_length = 4;
+}
+
+// Optional field in the NLRI carrying the distinguisher for Segment Routing Policy
+// NLRI with SAFI 73.
+message BgpNLRIPrefixSegmentRoutingDistinguisher {
+
+  // The value of the optional Segment Routing distinguisher of the prefix.
+  // default = 1
+  optional uint32 value = 1;
 }
 
 // Configuration for BGPv6 peer settings and routes.

--- a/device/bgp/bgpupdatereplay.yaml
+++ b/device/bgp/bgpupdatereplay.yaml
@@ -905,7 +905,9 @@ components:
           $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.ExplicitNullPolicy'
           x-field-uid: 7
         segment_list:
-          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.SegmentList'
+          type: array
+          items:
+             $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.SegmentList'
           x-field-uid: 8
     Bgp.Attributes.Bsid:
       description: |-

--- a/device/bgp/bgpupdatereplay.yaml
+++ b/device/bgp/bgpupdatereplay.yaml
@@ -184,6 +184,90 @@ components:
           format: uint32
           default: 1          
           x-field-uid: 1
+    
+    Bgp.OneIpv4SrPolicyNLRIPrefix:     
+      description: >-
+          One IPv4 Segment Routing Policy NLRI Prefix.
+      type: object 
+      properties:
+        address:
+          description: >-
+            The IPv4 address of the network.
+          type: string
+          format: ipv4
+          x-field-uid: 1
+        prefix:
+          description: >-
+            The IPv4 network prefix length to be applied to the address. 
+          type: integer
+          format: uint32
+          default: 24
+          maximum: 32
+          x-field-uid: 2
+        path_id:
+          $ref: '#/components/schemas/Bgp.NLRIPrefixPathId'
+          x-field-uid: 3
+        segment_routing_distinguisher:
+          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingDistinguisher'
+          x-field-uid: 4
+        segment_routing_color:
+          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingColor'
+          x-field-uid: 5
+
+    Bgp.OneIpv6SrPolicyNLRIPrefix:
+      description: >-
+          One IPv6 Segment Routing Policy NLRI Prefix.
+      type: object 
+      properties:
+        address:
+          description: >-
+            The IPv6 address of the network.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        prefix:
+          description: >-
+            The IPv6 network prefix length to be applied to the address. 
+          type: integer
+          format: uint32
+          default: 64
+          maximum: 128        
+          x-field-uid: 2
+        path_id:
+          $ref: '#/components/schemas/Bgp.NLRIPrefixPathId'
+          x-field-uid: 3
+        segment_routing_distinguisher:
+          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingDistinguisher'
+          x-field-uid: 4
+        segment_routing_color:
+          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingColor'
+          x-field-uid: 5         
+
+    Bgp.NLRIPrefixSegmentRoutingDistinguisher:
+      description: >-
+          Optional field in the NLRI carrying the distinguisher for Segment Routing Policy NLRI with SAFI 73.
+      type: object 
+      properties:
+        value:
+          description: >-
+            The value of the optional Segment Routing distinguisher of the prefix. 
+          type: integer
+          format: uint32
+          default: 1          
+          x-field-uid: 1
+    Bgp.NLRIPrefixSegmentRoutingColor:
+      description: >-
+          Optional field in the NLRI carrying color for Segment Routing Policy NLRI with SAFI 73.
+      type: object 
+      properties:
+        value:
+          description: >-
+            The value of the optional Segment Routing color of the prefix. 
+          type: integer
+          format: uint32
+          default: 1          
+          x-field-uid: 1
+
     Bgp.Attributes:
       description: |-
           Attributes carried in the Update packet alongwith the reach/unreach prefixes.
@@ -272,6 +356,9 @@ components:
           items:
             $ref: './bgpextendedcommunity.yaml#/components/schemas/Bgp.ExtendedCommunity'
           x-field-uid: 14
+        tunnel_encapsulation:
+          $ref: '#/components/schemas/Bgp.Attributes.TunnelEncapsulation'
+          x-field-uid: 15
         mp_reach:
           $ref: '#/components/schemas/Bgp.Attributes.MpReachNlri'
           x-field-uid: 16
@@ -653,6 +740,8 @@ components:
         The following AFI / SAFI combinations are supported:
         - IPv4 Unicast with AFI as 1 and SAFI as 1 
         - IPv6 Unicast with AFI as 2 and SAFI as 1 
+        - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73
+        - Segment Routing Policy for IPv6 Unicast with AFI as 2 and SAFI as 73
       type: object
       required: [choice]
       properties:
@@ -669,6 +758,10 @@ components:
                 x-field-uid: 1
               ipv6_unicast:
                 x-field-uid: 2
+              ipv4_srpolicy:
+                x-field-uid: 3
+              ipv6_srpolicy:
+                x-field-uid: 4
         ipv4_unicast:    
           description: >-
             List of IPv4 prefixes being sent in the IPv4 Unicast MPREACH_NLRI .
@@ -678,13 +771,25 @@ components:
           x-field-uid: 3
         ipv6_unicast:    
           description: >-
-            SAFI of the NLRI being sent in the Update.
-                   description: >-
             List of IPv6 prefixes being sent in the IPv6 Unicast MPREACH_NLRI .
           type: array
           items:
             $ref: '#/components/schemas/Bgp.OneIpv6NLRIPrefix'
           x-field-uid: 4
+        ipv4_srpolicy:    
+          description: >-
+            List of IPv4 prefixes with Segment Routing Policy being sent in the IPv4 MPREACH_NLRI .
+          type: array
+          items:
+            $ref: '#/components/schemas/Bgp.OneIpv4SrPolicyNLRIPrefix'
+          x-field-uid: 5
+        ipv6_srpolicy:    
+          description: >-
+            List of IPv6 prefixes with Segment Routing Policy being sent in the IPv6 MPREACH_NLRI .            
+          type: array
+          items:
+            $ref: '#/components/schemas/Bgp.OneIpv6SrPolicyNLRIPrefix'
+          x-field-uid: 6
 
     Bgp.Attributes.MpUnreachNlri:
       description: |-
@@ -692,6 +797,8 @@ components:
         The following AFI / SAFI combinations are supported:
         - IPv4 Unicast with AFI as 1 and SAFI as 1 
         - IPv6 Unicast with AFI as 2 and SAFI as 1 
+        - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73
+        - Segment Routing Policy for IPv6 Unicast with AFI as 2 and SAFI as 73
       type: object
       properties:
         choice:
@@ -704,6 +811,10 @@ components:
                 x-field-uid: 1
               ipv6_unicast:
                 x-field-uid: 2
+              ipv4_srpolicy:
+                x-field-uid: 3
+              ipv6_srpolicy:
+                x-field-uid: 4
         ipv4_unicast:    
           description: >-
             List of IPv4 prefixes being sent in the IPv4 Unicast MPUNREACH_NLRI .
@@ -719,7 +830,21 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Bgp.OneIpv6NLRIPrefix'
-          x-field-uid: 3        
+          x-field-uid: 3
+        ipv4_srpolicy:    
+          description: >-
+            List of IPv4 prefixes with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI .
+          type: array
+          items:
+            $ref: '#/components/schemas/Bgp.OneIpv4SrPolicyNLRIPrefix'
+          x-field-uid: 4
+        ipv6_srpolicy:    
+          description: >-
+            List of IPv6 prefixes with Segment Routing Policy being sent in the IPv6 MPUNREACH_NLRI .            
+          type: array
+          items:
+            $ref: '#/components/schemas/Bgp.OneIpv6SrPolicyNLRIPrefix'
+          x-field-uid: 5        
     Bgp.Attributes.MultiExitDiscriminator:
       description: |-
          Optional MULTI_EXIT_DISCRIMINATOR attribute sent to the peer to help in the route selection process. 
@@ -755,5 +880,954 @@ components:
           type: string
           format: ipv4
           default: "0.0.0.0"
+          x-field-uid: 1
+
+    Bgp.Attributes.TunnelEncapsulation:
+      description: |-
+         The TUNNEL_ENCAPSULATION  attribute is used by a BGP speaker to inform other BGP speakers how to encapsulate packets that need to be sent to it.
+         It is defined in RFC9012 and is assigned a Type code of 23.
+      properties: 
+        choice:
+          description: >-
+            Identifies a type of tunnel. The field contains values from the IANA registry "BGP Tunnel Encapsulation Attribute Tunnel Types".
+          type: string
+          x-field-uid: 1
+          x-enum:
+            sr_policy:
+              x-field-uid: 1
+          default: sr_policy
+        sr_policy:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy'
+          x-field-uid: 2
+    Bgp.Attributes.SegmentRoutingPolicy:
+      description: |-
+        Optional Segment Routing Policy information as defined in draft-ietf-idr-segment-routing-te-policy.
+        This information is carried in TUNNEL_ENCAPSULATION attribute with type set to  SR Policy (15).
+        - [From .proto :
+          message PaPolicy {
+            optional PaBindingSegmentIdentifier bsid = 1;
+            optional PaPreference preference = 2;
+            repeated PaSegmentList segment_lists = 3;
+            optional PaPriority priority = 4;
+            optional PaPolicyName policy_name = 5;
+            optional PaExplicitNullLabelPolicy explicit_null_label_policy = 6;
+          } 
+         ] 
+      type: object 
+      properties:
+        binding_segment_identifier:
+          description: |-
+            When the active candidate path has a specified Binding Segment Identifier, 
+            the SR Policy uses that BSID if this value (label in MPLS, IPv6 address in SRv6) is available.
+            The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy
+            Section 2.4.2 .
+            - [.proto:
+              message PaBindingSegmentIdentifier {
+                optional bool specified_bsid_only = 1;  // S-flag.
+                optional bool drop_upon_invalid = 2;    // I-flag. 
+                oneof sid {
+                  PaSegment.MPLS mpls = 4;
+                  monitoring.raven.IPAddressProto ipv6 = 5;
+                }
+              }
+            ]
+          $ref: '#/components/schemas/Bgp.Attributes.Bsid'
+          x-field-uid:  1          
+        prerefence:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.Preference'
+          x-field-uid: 2
+        priority:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.Priority'
+          x-field-uid: 3
+        policy_name:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.PolicyName'
+          x-field-uid: 4
+        explicit_null_policy:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.ExplicitNullPolicy'
+          x-field-uid: 5
+        segment_list:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.SegmentList'
+          x-field-uid: 6
+    Bgp.Attributes.Bsid:
+      description: |-
+        When the active candidate path has a specified Binding Segment Identifier, the SR Policy uses that 
+        BSID if this value (label in MPLS, IPv6 address in SRv6) is available.
+        - The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy Section 2.4.2 .
+        - [.proto:
+              message PaBindingSegmentIdentifier {
+                optional bool specified_bsid_only = 1;  // S-flag.
+                optional bool drop_upon_invalid = 2;    // I-flag. 
+                oneof sid {
+                  PaSegment.MPLS mpls = 4;
+                  monitoring.raven.IPAddressProto ipv6 = 5;
+                }
+              }
+            ]
+      type: object
+      required: [choice]
+      properties:
+        choice:
+          description: >-
+            The type of Segment Identifier.   
+          type: string
+          x-field-uid: 1
+          x-enum:
+            mpls:
+              x-field-uid: 1
+            srv6:
+              x-field-uid: 2
+        mpls:
+          $ref: '#/components/schemas/Bgp.Attributes.Bsid.Mpls'
+          x-field-uid: 2
+        srv6:
+          $ref: '#/components/schemas/Bgp.Attributes.Bsid.Srv6'
+          x-field-uid: 3
+    Bgp.Attributes.Bsid.Mpls:
+      description: |-
+        When the active candidate path has a specified Binding Segment Identifier, the SR Policy uses that BSID defined 
+        as a MPLS label.The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy  Section 2.4.2 .
+      type: object
+      properties:
+        flag_specified_bsid_only:
+          description: |-
+            S-Flag: This flag encodes the "Specified-BSID-only" behavior. It's usage is 
+            described in section 6.2.3 in [RFC9256].
+          type: boolean
+          default: false
+          x-field-uid: 1
+        flag_drop_upon_invalid:
+          description: |-
+            I-Flag: This flag encodes the "Drop Upon Invalid" behavior. 
+            It's usage is described in section 8.2 in [RFC9256].
+          type: boolean
+          default: false
+          x-field-uid: 2
+        mpls_sid:
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
+          x-field-uid: 3
+    Bgp.Attributes.Bsid.Srv6:
+      description: |-
+        When the active candidate path has a specified Binding Segment Identifier, the SR Policy uses that BSID defined 
+        as an IPv6 Address.The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy Section 2.4.2 .
+      type: object
+      properties:
+        flag_specified_bsid_only:
+          description: |-
+            S-Flag: This flag encodes the "Specified-BSID-only" behavior. It's usage is 
+            described in section 6.2.3 in [RFC9256].
+          type: boolean
+          default: false
+          x-field-uid: 1
+        flag_drop_upon_invalid:
+          description: |-
+            I-Flag: This flag encodes the "Drop Upon Invalid" behavior. 
+            It's usage is described in section 8.2 in [RFC9256].
+          type: boolean
+          default: false
+          x-field-uid: 2
+        flag_srv6_endpoint_behavior:
+          description: |-
+            B-Flag: This flag, when set, indicates the presence of the SRv6 Endpoint Behavior 
+            and SID Structure encoding specified in Section 2.4.4.2.4 of draft-ietf-idr-segment-routing-te-policy.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        ipv6_addr:
+          description: >-
+            IPv6 address denoting the SRv6 SID.
+          type: string          
+          format: ipv6
+          default: 0::0
+          x-field-uid: 4
+    Bgp.Attributes.Sid.Mpls:
+      description: |-
+        This carries a 20 bit Multi Protocol Label Switching alongwith 3 bits traffic class, 1 bit indicating presence
+        or absence of Bottom-Of-Stack and 8 bits carrying the Time to Live value. 
+        - [.proto : 
+            // Segment identified by MPLS label.
+          message MPLS {
+            optional uint32 label = 1;          // 20 bits.
+            optional uint32 traffic_class = 2;  // 3 bits (TC).
+            optional bool bottom_of_stack = 3;  // 1 bit (S).
+            optional uint32 time_to_live = 4;   // 8 bits (TTL).
+          }
+        ]
+      type: object 
+      properties:
+        label:
+          description: |- 
+            20 bit MPLS Label value.
+          type: integer
+          format: uint32
+          default: 16
+          maximum: 1048576
+          x-field-uid: 1
+        traffic_class:
+          description: |- 
+            3 bits of Traffic Class.
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        flag_bos:
+          description: |-
+            Bottom of Stack
+          type: boolean
+          default: true 
+          x-field-uid: 3
+        ttl:
+          description: |- 
+            8 bits Time to Live
+          type: integer
+          format: uint32
+          default: 63
+          maximum: 63
+          x-field-uid: 4
+    Bgp.Attributes.SrPolicy.Preference:
+      description: |
+        Optional Preference sub-tlv used to select the best candidate path for an SR Policy.
+      type: object
+      properties:
+        value:
+          description: |-
+            Value to be carried in the Preference sub-tlv.
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 1
+
+    Bgp.Attributes.SrPolicy.Priority:
+      description: |
+        Optional Priority sub-tlv used to select the order in which policies should be re-computed.
+      type: object
+      properties:
+        value:
+          description: |-
+            Value to be carried in the Priority sub-tlv.            
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 1
+
+    Bgp.Attributes.SrPolicy.PolicyName:
+      description: |-   
+        Optional Policy Name sub-tlv which carries the symbolic name for the SR Policy candidate path for debugging.    
+      type: object
+      required: [value]
+      properties:
+        value:
+          description: |-
+            Value of the symbolic policy name carried in the Policy Name sub-tlv.
+            It is recommended that the size of the name is limited to 255 bytes.
+          type: string          
+          maxLength: 500
+          x-field-uid: 1
+
+    Bgp.Attributes.SrPolicy.ExplicitNullPolicy:
+      description: |-
+        This is an optional sub-tlv . 
+        If included , it Indicates whether an Explicit NULL Label must be pushed on an unlabeled IP
+        packet before other labels for IPv4 or IPv6 flows.
+      properties:
+        choice:
+          description: >-
+            The Explicit NULL Label policy.
+          type: string
+          x-field-uid: 1
+          x-enum:
+            unknown:
+              x-field-uid: 1
+            push_ipv4:
+              x-field-uid: 2
+            push_ipv6:
+              x-field-uid: 3
+            push_ipv4_and_ipv6:
+              x-field-uid: 4
+            donot_push:
+              x-field-uid: 5
+          default: push_ipv4_and_ipv6
+    Bgp.Attributes.SrPolicy.SegmentList:
+      description: |-
+        One optional SEGMENT_LIST sub-tlv encoded with type of 128.
+        One sub-tlv encodes a single explicit path towards the endpoint as described in 
+        section 5.1 of [RFC9256]. 
+        The Segment List sub-TLV includes the elements of the paths (i.e., segments) as well 
+        as an optional Weight sub-TLV.
+        - [.proto :
+          // Contains one "segment (label) stack" with its weight. The weight is used for
+          // weighted multipath.
+          message PaSegmentList {
+            message Weight {
+              optional uint32 value = 1;
+            }
+            optional Weight weight = 1;
+            repeated PaSegment segments = 2;
+          }
+        ]
+      type: object
+      properties:
+        weight:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SegmentList.Weight'
+          x-field-uid:  1
+        segments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SegmentList.Segment'
+          x-field-uid:  2
+    Bgp.Attributes.SegmentRoutingPolicy.SegmentList.Weight:
+      description:
+        The optional Weight sub-TLV specifies the weight associated with a given segment list.
+        The weight is used for weighted multipath.
+      type: object
+      properties:
+        value:
+          description: Value of the weight.
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 1
+    Bgp.Attributes.SegmentRoutingPolicy.SegmentList.Segment:
+      description: |-
+        A Segment sub-TLV describes a single segment in a segment list  i.e., a single
+        element of the explicit path. The Segment sub-TLVs are optional.
+        - [.proto :
+          // This defines one segment. The distinction between a "segment" and a "segment
+          // identifier" (SID) is basically non-existent; these objects can be seen as
+          // either.
+          message PaSegment {
+            message Flags {  // 8 bits in total.
+              // V-flag. Indicates verification is enabled. See section 5,
+              // https://tools.ietf.org/html/draft-ietf-spring-segment-routing-policy-01
+              optional bool verification = 1;
+              // A-flag. Indicates presence of SR Algorithm field applicable to Segment
+              // Types 3, 4, and 9.
+              optional bool algorithm = 2;
+            }
+            // Segment identified by MPLS label.
+            message MPLS {
+              optional uint32 label = 1;          // 20 bits.
+              optional uint32 traffic_class = 2;  // 3 bits (TC).
+              optional bool bottom_of_stack = 3;  // 1 bit (S).
+              optional uint32 time_to_live = 4;   // 8 bits (TTL).
+            }
+            // SID only, in the form of MPLS Label.
+            message Type1 {
+              optional Flags flags = 1;
+              optional MPLS sid = 2;
+            }
+            // SID only, in the form of IPv6 address.
+            message Type2 {
+              optional Flags flags = 1;
+              optional monitoring.raven.IPAddressProto sid = 2;
+            }
+            // IPv4 Node Address with optional SID.
+            message Type3 {
+              optional Flags flags = 1;
+              optional PaAlgorithm algorithm = 2;
+              optional monitoring.raven.IPAddressProto node_address = 3;
+              optional MPLS sid = 4;
+            }
+            // IPv6 Node Address with optional SID for SR MPLS.
+            message Type4 {
+              optional Flags flags = 1;
+              optional PaAlgorithm algorithm = 2;
+              optional monitoring.raven.IPAddressProto node_address = 3;
+              optional MPLS sid = 4;
+            }
+            // IPv4 Address + index with optional SID.
+            message Type5 {
+              optional Flags flags = 1;
+              optional uint32 local_interface_id = 2;
+              optional monitoring.raven.IPAddressProto node_address = 3;
+              optional MPLS sid = 4;
+            }
+            // IPv4 Local and Remote addresses with optional SID.
+            message Type6 {
+              optional Flags flags = 1;
+              optional monitoring.raven.IPAddressProto local_address = 2;
+              optional monitoring.raven.IPAddressProto remote_address = 3;
+              optional MPLS sid = 4;
+            }
+            // IPv6 Address + index for local and remote pair with optional SID for SR
+            // MPLS.
+            message Type7 {
+              optional Flags flags = 1;
+              optional uint32 local_interface_id = 2;
+              optional monitoring.raven.IPAddressProto local_node_address = 3;
+              // `remote_interface_id` and `remote_node_address` pair is optional. Both
+              // must be present or both must be absent.
+              optional uint32 remote_interface_id = 4;
+              optional monitoring.raven.IPAddressProto remote_node_address = 5;
+              optional MPLS sid = 6;
+            }
+            // IPv6 Local and Remote addresses with optional SID for SR MPLS.
+            message Type8 {
+              optional Flags flags = 1;
+              optional monitoring.raven.IPAddressProto local_address = 2;
+              optional monitoring.raven.IPAddressProto remote_address = 3;
+              optional MPLS sid = 4;
+            }
+            // IPv6 Node Address with optional SID for SRv6.
+            message Type9 {
+              optional Flags flags = 1;
+              optional PaAlgorithm algorithm = 2;
+              optional monitoring.raven.IPAddressProto node_address = 3;
+              optional monitoring.raven.IPAddressProto sid = 4;
+            }
+            // IPv6 Address + index for local and remote pair with optional SID for SRv6.
+            message Type10 {
+              optional Flags flags = 1;
+              optional uint32 local_interface_id = 2;
+              optional monitoring.raven.IPAddressProto local_node_address = 3;
+              // `remote_interface_id` and `remote_node_address` pair is optional. Both
+              // must be present or both must be absent.
+              optional uint32 remote_interface_id = 4;
+              optional monitoring.raven.IPAddressProto remote_node_address = 5;
+              optional monitoring.raven.IPAddressProto sid = 6;
+            }
+            // IPv6 Local and Remote addresses for SRv6.
+            message Type11 {
+              optional Flags flags = 1;
+              optional monitoring.raven.IPAddressProto local_address = 2;
+              optional monitoring.raven.IPAddressProto remote_address = 3;
+              optional monitoring.raven.IPAddressProto sid = 4;
+            }
+
+            oneof segment {
+              Type1 type1 = 1;
+              Type2 type2 = 2;
+              Type3 type3 = 3;
+              Type4 type4 = 4;
+              Type5 type5 = 5;
+              Type6 type6 = 6;
+              Type7 type7 = 7;
+              Type8 type8 = 8;
+              Type9 type9 = 9;
+              Type10 type10 = 10;
+              Type11 type11 = 11;
+            }
+          }
+        ]
+      type: object
+      required: [choice]
+      properties:
+        choice:
+          description: |-
+            Specify one of the segment types as defined in ietf-idr-segment-routing-te-policy
+            - Type  A: SID only, in the form of MPLS Label.
+            - Type  B: SID only, in the form of IPv6 Address.
+            - Type  C: IPv4 Node Address with optional SID.
+            - Type  D: IPv6 Node Address with optional SID for SR MPLS.
+            - Type  E: IPv4 Address and index with optional SID.
+            - Type  F: IPv4 Local and Remote addresses with optional SID.
+            - Type  G: IPv6 Address and index for local and remote pair with optional SID for SR MPLS.
+            - Type  H: IPv6 Local and Remote addresses with optional SID for SR MPLS.
+            - Type  I: IPv6 Node Address with optional SID for SRv6.
+            - Type  J: IPv6 Address and index for local and remote pair with optional SID for SRv6.
+            - Type  K: IPv6 Local and Remote addresses for SRv6.
+          type: string
+          x-field-uid: 1
+          x-enum:
+            type_a:
+              x-field-uid: 1
+            type_b:
+              x-field-uid: 2
+            type_c:
+              x-field-uid: 3
+            type_d:
+              x-field-uid: 4
+            type_e:
+              x-field-uid: 5
+            type_f:
+              x-field-uid: 6
+            type_g:
+              x-field-uid: 7
+            type_h:
+              x-field-uid: 8
+            type_i:
+              x-field-uid: 9
+            type_j:
+              x-field-uid: 10
+            type_k:
+              x-field-uid: 11
+        type_a:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeA'
+          x-field-uid: 2     
+        type_b:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeB'
+          x-field-uid: 3
+        type_c:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeC'
+          x-field-uid: 4
+        type_d:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeD'
+          x-field-uid: 5
+        type_e:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeE'
+          x-field-uid: 6
+        type_f:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeF'
+          x-field-uid: 7
+        type_g:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeG'
+          x-field-uid: 8
+        type_h:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeH'
+          x-field-uid: 9
+        type_i:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeI'
+          x-field-uid: 10
+        type_j:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeJ'
+          x-field-uid: 11
+        type_k:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeK'
+          x-field-uid: 12
+    Bgp.Attributes.SegmentRoutingPolicy.TypeA:
+      description: |- 
+        Type  A: SID only, in the form of MPLS Label.
+        It is encoded as a Segment of Type 1 in the SEGMENT_LIST sub-tlv.
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        mpls_sid:
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
+          x-field-uid: 2
+    Bgp.Attributes.SegmentRoutingPolicy.TypeB:
+      description: |- 
+        Type B: SID only, in the form of IPv6 address.
+        It is encoded as a Segment of Type 2 in the SEGMENT_LIST sub-tlv.
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        srv6_sid:
+          description: >-
+            SRv6 SID.
+          type: string
+          format: ipv6
+          default : "0::0"
+          x-field-uid: 2
+        srv6_endpoint_behavior:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
+          x-field-uid: 3           
+    Bgp.Attributes.SegmentRoutingPolicy.TypeC:
+      description: |- 
+        Type C: IPv4 Node Address with optional SID.
+        It is encoded as a Segment of Type 3 in the SEGMENT_LIST sub-tlv.
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        sr_algorithm:
+          description: >-
+            SR Algorithm identifier when A-Flag in on. If A-flag is not enabled, it should be set to 0 on transmission and
+            ignored on receipt.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        ipv4_node_address:
+          description: >-
+            IPv4 address representing a node.
+          type: string
+          format: ipv4
+          default: "0.0.0.0"
+          x-field-uid: 3
+        sr_mpls_sid:
+          description: >-
+            Optional SR-MPLS SID.
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
+          x-field-uid: 4
+    Bgp.Attributes.SegmentRoutingPolicy.TypeD:
+      description: |- 
+        Type D: IPv6 Node Address with optional SID for SR MPLS.
+        It is encoded as a Segment of Type 4 in the SEGMENT_LIST sub-tlv.        
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        sr_algorithm:
+          description: >-
+            SR Algorithm identifier when A-Flag in on. If A-flag is not enabled, it should be set to 0 on transmission and
+            ignored on receipt.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        ipv6_node_address:
+          description: >-
+            IPv6 address representing a node.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 3
+        sr_mpls_sid:
+          description: >-
+            Optional SR-MPLS SID.
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
+          x-field-uid: 4
+    Bgp.Attributes.SegmentRoutingPolicy.TypeE:
+      description: |- 
+        Type E: IPv4 Address and Local Interface ID with optional SID
+        It is encoded as a Segment of Type 5 in the SEGMENT_LIST sub-tlv. 
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        local_interface_id:
+          description: >-
+            The Interface Index as defined in [RFC8664].
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 2
+        ipv4_node_address:
+          description: >-
+            IPv4 address representing a node.
+          type: string
+          format: ipv4
+          default: "0.0.0.0"
+          x-field-uid: 3
+        sr_mpls_sid:
+          description: >-
+            Optional SR-MPLS SID.
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
+          x-field-uid: 4
+    Bgp.Attributes.SegmentRoutingPolicy.TypeF:
+      description: |- 
+        Type F: IPv4 Local and Remote addresses with optional SID.
+        It is encoded as a Segment of Type 6 in the SEGMENT_LIST sub-tlv. 
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        local_ipv4_address:
+          description: >-
+            Local IPv4 Address.
+          type: string
+          format: ipv4
+          default: "0.0.0.0"
+          x-field-uid: 2
+        remote_ipv4_address:
+          description: >-
+            Remote IPv4 Address.
+          type: string
+          format: ipv4
+          default: "0.0.0.0"
+          x-field-uid: 3
+        sr_mpls_sid:
+          description: >-
+            Optional SR-MPLS SID.
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
+          x-field-uid: 4
+    Bgp.Attributes.SegmentRoutingPolicy.TypeG:
+      description: |- 
+        Type G: IPv6 Address, Interface ID for local and remote pair with optional SID for SR MPLS.
+        It is encoded as a Segment of Type 7 in the SEGMENT_LIST sub-tlv. 
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        local_interface_id:
+          description: >-
+            The local Interface Index as defined in [RFC8664].
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 2
+        local_ipv6_node_address:
+          description: >-
+            The IPv6 address representing the local node.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 3
+        remote_interface_id:
+          description: >-
+            The remote Interface Index as defined in [RFC8664].
+            The value MAY be set to zero when the local node address and interface identifiers are sufficient to describe the link.
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 4
+        remote_ipv6_node_address:
+          description: >-
+            IPv6 address representing the remote node.
+            The value MAY be set to zero when the local node address and interface identifiers are sufficient to describe the link.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 5
+        sr_mpls_sid:
+          description: >-
+            Optional SR-MPLS SID.
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
+          x-field-uid: 6
+    Bgp.Attributes.SegmentRoutingPolicy.TypeH:
+      description: |- 
+        Type H: IPv6 Local and Remote addresses with optional SID for SR MPLS.
+        It is encoded as a Segment of Type 8 in the SEGMENT_LIST sub-tlv. 
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        local_ipv6_address:
+          description: >-
+            Local IPv6 Address.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 2
+        remote_ipv6_address:
+          description: >-
+            Remote IPv6 Address.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 3
+        sr_mpls_sid:
+          description: >-
+            Optional SR-MPLS SID.
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Mpls'
+          x-field-uid: 6
+    Bgp.Attributes.SegmentRoutingPolicy.TypeI:
+      description: |- 
+        Type I: IPv6 Node Address with optional SRv6 SID.
+        It is encoded as a Segment of Type 9 in the SEGMENT_LIST sub-tlv. 
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        sr_algorithm:
+          description: >-
+            SR Algorithm identifier when A-Flag in on. If A-flag is not enabled, it should be set to 0 on transmission and
+            ignored on receipt.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        ipv6_node_address:
+          description: >-
+            IPv6 address representing a node.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 3
+        srv6_sid:
+          description: >-
+            Optional SRv6 SID.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 4
+        srv6_endpoint_behavior:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
+          x-field-uid: 5 
+    Bgp.Attributes.SegmentRoutingPolicy.TypeJ:
+      description: |- 
+        Type J: IPv6 Address, Interface ID for local and remote pair for SRv6 with optional SID.
+        It is encoded as a Segment of Type 10 in the SEGMENT_LIST sub-tlv. 
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        sr_algorithm:
+          description: >-
+            SR Algorithm identifier when A-Flag in on. If A-flag is not enabled, it should be set to 0 on transmission and
+            ignored on receipt.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        local_interface_id:
+          description: >-
+            The local Interface Index as defined in [RFC8664].
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 3
+        local_ipv6_node_address:
+          description: >-
+            The IPv6 address representing the local node.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 4
+        remote_interface_id:
+          description: >-
+            The remote Interface Index as defined in [RFC8664].
+            The value MAY be set to zero when the local node address and interface identifiers are sufficient to describe the link.
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 5
+        remote_ipv6_node_address:
+          description: >-
+            IPv6 address representing the remote node.
+            The value MAY be set to zero when the local node address and interface identifiers are sufficient to describe the link.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 6
+        srv6_sid:
+          description: >-
+            Optional SRv6 SID.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 7
+        srv6_endpoint_behavior:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
+          x-field-uid: 8
+    Bgp.Attributes.SegmentRoutingPolicy.TypeK:
+      description: |- 
+        Type K: IPv6 Local and Remote addresses for SRv6 with optional SID.
+        It is encoded as a Segment of Type 11 in the SEGMENT_LIST sub-tlv. 
+      type: object
+      properties:
+        flags:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
+          x-field-uid: 1
+        local_ipv6_address:
+          description: >-
+            Local IPv6 Address.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 2
+        remote_ipv6_address:
+          description: >-
+            Remote IPv6 Address.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 3
+        srv6_sid:
+          description: >-
+            Optional SRv6 SID.
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 4
+        srv6_endpoint_behavior:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
+          x-field-uid: 5 
+    Bgp.Attributes.SegmentRoutingPolicy.TypeFlags:
+      description: |-
+        Flags for each Segment in SEGMENT_LIST sub-tlv.
+        - V-flag. Indicates verification is enabled. See section 5, of https://datatracker.ietf.org/doc/html/rfc9256
+        - A-flag. Indicates presence of SR Algorithm field applicable to Segment Types 3, 4, and 9.
+        - B-Flag. Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding.  
+        - [.proto:
+            message Flags {  // 8 bits in total.
+              // V-flag. Indicates verification is enabled. See section 5,
+              // https://tools.ietf.org/html/draft-ietf-spring-segment-routing-policy-01
+              optional bool verification = 1;
+              // A-flag. Indicates presence of SR Algorithm field applicable to Segment
+              // Types 3, 4, and 9.
+              optional bool algorithm = 2;
+        }]
+      type: object 
+      properties:
+        v_flag:
+          description: |-
+            Indicates verification of segment data in is enabled.            
+          type: boolean
+          default: false
+          x-field-uid: 1
+        a_flag:
+          description: |-
+            Indicates presence of SR Algorithm field applicable to Segment Types 3, 4, and 9.           
+          type: boolean
+          default: false
+          x-field-uid: 2
+        b_flag:
+          description: |-
+            Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding specified in Section 2.4.4.2.4
+            of draft-ietf-idr-segment-routing-te-policy.         
+          type: boolean
+          default: false
+          x-field-uid: 3
+    Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure:
+      description: >-
+        Configuration for optional SRv6 Endpoint Behavior and SID Structure.
+        Summation of lengths for Locator Block, Locator Node,  Function, and Argument MUST be less than or equal to 128.
+        - This is specified in draft-ietf-idr-segment-routing-te-policy Section 2.4.4.2.4
+      type: object
+      properties:
+        lb_length:
+          description: >-
+            SRv6 SID Locator Block length in bits.
+          type: integer
+          format: uint32
+          maximum: 128
+          default: 0
+          x-field-uid: 1
+        ln_length:
+          description: >-
+            SRv6 SID Locator Node length in bits.
+          type: integer
+          format: uint32
+          maximum: 128
+          default: 0
+          x-field-uid: 2
+        func_length:
+          description: >-
+            SRv6 SID Function length in bits.
+          type: integer
+          format: uint32
+          maximum: 128
+          default: 0
+          x-field-uid: 3
+        arg_length:
+          description: >-
+            SRv6 SID Arguments length in bits.
+          type: integer
+          format: uint32
+          maximum: 128
+          default: 0
+          x-field-uid: 4   
+
+    Bgp.NLRIPrefixSegmentRoutingDistinguisher:
+      description: >-
+          Optional field in the NLRI carrying the distinguisher for Segment Routing Policy NLRI with SAFI 73.
+      type: object 
+      properties:
+        value:
+          description: >-
+            The value of the optional Segment Routing distinguisher of the prefix. 
+          type: integer
+          format: uint32
+          default: 1          
+          x-field-uid: 1
+    Bgp.NLRIPrefixSegmentRoutingColor:
+      description: >-
+          Optional field in the NLRI carrying color for Segment Routing Policy NLRI with SAFI 73.
+      type: object 
+      properties:
+        value:
+          description: >-
+            The value of the optional Segment Routing color of the prefix. 
+          type: integer
+          format: uint32
+          default: 1          
           x-field-uid: 1
 

--- a/device/bgp/bgpupdatereplay.yaml
+++ b/device/bgp/bgpupdatereplay.yaml
@@ -185,89 +185,69 @@ components:
           default: 1          
           x-field-uid: 1
     
-    Bgp.OneIpv4SrPolicyNLRIPrefix:     
+    Bgp.Ipv4SrPolicyNLRIPrefix:     
       description: >-
-          One IPv4 Segment Routing Policy NLRI Prefix.
+          IPv4 Segment Routing Policy NLRI Prefix.
       type: object 
       properties:
-        address:
-          description: >-
-            The IPv4 address of the network.
-          type: string
-          format: ipv4
-          x-field-uid: 1
-        prefix:
-          description: >-
-            The IPv4 network prefix length to be applied to the address. 
+        distinguisher:
+          description: >-        
+            The 4-octet value uniquely identifying the policy in the context of <color, endpoint> tuple. 
+            The distinguisher has no semantic value and is solely used by the SR Policy originator to make unique (from an NLRI perspective) 
+            both for multiple candidate paths of the same SR Policy as well as candidate paths of different SR Policies 
+            (i.e. with different segment lists) with the same Color and Endpoint but meant for different headends. 
           type: integer
           format: uint32
-          default: 24
-          maximum: 32
+          default: 1          
+          x-field-uid: 1          
+        color:
+          description: >-
+            4-octet value identifying (with the endpoint) the policy. The color is used to match the color of the destination 
+            prefixes to steer traffic into the SR Policy as specified in section 8 of RFC9256.
+          type: integer
+          format: uint32
+          default: 1          
           x-field-uid: 2
-        path_id:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixPathId'
+        endpoint:
+          description: >-
+            Identifies the endpoint of a policy. 
+            The Endpoint is an IPv4 address and can be either a unicast or an unspecified address (0.0.0.0) as specified in section 2.1 of RFC9256.
+          type: string
+          format: ipv4
+          default: "0.0.0.0"
           x-field-uid: 3
-        segment_routing_distinguisher:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingDistinguisher'
-          x-field-uid: 4
-        segment_routing_color:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingColor'
-          x-field-uid: 5
-
-    Bgp.OneIpv6SrPolicyNLRIPrefix:
+    Bgp.Ipv6SrPolicyNLRIPrefix:
       description: >-
           One IPv6 Segment Routing Policy NLRI Prefix.
       type: object 
       properties:
-        address:
+        distinguisher:
+          description: >-        
+            The 4-octet value uniquely identifying the policy in the context of <color, endpoint> tuple. 
+            The distinguisher has no semantic value and is solely used by the SR Policy originator to make unique (from an NLRI perspective) 
+            both for multiple candidate paths of the same SR Policy as well as candidate paths of different SR Policies 
+            (i.e. with different segment lists) with the same Color and Endpoint but meant for different headends. 
+          type: integer
+          format: uint32
+          default: 1          
+          x-field-uid: 1          
+        color:
           description: >-
-            The IPv6 address of the network.
+            4-octet value identifying (with the endpoint) the policy. The color is used to match the color of the destination 
+            prefixes to steer traffic into the SR Policy as specified in section 8 of RFC9256.
+          type: integer
+          format: uint32
+          default: 1          
+          x-field-uid: 2
+        endpoint:
+          description: >-
+            Identifies the endpoint of a policy. 
+            The Endpoint may represent a single node or a set of nodes (e.g., an anycast address).
+            The Endpoint is an IPv6 address and can be either a unicast or an unspecified address (0::0) as specified in section 2.1 of RFC9256.
           type: string
           format: ipv6
-          x-field-uid: 1
-        prefix:
-          description: >-
-            The IPv6 network prefix length to be applied to the address. 
-          type: integer
-          format: uint32
-          default: 64
-          maximum: 128        
-          x-field-uid: 2
-        path_id:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixPathId'
-          x-field-uid: 3
-        segment_routing_distinguisher:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingDistinguisher'
-          x-field-uid: 4
-        segment_routing_color:
-          $ref: '#/components/schemas/Bgp.NLRIPrefixSegmentRoutingColor'
-          x-field-uid: 5         
-
-    Bgp.NLRIPrefixSegmentRoutingDistinguisher:
-      description: >-
-          Optional field in the NLRI carrying the distinguisher for Segment Routing Policy NLRI with SAFI 73.
-      type: object 
-      properties:
-        value:
-          description: >-
-            The value of the optional Segment Routing distinguisher of the prefix. 
-          type: integer
-          format: uint32
-          default: 1          
-          x-field-uid: 1
-    Bgp.NLRIPrefixSegmentRoutingColor:
-      description: >-
-          Optional field in the NLRI carrying color for Segment Routing Policy NLRI with SAFI 73.
-      type: object 
-      properties:
-        value:
-          description: >-
-            The value of the optional Segment Routing color of the prefix. 
-          type: integer
-          format: uint32
-          default: 1          
-          x-field-uid: 1
-
+          default: "0::0"
+          x-field-uid: 3   
     Bgp.Attributes:
       description: |-
           Attributes carried in the Update packet alongwith the reach/unreach prefixes.
@@ -778,17 +758,13 @@ components:
           x-field-uid: 4
         ipv4_srpolicy:    
           description: >-
-            List of IPv4 prefixes with Segment Routing Policy being sent in the IPv4 MPREACH_NLRI .
-          type: array
-          items:
-            $ref: '#/components/schemas/Bgp.OneIpv4SrPolicyNLRIPrefix'
+            IPv4 endpoint with Segment Routing Policy being sent in the IPv4 MPREACH_NLRI .
+          $ref: '#/components/schemas/Bgp.Ipv4SrPolicyNLRIPrefix'
           x-field-uid: 5
         ipv6_srpolicy:    
           description: >-
-            List of IPv6 prefixes with Segment Routing Policy being sent in the IPv6 MPREACH_NLRI .            
-          type: array
-          items:
-            $ref: '#/components/schemas/Bgp.OneIpv6SrPolicyNLRIPrefix'
+            IPv6 endpoint with Segment Routing Policy being sent in the IPv6 MPREACH_NLRI .          
+          $ref: '#/components/schemas/Bgp.Ipv6SrPolicyNLRIPrefix'
           x-field-uid: 6
 
     Bgp.Attributes.MpUnreachNlri:
@@ -824,8 +800,6 @@ components:
           x-field-uid: 2
         ipv6_unicast:    
           description: >-
-            SAFI of the NLRI being sent in the Update.
-                   description: >-
             List of IPv6 prefixes being sent in the IPv6 Unicast MPUNREACH_NLRI .
           type: array
           items:
@@ -833,17 +807,13 @@ components:
           x-field-uid: 3
         ipv4_srpolicy:    
           description: >-
-            List of IPv4 prefixes with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI .
-          type: array
-          items:
-            $ref: '#/components/schemas/Bgp.OneIpv4SrPolicyNLRIPrefix'
+            IPv4 endpoint with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI .
+          $ref: '#/components/schemas/Bgp.Ipv4SrPolicyNLRIPrefix'
           x-field-uid: 4
         ipv6_srpolicy:    
           description: >-
-            List of IPv6 prefixes with Segment Routing Policy being sent in the IPv6 MPUNREACH_NLRI .            
-          type: array
-          items:
-            $ref: '#/components/schemas/Bgp.OneIpv6SrPolicyNLRIPrefix'
+            IPv6 endpoint with Segment Routing Policy being sent in the IPv4 MPUNREACH_NLRI .          
+          $ref: '#/components/schemas/Bgp.Ipv6SrPolicyNLRIPrefix'
           x-field-uid: 5        
     Bgp.Attributes.MultiExitDiscriminator:
       description: |-
@@ -1817,17 +1787,4 @@ components:
           type: integer
           format: uint32
           default: 1          
-          x-field-uid: 1
-    Bgp.NLRIPrefixSegmentRoutingColor:
-      description: >-
-          Optional field in the NLRI carrying color for Segment Routing Policy NLRI with SAFI 73.
-      type: object 
-      properties:
-        value:
-          description: >-
-            The value of the optional Segment Routing color of the prefix. 
-          type: integer
-          format: uint32
-          default: 1          
-          x-field-uid: 1
-
+          x-field-uid: 1    

--- a/device/bgp/bgpupdatereplay.yaml
+++ b/device/bgp/bgpupdatereplay.yaml
@@ -720,7 +720,7 @@ components:
         The following AFI / SAFI combinations are supported:
         - IPv4 Unicast with AFI as 1 and SAFI as 1 
         - IPv6 Unicast with AFI as 2 and SAFI as 1 
-        - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73
+        - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73 ( draft-ietf-idr-sr-policy-safi-02 Section 2.1 )
         - Segment Routing Policy for IPv6 Unicast with AFI as 2 and SAFI as 73
       type: object
       required: [choice]
@@ -773,7 +773,7 @@ components:
         The following AFI / SAFI combinations are supported:
         - IPv4 Unicast with AFI as 1 and SAFI as 1 
         - IPv6 Unicast with AFI as 2 and SAFI as 1 
-        - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73
+        - Segment Routing Policy for IPv4 Unicast with AFI as 1 and SAFI as 73 (draft-ietf-idr-sr-policy-safi-02 Section 2.1)
         - Segment Routing Policy for IPv6 Unicast with AFI as 2 and SAFI as 73
       type: object
       properties:
@@ -871,68 +871,51 @@ components:
           x-field-uid: 2
     Bgp.Attributes.SegmentRoutingPolicy:
       description: |-
-        Optional Segment Routing Policy information as defined in draft-ietf-idr-segment-routing-te-policy.
-        This information is carried in TUNNEL_ENCAPSULATION attribute with type set to  SR Policy (15).
-        - [From .proto :
-          message PaPolicy {
-            optional PaBindingSegmentIdentifier bsid = 1;
-            optional PaPreference preference = 2;
-            repeated PaSegmentList segment_lists = 3;
-            optional PaPriority priority = 4;
-            optional PaPolicyName policy_name = 5;
-            optional PaExplicitNullLabelPolicy explicit_null_label_policy = 6;
-          } 
-         ] 
+        Optional Segment Routing Policy information as defined in draft-ietf-idr-sr-policy-safi-02.
+        This information is carried in TUNNEL_ENCAPSULATION attribute with type set to  SR Policy (15). 
       type: object 
       properties:
         binding_segment_identifier:
-          description: |-
-            When the active candidate path has a specified Binding Segment Identifier, 
-            the SR Policy uses that BSID if this value (label in MPLS, IPv6 address in SRv6) is available.
-            The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy
-            Section 2.4.2 .
-            - [.proto:
-              message PaBindingSegmentIdentifier {
-                optional bool specified_bsid_only = 1;  // S-flag.
-                optional bool drop_upon_invalid = 2;    // I-flag. 
-                oneof sid {
-                  PaSegment.MPLS mpls = 4;
-                  monitoring.raven.IPAddressProto ipv6 = 5;
-                }
-              }
-            ]
           $ref: '#/components/schemas/Bgp.Attributes.Bsid'
-          x-field-uid:  1          
-        prerefence:
-          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.Preference'
+          x-field-uid: 1
+        srv6_binding_segment_identifier:
+          description: |-        
+            The SRv6 Binding SID sub-TLV is an optional sub-TLV of type 20 that is used to signal the SRv6 Binding SID
+            related information of an SR Policy candidate path. 
+              - More than one SRv6 Binding SID sub-TLVs MAY be signaled in the same SR Policy encoding to indicate one
+                or more SRv6 SIDs, each with potentially different SRv6 Endpoint Behaviors to be instantiated.
+              - The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02 Section 2.4.3 .       
+          type: array
+          items:
+            $ref: '#/components/schemas/Bgp.Attributes.Srv6Bsid'
           x-field-uid: 2
+        preference:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.Preference'
+          x-field-uid: 3
         priority:
           $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.Priority'
-          x-field-uid: 3
+          x-field-uid: 4
         policy_name:
           $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.PolicyName'
-          x-field-uid: 4
-        explicit_null_policy:
-          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.ExplicitNullPolicy'
           x-field-uid: 5
+        policy_candidate_name:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.PolicyCandidateName'
+          x-field-uid: 6
+        explicit_null_label_policy:
+          $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.ExplicitNullPolicy'
+          x-field-uid: 7
         segment_list:
           $ref: '#/components/schemas/Bgp.Attributes.SrPolicy.SegmentList'
-          x-field-uid: 6
+          x-field-uid: 8
     Bgp.Attributes.Bsid:
       description: |-
+        The Binding Segment Identifier is an optional sub-tlv of type 13 that can be sent with a SR Policy 
+        Tunnel Encapsulation attribute.
         When the active candidate path has a specified Binding Segment Identifier, the SR Policy uses that 
         BSID if this value (label in MPLS, IPv6 address in SRv6) is available.
-        - The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy Section 2.4.2 .
-        - [.proto:
-              message PaBindingSegmentIdentifier {
-                optional bool specified_bsid_only = 1;  // S-flag.
-                optional bool drop_upon_invalid = 2;    // I-flag. 
-                oneof sid {
-                  PaSegment.MPLS mpls = 4;
-                  monitoring.raven.IPAddressProto ipv6 = 5;
-                }
-              }
-            ]
+        - The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02 Section 2.4.2 . 
+        - It is recommended that if SRv6 Binding SID is desired to be signalled, the SRv6 Binding SID sub-TLV that enables 
+          the specification of the SRv6 Endpoint Behavior should be used.
       type: object
       required: [choice]
       properties:
@@ -955,7 +938,7 @@ components:
     Bgp.Attributes.Bsid.Mpls:
       description: |-
         When the active candidate path has a specified Binding Segment Identifier, the SR Policy uses that BSID defined 
-        as a MPLS label.The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy  Section 2.4.2 .
+        as a MPLS label.The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02  Section 2.4.2 .
       type: object
       properties:
         flag_specified_bsid_only:
@@ -978,7 +961,37 @@ components:
     Bgp.Attributes.Bsid.Srv6:
       description: |-
         When the active candidate path has a specified Binding Segment Identifier, the SR Policy uses that BSID defined 
-        as an IPv6 Address.The format of the sub-TLV is defined in draft-ietf-idr-segment-routing-te-policy Section 2.4.2 .
+        as an IPv6 Address.The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02 Section 2.4.2 .
+      type: object
+      properties:
+        flag_specified_bsid_only:
+          description: |-
+            S-Flag: This flag encodes the "Specified-BSID-only" behavior. It's usage is 
+            described in section 6.2.3 in [RFC9256].
+          type: boolean
+          default: false
+          x-field-uid: 1
+        flag_drop_upon_invalid:
+          description: |-
+            I-Flag: This flag encodes the "Drop Upon Invalid" behavior. 
+            It's usage is described in section 8.2 in [RFC9256].
+          type: boolean
+          default: false
+          x-field-uid: 2
+        ipv6_addr:
+          description: >-
+            IPv6 address denoting the SRv6 SID.
+          type: string          
+          format: ipv6
+          default: 0::0
+          x-field-uid: 3
+    Bgp.Attributes.Srv6Bsid:
+      description: |-        
+        The SRv6 Binding SID sub-TLV is an optional sub-TLV of type 20 that is used to signal the SRv6 Binding SID
+        related information of an SR Policy candidate path. 
+          - More than one SRv6 Binding SID sub-TLVs MAY be signaled in the same SR Policy encoding to indicate one or
+            more SRv6 SIDs, each with potentially different SRv6 Endpoint Behaviors to be instantiated.
+          - The format of the sub-TLV is defined in draft-ietf-idr-sr-policy-safi-02 Section 2.4.3 .
       type: object
       properties:
         flag_specified_bsid_only:
@@ -998,7 +1011,7 @@ components:
         flag_srv6_endpoint_behavior:
           description: |-
             B-Flag: This flag, when set, indicates the presence of the SRv6 Endpoint Behavior 
-            and SID Structure encoding specified in Section 2.4.4.2.4 of draft-ietf-idr-segment-routing-te-policy.
+            and SID Structure encoding specified in Section 2.4.4.2.4 of draft-ietf-idr-sr-policy-safi-02.
           type: boolean
           default: false
           x-field-uid: 3
@@ -1009,19 +1022,13 @@ components:
           format: ipv6
           default: 0::0
           x-field-uid: 4
+        srv6_endpoint_behavior:
+          $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
+          x-field-uid: 5 
     Bgp.Attributes.Sid.Mpls:
       description: |-
         This carries a 20 bit Multi Protocol Label Switching alongwith 3 bits traffic class, 1 bit indicating presence
         or absence of Bottom-Of-Stack and 8 bits carrying the Time to Live value. 
-        - [.proto : 
-            // Segment identified by MPLS label.
-          message MPLS {
-            optional uint32 label = 1;          // 20 bits.
-            optional uint32 traffic_class = 2;  // 3 bits (TC).
-            optional bool bottom_of_stack = 3;  // 1 bit (S).
-            optional uint32 time_to_live = 4;   // 8 bits (TTL).
-          }
-        ]
       type: object 
       properties:
         label:
@@ -1054,9 +1061,20 @@ components:
           default: 63
           maximum: 63
           x-field-uid: 4
+    Bgp.Attributes.Sid.Srv6:
+      description: |-
+        An IPv6 address denoting a SRv6 SID.
+      type: object 
+      properties:
+        ip:
+          type: string
+          format: ipv6
+          default: "0::0"
+          x-field-uid: 1
     Bgp.Attributes.SrPolicy.Preference:
       description: |
-        Optional Preference sub-tlv used to select the best candidate path for an SR Policy.
+        Optional Preference sub-tlv (Type 12) is used to select the best candidate path for an SR Policy.
+        It is defined in Section 2.4.1 of draft-ietf-idr-sr-policy-safi-02 .
       type: object
       properties:
         value:
@@ -1066,10 +1084,10 @@ components:
           format: uint32
           default: 0
           x-field-uid: 1
-
     Bgp.Attributes.SrPolicy.Priority:
-      description: |
-        Optional Priority sub-tlv used to select the order in which policies should be re-computed.
+      description: |- 
+        Optional Priority sub-tlv (Type 15) used to select the order in which policies should be re-computed.
+        - It is defined in Section 2.4.6 of draft-ietf-idr-sr-policy-safi-02 .
       type: object
       properties:
         value:
@@ -1081,9 +1099,27 @@ components:
           default: 0
           x-field-uid: 1
 
+    Bgp.Attributes.SrPolicy.PolicyCandidateName:
+      description: |-   
+        Optional Policy Candidate Path Name sub-tlv (Type 129) which carries the symbolic name for the SR Policy candidate path 
+        for debugging.    
+        - It is defined in Section 2.4.7 of draft-ietf-idr-sr-policy-safi-02 .
+      type: object
+      required: [value]
+      properties:
+        value:
+          description: |-
+            Value of the symbolic Policy Candidate Path Name carried in the Policy Candidate Path Name sub-tlv.
+            It is recommended that the size of the name is limited to 255 bytes.
+          type: string          
+          maxLength: 500
+          x-field-uid: 1
+
     Bgp.Attributes.SrPolicy.PolicyName:
       description: |-   
-        Optional Policy Name sub-tlv which carries the symbolic name for the SR Policy candidate path for debugging.    
+        Optional Policy Name sub-tlv (Type 130) which carries the symbolic name for the SR Policy for which the 
+        candidate path is being advertised for debugging.    
+        - It is defined in Section 2.4.8 of draft-ietf-idr-sr-policy-safi-02 .
       type: object
       required: [value]
       properties:
@@ -1094,12 +1130,11 @@ components:
           type: string          
           maxLength: 500
           x-field-uid: 1
-
     Bgp.Attributes.SrPolicy.ExplicitNullPolicy:
       description: |-
-        This is an optional sub-tlv . 
-        If included , it Indicates whether an Explicit NULL Label must be pushed on an unlabeled IP
+        This is an optional sub-tlv (Type 14) which indicates whether an Explicit NULL Label must be pushed on an unlabeled IP
         packet before other labels for IPv4 or IPv6 flows.
+        - It is defined in Section 2.4.5 of draft-ietf-idr-sr-policy-safi-02.
       properties:
         choice:
           description: >-
@@ -1121,21 +1156,10 @@ components:
     Bgp.Attributes.SrPolicy.SegmentList:
       description: |-
         One optional SEGMENT_LIST sub-tlv encoded with type of 128.
-        One sub-tlv encodes a single explicit path towards the endpoint as described in 
+        One sub-tlv (Type 128) encodes a single explicit path towards the endpoint as described in 
         section 5.1 of [RFC9256]. 
         The Segment List sub-TLV includes the elements of the paths (i.e., segments) as well 
         as an optional Weight sub-TLV.
-        - [.proto :
-          // Contains one "segment (label) stack" with its weight. The weight is used for
-          // weighted multipath.
-          message PaSegmentList {
-            message Weight {
-              optional uint32 value = 1;
-            }
-            optional Weight weight = 1;
-            repeated PaSegment segments = 2;
-          }
-        ]
       type: object
       properties:
         weight:
@@ -1148,7 +1172,7 @@ components:
           x-field-uid:  2
     Bgp.Attributes.SegmentRoutingPolicy.SegmentList.Weight:
       description:
-        The optional Weight sub-TLV specifies the weight associated with a given segment list.
+        The optional Weight sub-TLV (Type 9) specifies the weight associated with a given segment list.
         The weight is used for weighted multipath.
       type: object
       properties:
@@ -1162,124 +1186,8 @@ components:
       description: |-
         A Segment sub-TLV describes a single segment in a segment list  i.e., a single
         element of the explicit path. The Segment sub-TLVs are optional.
-        - [.proto :
-          // This defines one segment. The distinction between a "segment" and a "segment
-          // identifier" (SID) is basically non-existent; these objects can be seen as
-          // either.
-          message PaSegment {
-            message Flags {  // 8 bits in total.
-              // V-flag. Indicates verification is enabled. See section 5,
-              // https://tools.ietf.org/html/draft-ietf-spring-segment-routing-policy-01
-              optional bool verification = 1;
-              // A-flag. Indicates presence of SR Algorithm field applicable to Segment
-              // Types 3, 4, and 9.
-              optional bool algorithm = 2;
-            }
-            // Segment identified by MPLS label.
-            message MPLS {
-              optional uint32 label = 1;          // 20 bits.
-              optional uint32 traffic_class = 2;  // 3 bits (TC).
-              optional bool bottom_of_stack = 3;  // 1 bit (S).
-              optional uint32 time_to_live = 4;   // 8 bits (TTL).
-            }
-            // SID only, in the form of MPLS Label.
-            message Type1 {
-              optional Flags flags = 1;
-              optional MPLS sid = 2;
-            }
-            // SID only, in the form of IPv6 address.
-            message Type2 {
-              optional Flags flags = 1;
-              optional monitoring.raven.IPAddressProto sid = 2;
-            }
-            // IPv4 Node Address with optional SID.
-            message Type3 {
-              optional Flags flags = 1;
-              optional PaAlgorithm algorithm = 2;
-              optional monitoring.raven.IPAddressProto node_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv6 Node Address with optional SID for SR MPLS.
-            message Type4 {
-              optional Flags flags = 1;
-              optional PaAlgorithm algorithm = 2;
-              optional monitoring.raven.IPAddressProto node_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv4 Address + index with optional SID.
-            message Type5 {
-              optional Flags flags = 1;
-              optional uint32 local_interface_id = 2;
-              optional monitoring.raven.IPAddressProto node_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv4 Local and Remote addresses with optional SID.
-            message Type6 {
-              optional Flags flags = 1;
-              optional monitoring.raven.IPAddressProto local_address = 2;
-              optional monitoring.raven.IPAddressProto remote_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv6 Address + index for local and remote pair with optional SID for SR
-            // MPLS.
-            message Type7 {
-              optional Flags flags = 1;
-              optional uint32 local_interface_id = 2;
-              optional monitoring.raven.IPAddressProto local_node_address = 3;
-              // `remote_interface_id` and `remote_node_address` pair is optional. Both
-              // must be present or both must be absent.
-              optional uint32 remote_interface_id = 4;
-              optional monitoring.raven.IPAddressProto remote_node_address = 5;
-              optional MPLS sid = 6;
-            }
-            // IPv6 Local and Remote addresses with optional SID for SR MPLS.
-            message Type8 {
-              optional Flags flags = 1;
-              optional monitoring.raven.IPAddressProto local_address = 2;
-              optional monitoring.raven.IPAddressProto remote_address = 3;
-              optional MPLS sid = 4;
-            }
-            // IPv6 Node Address with optional SID for SRv6.
-            message Type9 {
-              optional Flags flags = 1;
-              optional PaAlgorithm algorithm = 2;
-              optional monitoring.raven.IPAddressProto node_address = 3;
-              optional monitoring.raven.IPAddressProto sid = 4;
-            }
-            // IPv6 Address + index for local and remote pair with optional SID for SRv6.
-            message Type10 {
-              optional Flags flags = 1;
-              optional uint32 local_interface_id = 2;
-              optional monitoring.raven.IPAddressProto local_node_address = 3;
-              // `remote_interface_id` and `remote_node_address` pair is optional. Both
-              // must be present or both must be absent.
-              optional uint32 remote_interface_id = 4;
-              optional monitoring.raven.IPAddressProto remote_node_address = 5;
-              optional monitoring.raven.IPAddressProto sid = 6;
-            }
-            // IPv6 Local and Remote addresses for SRv6.
-            message Type11 {
-              optional Flags flags = 1;
-              optional monitoring.raven.IPAddressProto local_address = 2;
-              optional monitoring.raven.IPAddressProto remote_address = 3;
-              optional monitoring.raven.IPAddressProto sid = 4;
-            }
-
-            oneof segment {
-              Type1 type1 = 1;
-              Type2 type2 = 2;
-              Type3 type3 = 3;
-              Type4 type4 = 4;
-              Type5 type5 = 5;
-              Type6 type6 = 6;
-              Type7 type7 = 7;
-              Type8 type8 = 8;
-              Type9 type9 = 9;
-              Type10 type10 = 10;
-              Type11 type11 = 11;
-            }
-          }
-        ]
+        Segment Types A and B are defined as described in 2.4.4.2.
+        Segment Types C upto K are defined as described in in draft-ietf-idr-bgp-sr-segtypes-ext-03  .      
       type: object
       required: [choice]
       properties:
@@ -1288,15 +1196,15 @@ components:
             Specify one of the segment types as defined in ietf-idr-segment-routing-te-policy
             - Type  A: SID only, in the form of MPLS Label.
             - Type  B: SID only, in the form of IPv6 Address.
-            - Type  C: IPv4 Node Address with optional SID.
-            - Type  D: IPv6 Node Address with optional SID for SR MPLS.
-            - Type  E: IPv4 Address and index with optional SID.
-            - Type  F: IPv4 Local and Remote addresses with optional SID.
-            - Type  G: IPv6 Address and index for local and remote pair with optional SID for SR MPLS.
-            - Type  H: IPv6 Local and Remote addresses with optional SID for SR MPLS.
-            - Type  I: IPv6 Node Address with optional SID for SRv6.
-            - Type  J: IPv6 Address and index for local and remote pair with optional SID for SRv6.
-            - Type  K: IPv6 Local and Remote addresses for SRv6.
+            - Type  C: IPv4 Prefix with optional SR Algorithm.
+            - Type  D: IPv6 Global Prefix with optional SR Algorithm for SR-MPLS.
+            - Type  E: IPv4 Prefix with Local Interface ID.
+            - Type  F: IPv4 Addresses for link endpoints as Local, Remote pair.
+            - Type  G: IPv6 Prefix and Interface ID for link endpoints as Local, Remote pair for SR-MPLS.
+            - Type  H: IPv6 Addresses for link endpoints as Local, Remote pair for SR-MPLS.
+            - Type  I: IPv6 Global Prefix with optional SR Algorithm for SRv6.
+            - Type  J: IPv6 Prefix and Interface ID for link endpoints as Local, Remote pair for SRv6.
+            - Type  K: IPv6 Addresses for link endpoints as Local, Remote pair for SRv6.
           type: string
           x-field-uid: 1
           x-enum:
@@ -1357,7 +1265,7 @@ components:
           x-field-uid: 12
     Bgp.Attributes.SegmentRoutingPolicy.TypeA:
       description: |- 
-        Type  A: SID only, in the form of MPLS Label.
+        Type A: SID only, in the form of MPLS Label.
         It is encoded as a Segment of Type 1 in the SEGMENT_LIST sub-tlv.
       type: object
       properties:
@@ -1370,7 +1278,7 @@ components:
     Bgp.Attributes.SegmentRoutingPolicy.TypeB:
       description: |- 
         Type B: SID only, in the form of IPv6 address.
-        It is encoded as a Segment of Type 2 in the SEGMENT_LIST sub-tlv.
+        It is encoded as a Segment of Type 13 in the SEGMENT_LIST sub-tlv.
       type: object
       properties:
         flags:
@@ -1476,7 +1384,7 @@ components:
           x-field-uid: 4
     Bgp.Attributes.SegmentRoutingPolicy.TypeF:
       description: |- 
-        Type F: IPv4 Local and Remote addresses with optional SID.
+        Type F: IPv4 Local and Remote addresses with optional SR-MPLS SID.
         It is encoded as a Segment of Type 6 in the SEGMENT_LIST sub-tlv. 
       type: object
       properties:
@@ -1576,8 +1484,8 @@ components:
           x-field-uid: 6
     Bgp.Attributes.SegmentRoutingPolicy.TypeI:
       description: |- 
-        Type I: IPv6 Node Address with optional SRv6 SID.
-        It is encoded as a Segment of Type 9 in the SEGMENT_LIST sub-tlv. 
+        Type I: IPv6 Node Address with optional SR Algorithm and optional SRv6 SID.
+        It is encoded as a Segment of Type 14 in the SEGMENT_LIST sub-tlv. 
       type: object
       properties:
         flags:
@@ -1600,11 +1508,7 @@ components:
           default: "0::0"
           x-field-uid: 3
         srv6_sid:
-          description: >-
-            Optional SRv6 SID.
-          type: string
-          format: ipv6
-          default: "0::0"
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Srv6'          
           x-field-uid: 4
         srv6_endpoint_behavior:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
@@ -1612,7 +1516,7 @@ components:
     Bgp.Attributes.SegmentRoutingPolicy.TypeJ:
       description: |- 
         Type J: IPv6 Address, Interface ID for local and remote pair for SRv6 with optional SID.
-        It is encoded as a Segment of Type 10 in the SEGMENT_LIST sub-tlv. 
+        It is encoded as a Segment of Type 15 in the SEGMENT_LIST sub-tlv. 
       type: object
       properties:
         flags:
@@ -1658,11 +1562,7 @@ components:
           default: "0::0"
           x-field-uid: 6
         srv6_sid:
-          description: >-
-            Optional SRv6 SID.
-          type: string
-          format: ipv6
-          default: "0::0"
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Srv6'          
           x-field-uid: 7
         srv6_endpoint_behavior:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
@@ -1670,51 +1570,49 @@ components:
     Bgp.Attributes.SegmentRoutingPolicy.TypeK:
       description: |- 
         Type K: IPv6 Local and Remote addresses for SRv6 with optional SID.
-        It is encoded as a Segment of Type 11 in the SEGMENT_LIST sub-tlv. 
+        It is encoded as a Segment of Type 16 in the SEGMENT_LIST sub-tlv. 
       type: object
       properties:
         flags:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.TypeFlags'
           x-field-uid: 1
+        sr_algorithm:
+          description: >-
+            SR Algorithm identifier when A-Flag in on. If A-flag is not enabled, it should be set to 0 on transmission and
+            ignored on receipt.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
         local_ipv6_address:
           description: >-
             Local IPv6 Address.
           type: string
           format: ipv6
           default: "0::0"
-          x-field-uid: 2
+          x-field-uid: 3
         remote_ipv6_address:
           description: >-
             Remote IPv6 Address.
           type: string
           format: ipv6
           default: "0::0"
-          x-field-uid: 3
-        srv6_sid:
-          description: >-
-            Optional SRv6 SID.
-          type: string
-          format: ipv6
-          default: "0::0"
           x-field-uid: 4
+        srv6_sid:
+          $ref: '#/components/schemas/Bgp.Attributes.Sid.Srv6'     
+          x-field-uid: 5
         srv6_endpoint_behavior:
           $ref: '#/components/schemas/Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure'
-          x-field-uid: 5 
+          x-field-uid: 6 
     Bgp.Attributes.SegmentRoutingPolicy.TypeFlags:
       description: |-
         Flags for each Segment in SEGMENT_LIST sub-tlv.
         - V-flag. Indicates verification is enabled. See section 5, of https://datatracker.ietf.org/doc/html/rfc9256
-        - A-flag. Indicates presence of SR Algorithm field applicable to Segment Types 3, 4, and 9.
-        - B-Flag. Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding.  
-        - [.proto:
-            message Flags {  // 8 bits in total.
-              // V-flag. Indicates verification is enabled. See section 5,
-              // https://tools.ietf.org/html/draft-ietf-spring-segment-routing-policy-01
-              optional bool verification = 1;
-              // A-flag. Indicates presence of SR Algorithm field applicable to Segment
-              // Types 3, 4, and 9.
-              optional bool algorithm = 2;
-        }]
+        - A-flag. Indicates presence of SR Algorithm field applicable to Segment Types C, D , I , J and K .
+        - B-Flag. Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding applicable to Segment Types B , I , J and K .
+        - S-Flag: This flag, when set, indicates the presence of the SR-MPLS or SRv6 SID depending on the segment type. (draft-ietf-idr-bgp-sr-segtypes-ext-03 Section 2.10).
+                  This flag is applicable for Segment Types C, D, E, F, G, H, I, J, and K.
       type: object 
       properties:
         v_flag:
@@ -1729,20 +1627,38 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-        b_flag:
+        s_flag:
           description: |-
-            Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding specified in Section 2.4.4.2.4
-            of draft-ietf-idr-segment-routing-te-policy.         
+            This flag, when set, indicates the presence of the SR-MPLS or SRv6 SID depending on the segment type.
           type: boolean
           default: false
           x-field-uid: 3
+        b_flag:
+          description: |-
+            Indicates presence of SRv6 Endpoint Behavior and SID Structure encoding specified in Section 2.4.4.2.4
+            of draft-ietf-idr-sr-policy-safi-02.         
+          type: boolean
+          default: false
+          x-field-uid: 4
     Bgp.Attributes.SegmentRoutingPolicy.SRv6SIDEndpointBehaviorAndStructure:
       description: >-
         Configuration for optional SRv6 Endpoint Behavior and SID Structure.
         Summation of lengths for Locator Block, Locator Node,  Function, and Argument MUST be less than or equal to 128.
-        - This is specified in draft-ietf-idr-segment-routing-te-policy Section 2.4.4.2.4
+        - This is specified in draft-ietf-idr-sr-policy-safi-02 Section 2.4.4.2.4
       type: object
       properties:
+        endpoint_behaviour:
+          description: |-
+            This is a 2-octet field that is used to specify the SRv6 Endpoint Behavior code point for the SRv6 SID as defined 
+            in section 9.2 of [RFC8986]. When set with the value 0xFFFF (i.e., Opaque), the choice of SRv6 Endpoint Behavior is 
+            left to the headend. Well known 16-bit values for this field are available at 
+            https://www.iana.org/assignments/segment-routing/segment-routing.xhtml .
+          type: string
+          format: hex
+          default: "ffff"
+          maxLength: 4
+          x-field-uid: 1
+
         lb_length:
           description: >-
             SRv6 SID Locator Block length in bits.
@@ -1750,7 +1666,7 @@ components:
           format: uint32
           maximum: 128
           default: 0
-          x-field-uid: 1
+          x-field-uid: 2
         ln_length:
           description: >-
             SRv6 SID Locator Node length in bits.
@@ -1758,7 +1674,7 @@ components:
           format: uint32
           maximum: 128
           default: 0
-          x-field-uid: 2
+          x-field-uid: 3
         func_length:
           description: >-
             SRv6 SID Function length in bits.
@@ -1766,7 +1682,7 @@ components:
           format: uint32
           maximum: 128
           default: 0
-          x-field-uid: 3
+          x-field-uid: 4
         arg_length:
           description: >-
             SRv6 SID Arguments length in bits.
@@ -1774,7 +1690,7 @@ components:
           format: uint32
           maximum: 128
           default: 0
-          x-field-uid: 4   
+          x-field-uid: 5   
 
     Bgp.NLRIPrefixSegmentRoutingDistinguisher:
       description: >-


### PR DESCRIPTION
**Redocly View:** 
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/bgp_replay_sr_policy/artifacts/openapi.yaml&nocors#tag/Configuration) 

New optional attributes at : 
- `set_config/devices/bgp/ipv[46]_interfaces/peers/replay_updates/structured_pdus/updates/path_attributes/tunnel_encapsulation`
- `set_config/devices/bgp/ipv[46]_interfaces/peers/replay_updates/structured_pdus/updates/path_attributes/mp_[un]reach/ipv4[6]_srpolicy`

**Requirement:**
Provide a way for importing/creating a list of updates containing Tunnel Encapsulation attribute with SR Policy details as well as sending MP_REACH / MP_UNREACH with Segment Routing information with SAFI as 73 . 
Note the model and resulting implementations as of now will be adhering to draft versions of the specification ( and hence there might be implementations/tools with lower version support ) and though the drafts are pretty mature, this is a slight chance of format changes in the future drafts till it is standardized to RFC status.
_Current drafts:_
https://www.ietf.org/archive/id/draft-ietf-idr-sr-policy-safi-02.html
( Note that this itself is a replacement of https://datatracker.ietf.org/doc/html/draft-ietf-idr-segment-routing-te-policy-26 )
Segment Types from Type C onwards are now defined in :
https://datatracker.ietf.org/doc/html/draft-ietf-idr-bgp-sr-segtypes-ext


**Example usage: Create Replay Updates with SR Policy by manually specifying Structured Updates in the UpdateReplay list** 
```
       /* Not including snippet upto creation of BGP Peer where with AS type/AS number should match the Updates being created */
 
        //enable seTEPolicy capability  . This must be enabled on DUT as well for it to accept SR Policy NLRIs.
        peer.Capability().SetIpv4SrTePolicy(true)

        updateReplayBlock := peer.ReplayUpdates().StructuredPdus()
        adv1 := updateReplayBlock.Updates().Add()
        adv1.PathAttributes().
                SetOrigin(gosnappi.BgpAttributesOrigin.IGP)

        adv1.PathAttributes().
                AsPath().FourByteAsPath().Segments().Add().
                SetType(gosnappi.BgpAttributesFourByteAsPathSegmentType.AS_SEQ).
                SetAsNumbers([]uint32{2222, 1113, 7000, 80000})

        adv1.PathAttributes().
                MultiExitDiscriminator().
                SetValue(145)

        // Either Community of type NO_ADVERTISE or Extended Community of type Route Target must be present for
        // DUT to accept SR Policy NLRI 
        adv1.PathAttributes().
                Community().Add().
                NoAdvertised()   

        adv1.PathAttributes().MpReach().
                 NextHop().SetIpv4("1.1.1.2")
        ipv4_sr_routes_adv := adv1.PathAttributes().MpReach().Ipv4Srpolicy()
        ipv4_sr_routes_adv.SetEndpoint("0.0.0.0").
                SetColor(100).SetDistinguisher(1)
        sr := adv1.PathAttributes().TunnelEncapsulation().SrPolicy()
        sr.Preference().SetValue(3)
        sr.PolicyName().SetValue("TypeA Policy")
        sr.Priority().SetValue(3)
        sr.ExplicitNullLabelPolicy().PushIpv4()
        sr.BindingSegmentIdentifier().Mpls().SetFlagSpecifiedBsidOnly(true).MplsSid().SetLabel(22222).SetTtl(0)
        
        // adding 2 segment lists with 2 labels each
        segmentList := sr.SegmentList().Add()
        segmentList.Weight().SetValue(200)
        typeA := segmentList.Segments().Add().TypeA()
        typeA.Flags().SetSFlag(true)
        typeA.MplsSid().SetLabel(10000)
        typeA = segmentList.Segments().Add().TypeA()
        typeA.Flags().SetSFlag(true)
        typeA.MplsSid().SetLabel(11000)

        segmentList = sr.SegmentList().Add()
        segmentList.Weight().SetValue(200)
        typeA = segmentList.Segments().Add().TypeA()
        typeA.Flags().SetSFlag(true)
        typeA.MplsSid().SetLabel(1000)
        typeA = segmentList.Segments().Add().TypeA()
        typeA.Flags().SetSFlag(true)
        typeA.MplsSid().SetLabel(1100)

```
To download corresponding gosnappi from this branch:
`go get github.com/open-traffic-generator/snappi/gosnappi@bgp_replay_sr_policy`