### PR TITLE
Support for SNMPv3 Packet Header (Data Plane Only)

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7969,6 +7969,9 @@ components:
         rsvp:
           $ref: '#/components/schemas/Flow.Rsvp'
           x-field-uid: 22
+        snmpv3:
+          $ref: '#/components/schemas/Flow.Snmpv3'
+          x-field-uid: 23
     Flow.Custom:
       type: object
       description: |-
@@ -8803,7 +8806,7 @@ components:
           x-field-uid: 9
     Flow.Snmpv2c.PDU:
       description: |-
-        This contains the body of the SNMPv2C PDU.
+        This contains the body of the SNMP PDU.
       type: object
       properties:
         request_id:
@@ -10196,6 +10199,158 @@ components:
           minLength: 1
           maxLength: 131050
           default: '0000'
+          x-field-uid: 3
+    Flow.Snmpv3:
+      description: |-
+        SNMPv3 packet header as defined in RFC3412, RFC2274 and RFC2574.
+      type: object
+      properties:
+        version:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.Version'
+        global_data:
+          $ref: '#/components/schemas/Flow.Snmpv3.HeaderData'
+          x-field-uid: 2
+        security_parameters:
+          $ref: '#/components/schemas/Flow.Snmpv3.SecurityParameters'
+          x-field-uid: 3
+        data:
+          $ref: '#/components/schemas/Flow.Snmpv3.ScopedPduData'
+          x-field-uid: 4
+    Flow.Snmpv3.HeaderData:
+      description: |-
+        It contains administrative parameters.
+      type: object
+      properties:
+        id:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.Id'
+        max_size:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.MaxSize'
+        flags:
+          $ref: '#/components/schemas/Flow.Snmpv3.HeaderDataFlags'
+          x-field-uid: 3
+        security_model:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.SecurityModel'
+    Flow.Snmpv3.HeaderDataFlags:
+      description: |-
+        It contains several bit fields which control processing of the message.
+      type: object
+      properties:
+        reportable:
+          description: |-
+            It is a secondary aid in determining whether a Report PDU MUST be sent.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        encrypted:
+          description: |-
+            If this flag is set, then the securityModel used by the SNMP  engine which sent the message MUST also protect the scopedPDU  in an SNMP message from disclosure.
+          type: boolean
+          default: false
+          x-field-uid: 2
+        authenticated:
+          description: |-
+            If this flag is set, then the securityModel used by  the SNMP engine which sent the message MUST identify  the securityName on whose behalf the SNMP message was generated and MUST provide,  in a securityModel-specific manner,  sufficient data for the receiver of the message to be able to authenticate that identification.
+          type: boolean
+          default: false
+          x-field-uid: 3
+    Flow.Snmpv3.SecurityParameters:
+      description: |-
+        It is used for communication between the Security Model modules in the sending and receiving SNMP engines.  It follows RFC2274 and RFC2574.
+      type: object
+      properties:
+        authoritative_engine_id:
+          description: |-
+            It specifies the snmpEngineID of the authoritative SNMP engine involved in the exchange of the message.
+          type: string
+          format: hex
+          default: ''
+          maxLength: 10000
+          x-field-uid: 1
+        authoritative_engine_boots:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineBoots'
+        authoritative_engine_time:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineTime'
+        user_name:
+          description: |-
+            It specifies the user (principal) on whose behalf the message is being exchanged.
+          type: string
+          format: hex
+          default: ''
+          maxLength: 32
+          x-field-uid: 4
+        authentication_parameters:
+          description: |-
+            These are defined by the authentication protocol in use for the message,  as defined by the usmUserAuthProtocol column in the user's entry in the usmUserTable.
+          type: string
+          format: hex
+          maxLength: 10000
+          default: ''
+          x-field-uid: 5
+        privacy_parameters:
+          description: |-
+            These are defined by the privacy protocol in use for the message,  as defined by the usmUserPrivProtocol column in the user's entry in the usmUserTable).
+          type: string
+          format: hex
+          default: ''
+          maxLength: 10000
+          x-field-uid: 6
+    Flow.Snmpv3.ScopedPduData:
+      description: |-
+        This field represents either the plain text scopedPDU  if the encrypted flag in the snmpv3.global_data.flags is zero,  or it represents an encryptedPDU (encoded as an OCTET STRING)  which MUST be decrypted by the securityModel in use to produce a plaintext scopedPDU.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: plain_text
+          x-field-uid: 1
+          x-enum:
+            plain_text:
+              x-field-uid: 1
+            encrypted_pdu:
+              x-field-uid: 2
+          enum:
+          - plain_text
+          - encrypted_pdu
+        plain_text:
+          $ref: '#/components/schemas/Flow.Snmpv3.ScopedPDU'
+          x-field-uid: 2
+        encrypted_pdu:
+          description: |-
+            It represents an encryptedPDU (encoded as an OCTET STRING).
+          type: string
+          format: hex
+          default: ''
+          maxLength: 10000
+          x-field-uid: 3
+    Flow.Snmpv3.ScopedPDU:
+      description: |-
+        It contains information to identify an administratively unique context and a PDU.  The object identifiers in the PDU refer to managed objects which are (expected to be) accessible within the specified context.
+      type: object
+      properties:
+        context_engine_id:
+          description: |-
+            It is an unique identifier within an administrative domain,  an SNMP entity that may realize an instance of a context with a particular contextName.
+          type: string
+          format: hex
+          default: ''
+          maxLength: 10000
+          x-field-uid: 1
+        context_name:
+          description: |-
+            It in conjunction with the context_engine_id field,  identifies the particular context associated with  the management information contained in the PDU portion of the message.
+          type: string
+          format: hex
+          default: ''
+          maxLength: 10000
+          x-field-uid: 2
+        data:
+          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
           x-field-uid: 3
     Flow.Size:
       description: |-
@@ -33703,6 +33858,408 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv3.Version.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 3
+          format: uint32
+          maximum: 2147483647
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 2147483647
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 2147483647
+    Pattern.Flow.Snmpv3.Version:
+      description: |-
+        Version
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 3
+          format: uint32
+          maximum: 2147483647
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 2147483647
+          x-field-uid: 3
+          default:
+          - 3
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.Version.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.Version.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv3.HeaderData.Id.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 2147483647
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 2147483647
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 2147483647
+    Pattern.Flow.Snmpv3.HeaderData.Id:
+      description: |-
+        It is used between two SNMP entities to coordinate request messages and responses.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 2147483647
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 2147483647
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.Id.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.Id.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv3.HeaderData.MaxSize.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 2147483647
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 2147483647
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 2147483647
+    Pattern.Flow.Snmpv3.HeaderData.MaxSize:
+      description: |-
+        The maximum message size that the sender can accept when another SNMP engine sends  an SNMP message (be it a response or any other message) to the sender of this message  on the transport in use for this message.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 2147483647
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 2147483647
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.MaxSize.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.MaxSize.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv3.HeaderData.SecurityModel.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 2147483647
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 2147483647
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 2147483647
+    Pattern.Flow.Snmpv3.HeaderData.SecurityModel:
+      description: |-
+        It identifies which Security Model was used by the sender to generate  the message and therefore which securityModel MUST be used by the receiver to perform security  processing for the message.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 2147483647
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 2147483647
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.SecurityModel.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.HeaderData.SecurityModel.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineBoots.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 2147483647
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 2147483647
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 2147483647
+    Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineBoots:
+      description: |-
+        It specifies the snmpEngineBoots value at the authoritative SNMP engine involved in the exchange of the message.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 2147483647
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 2147483647
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineBoots.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineBoots.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineTime.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 2147483647
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 2147483647
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 2147483647
+    Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineTime:
+      description: |-
+        It specifies the snmpEngineTime value at the authoritative SNMP engine involved in the exchange of the message.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 2147483647
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 2147483647
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineTime.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Snmpv3.SecurityParameters.AuthoritativeEngineTime.Counter'
           x-field-uid: 6
     Version:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8743,7 +8743,7 @@ components:
           x-field-uid: 3
     Flow.Snmpv2c.Data:
       description: |-
-        This contains the body of the SNMPv2C message.
+        This contains the body of the SNMP message.
 
         - Encoding of subsequent fields follow ASN.1 specification.
           Refer: http://www.itu.int/ITU-T/asn1/
@@ -10350,7 +10350,7 @@ components:
           maxLength: 10000
           x-field-uid: 2
         data:
-          $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
+          $ref: '#/components/schemas/Flow.Snmpv2c.Data'
           x-field-uid: 3
     Flow.Size:
       description: |-

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6563,7 +6563,7 @@ message FlowSnmpv2c {
   FlowSnmpv2cData data = 3;
 }
 
-// This contains the body of the SNMPv2C message.
+// This contains the body of the SNMP message.
 // 
 // - Encoding of subsequent fields follow ASN.1 specification.
 // Refer: http://www.itu.int/ITU-T/asn1/
@@ -7899,7 +7899,7 @@ message FlowSnmpv3ScopedPDU {
   optional string context_name = 2;
 
   // Description missing in models
-  FlowSnmpv2cPDU data = 3;
+  FlowSnmpv2cData data = 3;
 }
 
 // The frame size which overrides the total length of the packet

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5854,6 +5854,9 @@ message FlowHeader {
 
   // Description missing in models
   FlowRsvp rsvp = 22;
+
+  // Description missing in models
+  FlowSnmpv3 snmpv3 = 23;
 }
 
 // Custom packet header
@@ -6608,7 +6611,7 @@ message FlowSnmpv2cData {
   FlowSnmpv2cPDU report = 9;
 }
 
-// This contains the body of the SNMPv2C PDU.
+// This contains the body of the SNMP PDU.
 message FlowSnmpv2cPDU {
 
   // Description missing in models
@@ -7771,6 +7774,132 @@ message FlowRSVPPathObjectsCustom {
   // is 131050 (65525 * 2 hex character per byte).
   // default = 0000
   optional string bytes = 3;
+}
+
+// SNMPv3 packet header as defined in RFC3412, RFC2274 and RFC2574.
+message FlowSnmpv3 {
+
+  // Description missing in models
+  PatternFlowSnmpv3Version version = 1;
+
+  // Description missing in models
+  FlowSnmpv3HeaderData global_data = 2;
+
+  // Description missing in models
+  FlowSnmpv3SecurityParameters security_parameters = 3;
+
+  // Description missing in models
+  FlowSnmpv3ScopedPduData data = 4;
+}
+
+// It contains administrative parameters.
+message FlowSnmpv3HeaderData {
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataId id = 1;
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataMaxSize max_size = 2;
+
+  // Description missing in models
+  FlowSnmpv3HeaderDataFlags flags = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataSecurityModel security_model = 4;
+}
+
+// It contains several bit fields which control processing of the message.
+message FlowSnmpv3HeaderDataFlags {
+
+  // It is a secondary aid in determining whether a Report PDU MUST be sent.
+  // default = False
+  optional bool reportable = 1;
+
+  // If this flag is set, then the securityModel used by the SNMP  engine which sent the
+  // message MUST also protect the scopedPDU  in an SNMP message from disclosure.
+  // default = False
+  optional bool encrypted = 2;
+
+  // If this flag is set, then the securityModel used by  the SNMP engine which sent the
+  // message MUST identify  the securityName on whose behalf the SNMP message was generated
+  // and MUST provide,  in a securityModel-specific manner,  sufficient data for the receiver
+  // of the message to be able to authenticate that identification.
+  // default = False
+  optional bool authenticated = 3;
+}
+
+// It is used for communication between the Security Model modules in the sending and
+// receiving SNMP engines.  It follows RFC2274 and RFC2574.
+message FlowSnmpv3SecurityParameters {
+
+  // It specifies the snmpEngineID of the authoritative SNMP engine involved in the exchange
+  // of the message.
+  // default =
+  optional string authoritative_engine_id = 1;
+
+  // Description missing in models
+  PatternFlowSnmpv3SecurityParametersAuthoritativeEngineBoots authoritative_engine_boots = 2;
+
+  // Description missing in models
+  PatternFlowSnmpv3SecurityParametersAuthoritativeEngineTime authoritative_engine_time = 3;
+
+  // It specifies the user (principal) on whose behalf the message is being exchanged.
+  // default =
+  optional string user_name = 4;
+
+  // These are defined by the authentication protocol in use for the message,  as defined
+  // by the usmUserAuthProtocol column in the user's entry in the usmUserTable.
+  // default =
+  optional string authentication_parameters = 5;
+
+  // These are defined by the privacy protocol in use for the message,  as defined by
+  // the usmUserPrivProtocol column in the user's entry in the usmUserTable).
+  // default =
+  optional string privacy_parameters = 6;
+}
+
+// This field represents either the plain text scopedPDU  if the encrypted flag in the
+// snmpv3.global_data.flags is zero,  or it represents an encryptedPDU (encoded as an
+// OCTET STRING)  which MUST be decrypted by the securityModel in use to produce a plaintext
+// scopedPDU.
+message FlowSnmpv3ScopedPduData {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      plain_text = 1;
+      encrypted_pdu = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.plain_text
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowSnmpv3ScopedPDU plain_text = 2;
+
+  // It represents an encryptedPDU (encoded as an OCTET STRING).
+  // default =
+  optional string encrypted_pdu = 3;
+}
+
+// It contains information to identify an administratively unique context and a PDU.
+// The object identifiers in the PDU refer to managed objects which are (expected to
+// be) accessible within the specified context.
+message FlowSnmpv3ScopedPDU {
+
+  // It is an unique identifier within an administrative domain,  an SNMP entity that
+  // may realize an instance of a context with a particular contextName.
+  // default =
+  optional string context_engine_id = 1;
+
+  // It in conjunction with the context_engine_id field,  identifies the particular context
+  // associated with  the management information contained in the PDU portion of the message.
+  // default =
+  optional string context_name = 2;
+
+  // Description missing in models
+  FlowSnmpv2cPDU data = 3;
 }
 
 // The frame size which overrides the total length of the packet
@@ -24060,6 +24189,294 @@ message PatternFlowRSVPPathObjectsCustomType {
 
   // Description missing in models
   PatternFlowRSVPPathObjectsCustomTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv3VersionCounter {
+
+  // Description missing in models
+  // default = 3
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Version
+message PatternFlowSnmpv3Version {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 3
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [3]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv3VersionCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv3VersionCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv3HeaderDataIdCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// It is used between two SNMP entities to coordinate request messages and responses.
+message PatternFlowSnmpv3HeaderDataId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataIdCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv3HeaderDataMaxSizeCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The maximum message size that the sender can accept when another SNMP engine sends
+// an SNMP message (be it a response or any other message) to the sender of this message
+// on the transport in use for this message.
+message PatternFlowSnmpv3HeaderDataMaxSize {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataMaxSizeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataMaxSizeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv3HeaderDataSecurityModelCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// It identifies which Security Model was used by the sender to generate  the message
+// and therefore which securityModel MUST be used by the receiver to perform security
+// processing for the message.
+message PatternFlowSnmpv3HeaderDataSecurityModel {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataSecurityModelCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv3HeaderDataSecurityModelCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv3SecurityParametersAuthoritativeEngineBootsCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// It specifies the snmpEngineBoots value at the authoritative SNMP engine involved
+// in the exchange of the message.
+message PatternFlowSnmpv3SecurityParametersAuthoritativeEngineBoots {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv3SecurityParametersAuthoritativeEngineBootsCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv3SecurityParametersAuthoritativeEngineBootsCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowSnmpv3SecurityParametersAuthoritativeEngineTimeCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// It specifies the snmpEngineTime value at the authoritative SNMP engine involved in
+// the exchange of the message.
+message PatternFlowSnmpv3SecurityParametersAuthoritativeEngineTime {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowSnmpv3SecurityParametersAuthoritativeEngineTimeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowSnmpv3SecurityParametersAuthoritativeEngineTimeCounter decrement = 6;
 }
 
 // Version details

--- a/flow/packet-headers/header.yaml
+++ b/flow/packet-headers/header.yaml
@@ -118,3 +118,6 @@ components:
         rsvp:
           $ref: './rsvp.yaml#/components/schemas/Flow.Rsvp'
           x-field-uid: 22
+        snmpv3:
+          $ref: './snmpv3.yaml#/components/schemas/Flow.Snmpv3'
+          x-field-uid: 23

--- a/flow/packet-headers/snmpv2c.yaml
+++ b/flow/packet-headers/snmpv2c.yaml
@@ -80,7 +80,7 @@ components:
           $ref: '#/components/schemas/Flow.Snmpv2c.PDU'
           x-field-uid: 9 
     Flow.Snmpv2c.PDU:
-      description: This contains the body of the SNMPv2C PDU.
+      description: This contains the body of the SNMP PDU.
       type: object
       properties:
         request_id:

--- a/flow/packet-headers/snmpv2c.yaml
+++ b/flow/packet-headers/snmpv2c.yaml
@@ -27,7 +27,7 @@ components:
           x-field-uid: 3
     Flow.Snmpv2c.Data:
       description: |-
-          This contains the body of the SNMPv2C message.
+          This contains the body of the SNMP message.
 
           - Encoding of subsequent fields follow ASN.1 specification.
             Refer: http://www.itu.int/ITU-T/asn1/

--- a/flow/packet-headers/snmpv3.yaml
+++ b/flow/packet-headers/snmpv3.yaml
@@ -1,0 +1,226 @@
+components:
+  schemas:
+    Flow.Snmpv3:
+      description: SNMPv3 packet header as defined in RFC3412, RFC2274 and RFC2574.
+      type: object
+      properties:
+        version:
+          x-field-pattern:
+            description: >-
+              Version
+            format: integer
+            length: 31
+            default: 3
+            features: [count]
+          x-field-uid: 1
+        global_data:
+          $ref: '#/components/schemas/Flow.Snmpv3.HeaderData'
+          x-field-uid: 2 
+        security_parameters:
+          $ref: '#/components/schemas/Flow.Snmpv3.SecurityParameters'
+          x-field-uid: 3 
+        data:
+          $ref: '#/components/schemas/Flow.Snmpv3.ScopedPduData'
+          x-field-uid: 4
+
+    Flow.Snmpv3.HeaderData:
+      description: It contains administrative parameters.
+      type: object
+      properties:
+        id:
+          x-field-pattern:
+            description: >-
+              It is used between two SNMP entities to coordinate request messages and responses.
+            format: integer
+            length: 31
+            default: 0
+            features: [count]
+          x-field-uid: 1
+        max_size:
+          x-field-pattern:
+            description: >-
+              The maximum message size that the sender can accept when another SNMP engine sends 
+              an SNMP message (be it a response or any other message) to the sender of this message 
+              on the transport in use for this message.
+            format: integer
+            length: 31
+            default: 0
+            minimum: 484
+            features: [count]
+          x-field-uid: 2
+        flags:
+          $ref: '#/components/schemas/Flow.Snmpv3.HeaderDataFlags'
+          x-field-uid: 3
+        security_model:
+          x-field-pattern:
+            description: >-
+              It identifies which Security Model was used by the sender to generate 
+              the message and therefore which securityModel MUST be used by the receiver to perform security 
+              processing for the message.
+            format: integer
+            length: 31
+            default: 1
+            minimum: 1
+            features: [count]
+          x-field-uid: 4
+  
+    Flow.Snmpv3.HeaderDataFlags:
+      description: It contains several bit fields which control processing of the message.
+      type: object
+      properties:
+        reportable:
+          description: >-
+            It is a secondary aid in determining whether a Report PDU MUST be sent.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        encrypted:
+          description: >-
+            If this flag is set, then the securityModel used by the SNMP 
+            engine which sent the message MUST also protect the scopedPDU 
+            in an SNMP message from disclosure.
+            
+          type: boolean
+          default: false
+          x-field-uid: 2
+        authenticated:
+          description: >-
+            If this flag is set, then the securityModel used by 
+            the SNMP engine which sent the message MUST identify 
+            the securityName on whose behalf the SNMP message was generated and MUST provide, 
+            in a securityModel-specific manner, 
+            sufficient data for the receiver of the message to be able to authenticate that identification.
+          type: boolean
+          default: false
+          x-field-uid: 3
+
+    Flow.Snmpv3.SecurityParameters:
+      description: >-
+        It is used for communication between the Security Model modules in the sending and receiving SNMP engines. 
+        It follows RFC2274 and RFC2574.
+      type: object
+      properties:
+        authoritative_engine_id:
+          description: >-
+            It specifies the snmpEngineID of the authoritative SNMP engine involved in the exchange of the message.
+          type: string
+          format: hex
+          default: ""
+          maxLength: 10000
+          x-field-uid: 1
+        authoritative_engine_boots:
+          x-field-pattern:
+            description: >-
+              It specifies the snmpEngineBoots value at the authoritative SNMP engine involved in the exchange of the message.
+            format: integer
+            length: 31
+            default: 0
+            features: [count]
+          x-field-uid: 2
+        authoritative_engine_time:
+          x-field-pattern:
+            description: >-
+              It specifies the snmpEngineTime value at the authoritative SNMP engine involved in the exchange of the message.
+            format: integer
+            default: 0
+            length: 31
+            features: [count]
+          x-field-uid: 3
+        user_name:
+          description: >-
+            It specifies the user (principal) on whose behalf the message is being exchanged.
+          type: string
+          format: hex
+          default: ""
+          maxLength: 32
+          x-field-uid: 4
+        authentication_parameters:
+          description: >-
+            These are defined by the authentication protocol in use for the message, 
+            as defined by the usmUserAuthProtocol column in the user's entry in the usmUserTable.
+          type: string
+          format: hex
+          maxLength: 10000
+          default: ""
+          x-field-uid: 5
+        privacy_parameters:
+          description: >-
+            These are defined by the privacy protocol in use for the message, 
+            as defined by the usmUserPrivProtocol column in the user's entry in the usmUserTable).
+          type: string
+          format: hex
+          default: ""
+          maxLength: 10000
+          x-field-uid: 6
+
+    Flow.Snmpv3.ScopedPduData:
+      description: >-
+        This field represents either the plain text scopedPDU 
+        if the encrypted flag in the snmpv3.global_data.flags is zero, 
+        or it represents an encryptedPDU (encoded as an OCTET STRING) 
+        which MUST be decrypted by the securityModel in use to produce a plaintext scopedPDU.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: plain_text
+          x-field-uid: 1
+          x-enum:
+            plain_text:
+              x-field-uid: 1
+            encrypted_pdu:
+              x-field-uid: 2
+        plain_text:
+          $ref: '#/components/schemas/Flow.Snmpv3.ScopedPDU'
+          x-field-uid: 2
+        encrypted_pdu:
+          description: >-
+            It represents an encryptedPDU (encoded as an OCTET STRING).
+          type: string
+          format: hex
+          default: ""
+          maxLength: 10000
+          x-field-uid: 3
+
+    Flow.Snmpv3.ScopedPDU :
+      description: >-
+        It contains information to identify an administratively
+        unique context and a PDU.  The object identifiers in the PDU refer to
+        managed objects which are (expected to be) accessible within the
+        specified context.
+      type: object
+      properties:
+        context_engine_id :
+          description: >-
+            It is an unique identifier within an administrative domain, 
+            an SNMP entity that may realize an instance of a context with a particular contextName.
+          type: string
+          format: hex
+          default: ""
+          maxLength: 10000
+          x-field-uid: 1
+        context_name :
+          description: >-
+            It in conjunction with the context_engine_id field, 
+            identifies the particular context associated with 
+            the management information contained in the PDU portion of the message.
+          type: string
+          format: hex
+          default: ""
+          maxLength: 10000
+          x-field-uid: 2
+        data:
+          $ref: './snmpv2c.yaml#/components/schemas/Flow.Snmpv2c.PDU'
+          x-field-uid: 3
+    
+        
+        
+    
+       
+
+          
+
+
+
+        
+    

--- a/flow/packet-headers/snmpv3.yaml
+++ b/flow/packet-headers/snmpv3.yaml
@@ -210,7 +210,7 @@ components:
           maxLength: 10000
           x-field-uid: 2
         data:
-          $ref: './snmpv2c.yaml#/components/schemas/Flow.Snmpv2c.PDU'
+          $ref: './snmpv2c.yaml#/components/schemas/Flow.Snmpv2c.Data'
           x-field-uid: 3
     
         


### PR DESCRIPTION
Redocly View:
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-snmpv3/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config)
( New object at : set_config/flows/packet/snmpv3 )

[SNMPv3-RFC3412](https://www.ietf.org/rfc/rfc3412.txt?number=3412)
[USM-RFC2274](https://datatracker.ietf.org/doc/html/rfc2274)
[USM-SNMPv3-RFC2574](https://www.ietf.org/rfc/rfc2574.txt)


Requirement:
The user able to define SNMPv3 data plane packet headers. Purpose is to flood DUT with SNMPv3 request and responses. The user should be able to configure different fields in Global Data, Security Parameters and Data with ability to specify Increment/Decrement operations on certain applicable fields  in the specified fields.


Example usage:

```
f1 := config.Flows().Items()[0]
f1.SetName("f1:p1->p2").
TxRx().Port().SetTxName(p1.Name()).SetRxName(p2.Name())

f1.Duration().FixedPackets().SetPackets(100)
f1.Rate().SetPps(10)

f1.Packet().Add().Ethernet()
f1.Packet().Add().Ipv4()
f1.Packet().Add().Tcp()

// SNMPv3 Header
flowSnmpv3 := flow.Packet().Add().Snmpv3()

// Version
flowSnmpv3.Version().SetValue(3)

// Global Data
globalData := flowSnmpv3.GlobalData()
globalData.Id().SetValue(1)
globalData.MaxSize().SetValue(100)
globalData.Flags().
SetReportable(false).
SetEncrypted(false).
SetAuthenticated(true)
globalData.SecurityModel().SetValue(1)

// Security Parameters
securityParams := flowSnmpv3.SecurityParameters()
securityParams.SetAuthoritativeEngineId("80004f4db1aadcadbc89affa118dbd53824c6b05")
securityParams.AuthoritativeEngineBoots().SetValue(3)
securityParams.AuthoritativeEngineTime().SetValue(68125)
securityParams.SetUserName("tchyon")
securityParams.SetAuthenticationParameters("66716b4bc972810572775da4")
securityParams.SetPrivacyParameters("8c8c110c5bbf5ed5")

// Data
plainText := flowSnmpv3.Data().PlainText()
plainText.SetContextName("tchyon")
plainText.SetContextEngineId("80004f4db1aadcadbc89affa118dbd53824c6b05")
pdu := plainText.Data().GetRequest()
pdu.RequestId().SetValue(722681733)
pdu.SetErrorStatus(gosnappi.FlowSnmpv2CPDUErrorStatus.WRONG_VALUE)
pdu.ErrorIndex().SetValue(0)
varBinds := pdu.VariableBindings().Add()
varBinds.SetObjectIdentifier("0.1")
varBinds.Value().TimeticksValue().SetValue(20)
```