### PR TITLE
TCP Checksum added in TCP header

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -23884,7 +23884,7 @@ components:
           x-field-uid: 7
     Pattern.Flow.Tcp.Checksum:
       description: |-
-        The one's complement of the one's complement sum of all 16 bit words in header and text.  An all-zero value means that no checksum was transmitted.
+        The one's complement of the one's complement sum of all 16 bit words in header and text.  An all-zero value means that no checksum will be transmitted.   While computing the checksum, the checksum field itself is replaced with zeros.
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8429,6 +8429,9 @@ components:
         window:
           x-field-uid: 15
           $ref: '#/components/schemas/Pattern.Flow.Tcp.Window'
+        checksum:
+          x-field-uid: 16
+          $ref: '#/components/schemas/Pattern.Flow.Tcp.Checksum'
     Flow.Udp:
       description: |-
         UDP packet header
@@ -23879,6 +23882,46 @@ components:
           items:
             $ref: '#/components/schemas/Pattern.Flow.Tcp.Window.MetricTag'
           x-field-uid: 7
+    Pattern.Flow.Tcp.Checksum:
+      description: |-
+        The one's complement of the one's complement sum of all 16 bit words in header and text.  An all-zero value means that no checksum was transmitted.
+      type: object
+      properties:
+        choice:
+          description: |-
+            The type of checksum
+          type: string
+          x-enum:
+            generated:
+              x-field-uid: 1
+            custom:
+              x-field-uid: 2
+          default: generated
+          x-field-uid: 1
+          enum:
+          - generated
+          - custom
+        generated:
+          description: |-
+            A system generated checksum value
+          type: string
+          x-enum:
+            good:
+              x-field-uid: 1
+            bad:
+              x-field-uid: 2
+          default: good
+          x-field-uid: 2
+          enum:
+          - good
+          - bad
+        custom:
+          description: |-
+            A custom checksum value
+          type: integer
+          format: uint32
+          maximum: 65535
+          x-field-uid: 3
     Pattern.Flow.Udp.SrcPort.Counter:
       description: |-
         integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6264,6 +6264,9 @@ message FlowTcp {
 
   // Description missing in models
   PatternFlowTcpWindow window = 15;
+
+  // Description missing in models
+  PatternFlowTcpChecksum checksum = 16;
 }
 
 // UDP packet header
@@ -17104,6 +17107,36 @@ message PatternFlowTcpWindow {
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
   repeated PatternFlowTcpWindowMetricTag metric_tags = 7;
+}
+
+// The one's complement of the one's complement sum of all 16 bit words in header and
+// text.  An all-zero value means that no checksum was transmitted.
+message PatternFlowTcpChecksum {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      generated = 1;
+      custom = 2;
+    }
+  }
+  // The type of checksum
+  // default = Choice.Enum.generated
+  optional Choice.Enum choice = 1;
+
+  message Generated {
+    enum Enum {
+      unspecified = 0;
+      good = 1;
+      bad = 2;
+    }
+  }
+  // A system generated checksum value
+  // default = Generated.Enum.good
+  optional Generated.Enum generated = 2;
+
+  // A custom checksum value
+  optional uint32 custom = 3;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -17110,7 +17110,8 @@ message PatternFlowTcpWindow {
 }
 
 // The one's complement of the one's complement sum of all 16 bit words in header and
-// text.  An all-zero value means that no checksum was transmitted.
+// text.  An all-zero value means that no checksum will be transmitted.   While computing
+// the checksum, the checksum field itself is replaced with zeros.
 message PatternFlowTcpChecksum {
 
   message Choice {

--- a/flow/packet-headers/tcp.yaml
+++ b/flow/packet-headers/tcp.yaml
@@ -147,7 +147,8 @@ components:
           x-field-pattern:
             description: >-
               The one's complement of the one's complement sum of all 16 bit words in header and text. 
-              An all-zero value means that no checksum was transmitted.
+              An all-zero value means that no checksum will be transmitted.  
+              While computing the checksum, the checksum field itself is replaced with zeros.
             format: checksum
             length: 16
           x-field-uid: 16

--- a/flow/packet-headers/tcp.yaml
+++ b/flow/packet-headers/tcp.yaml
@@ -143,3 +143,11 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 15
+        checksum:
+          x-field-pattern:
+            description: >-
+              The one's complement of the one's complement sum of all 16 bit words in header and text. 
+              An all-zero value means that no checksum was transmitted.
+            format: checksum
+            length: 16
+          x-field-uid: 16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 click==8.0.4
-openapiart==0.3.10
+openapiart==0.3.11


### PR DESCRIPTION
**Redocly View**
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-checksum/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config)

**Objective :**
User defined checksum value (0 or anything else) as custom option in TCP checksum.

**Example:**

```

	config := gosnappi.NewConfig()
	// add ports
	p1 := config.Ports().Add().SetName("p1").SetLocation("eth1")
	p2 := config.Ports().Add().SetName("p2").SetLocation("eth2")

	f1 := config.Flows().Items()[0]
	f1.SetName("f1:p1->p2").
		TxRx().Port().SetTxName(p1.Name()).SetRxName(p2.Name())
	f1.Duration().FixedPackets().SetPackets(100)
	f1.Rate().SetPps(10)

	f1.Packet().Add().Ethernet()
        f1.Packet().Add().Ipv4()

        tcp := f1.Packet().Add().Tcp()
        tcp.Checksum().SetCustom(0)

```

@arkajyoti-cloud 