### PR TITLE
Support for User Defined Metrics

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11161,8 +11161,6 @@ components:
           description: |-
             Association.
           $ref: '#/components/schemas/FilterMetric.Association'
-          minItems: 1
-          maxItems: 32
           x-field-uid: 1
         receive_filters:
           description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8112,7 +8112,6 @@ components:
           description: |-
             The type of association.
           type: string
-          default: port_names
           x-field-uid: 1
           x-enum:
             port_names:
@@ -15790,9 +15789,8 @@ components:
       properties:
         choice:
           description: |-
-            The
+            The type
           type: string
-          default: port_names
           x-field-uid: 1
           x-enum:
             port_names:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -5960,7 +5960,6 @@ message FilterMetricAssociation {
     }
   }
   // The type of association.
-  // default = Choice.Enum.port_names
   optional Choice.Enum choice = 1;
 
   // List of port names.
@@ -11961,8 +11960,7 @@ message UserDefinedMetricsRequest {
       flow_names = 2;
     }
   }
-  // The
-  // default = Choice.Enum.port_names
+  // The type
   optional Choice.Enum choice = 1;
 
   // Names of ports for which to return results.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,6 +64,17 @@ components:
           items:
             $ref: '../lldp/lldp.yaml#/components/schemas/Lldp'
           x-field-uid: 9
+        filter_metrics:
+          x-status:
+            status: under_review
+            information: There may be changes in filter_metrics configuration
+          description: |-
+            The filter_metrics that will be configured on traffic generator.
+          type: array
+          items:
+            $ref: '../filter_metrics/filter_metrics.yaml#/components/schemas/FilterMetric'
+          x-field-uid: 10
+  
     Config.Options:
       description: |-
         Global configuration options.

--- a/filter_metrics/filter_metrics.yaml
+++ b/filter_metrics/filter_metrics.yaml
@@ -43,7 +43,6 @@ components:
           description: |-
             The type of association.
           type: string
-          default: port_names
           x-field-uid: 1
           x-enum:
             port_names:

--- a/filter_metrics/filter_metrics.yaml
+++ b/filter_metrics/filter_metrics.yaml
@@ -1,0 +1,72 @@
+components:
+  schemas:
+    FilterMetric:
+      x-status:
+        status: under_review
+        information: There may be changes in filter_metric configuration
+      description: >-
+        Configuration for FilterMetrics settings.
+      type: object
+      required: [name]
+      properties:
+        association:
+          description: >-
+            Association.
+          $ref: '#/components/schemas/FilterMetric.Association'
+          minItems: 1
+          maxItems: 32
+          x-field-uid: 1
+        receive_filters:
+          description: >-
+            A list of filters to apply to the packet receiving ports.
+            If no filters are specified then all packets will be counted.
+            A filter_metric can have multiple filters. The number of filters supported
+            is determined by the implementation.
+
+            When multiple filters are specified then implementation must &&
+            (and) all the filters.
+          type: array
+          items:
+            $ref: '../capture/capture.yaml#/components/schemas/Capture.Filter'
+          minItems: 1
+          maxItems: 32
+          x-field-uid: 2
+        name:
+          x-include: ../common/common.yaml#/components/schemas/Named.Object/properties/name
+          x-field-uid: 3
+
+    FilterMetric.Association:
+      description: >-
+        Configuration for filter_metric Association.
+        Based on the association, filter_metric will be applied to count packets on per port or per flow.
+      type: object
+      properties:
+        choice:
+          description: |-
+            The type of association.
+          type: string
+          default: port_names
+          x-field-uid: 1
+          x-enum:
+            port_names:
+              x-field-uid: 1
+            flow_names:
+              x-field-uid: 2
+        port_names:
+          description: >-
+            List of port names.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Port/properties/name'
+          x-field-uid: 2
+        flow_names:
+          description: >-
+            List of flow names.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Flow/properties/name'
+          x-field-uid: 3   

--- a/filter_metrics/filter_metrics.yaml
+++ b/filter_metrics/filter_metrics.yaml
@@ -25,7 +25,7 @@ components:
             (and) all the filters.
           type: array
           items:
-            $ref: '../capture/capture.yaml#/components/schemas/Capture.Filter'
+            $ref: '#/components/schemas/Filter.Packet'
           minItems: 1
           maxItems: 32
           x-field-uid: 2
@@ -67,4 +67,153 @@ components:
             type: string
           x-constraint:
           - '/components/schemas/Flow/properties/name'
-          x-field-uid: 3   
+          x-field-uid: 3
+
+    Filter.Packet:
+      description: >-
+        Configuration for filter packets
+      type: object
+      properties:
+        choice:
+          description: |-
+            The type of packet filter.
+          type: string
+          default: custom
+          x-field-uid: 1
+          x-enum:
+            custom:
+              x-field-uid: 1
+            ethernet:
+              x-field-uid: 2
+            vlan:
+              x-field-uid: 3
+            vxlan:
+              x-field-uid: 4
+            ipv4:
+              x-field-uid: 5
+            ipv6:
+              x-field-uid: 6
+            pfcpause:
+              x-field-uid: 7
+            ethernetpause:
+              x-field-uid: 8
+            tcp:
+              x-field-uid: 9
+            udp:
+              x-field-uid: 10
+            gre:
+              x-field-uid: 11
+            gtpv1:
+              x-field-uid: 12
+            gtpv2:
+              x-field-uid: 13
+            arp:
+              x-field-uid: 14
+            icmp:
+              x-field-uid: 15
+            icmpv6:
+              x-field-uid: 16
+            ppp:
+              x-field-uid: 17
+            igmpv1:
+              x-field-uid: 18
+            mpls:
+              x-field-uid: 19
+            snmpv2c:
+              x-field-uid: 20
+            rsvp:
+              x-field-uid: 21
+        custom:
+          description: >-
+            custom
+          $ref: '#/components/schemas/Filter.Field.Custom'
+          x-field-uid: 2
+        ethernet:
+          $ref: '../flow/packet-headers/ethernet.yaml#/components/schemas/Filter.Ethernet'
+          x-field-uid: 3
+        vlan:
+          $ref: '../flow/packet-headers/vlan.yaml#/components/schemas/Filter.Vlan'
+          x-field-uid: 4
+        vxlan:
+          $ref: '../flow/packet-headers/vxlan.yaml#/components/schemas/Filter.Vxlan'
+          x-field-uid: 5
+        ipv4:
+          $ref: '../flow/packet-headers/ipv4.yaml#/components/schemas/Filter.Ipv4'
+          x-field-uid: 6
+        ipv6:
+          $ref: '../flow/packet-headers/ipv6.yaml#/components/schemas/Filter.Ipv6'
+          x-field-uid: 7
+        pfcpause:
+          $ref: '../flow/packet-headers/pfcpause.yaml#/components/schemas/Filter.PfcPause'
+          x-field-uid: 8
+        ethernetpause:
+          $ref: '../flow/packet-headers/ethernetpause.yaml#/components/schemas/Filter.EthernetPause'
+          x-field-uid: 9
+        tcp:
+          $ref: '../flow/packet-headers/tcp.yaml#/components/schemas/Filter.Tcp'
+          x-field-uid: 10
+        udp:
+          $ref: '../flow/packet-headers/udp.yaml#/components/schemas/Filter.Udp'
+          x-field-uid: 11
+        gre:
+          $ref: '../flow/packet-headers/gre.yaml#/components/schemas/Filter.Gre'
+          x-field-uid: 12
+        gtpv1:
+          $ref: '../flow/packet-headers/gtp.yaml#/components/schemas/Filter.Gtpv1'
+          x-field-uid: 13
+        gtpv2:
+          $ref: '../flow/packet-headers/gtpv2.yaml#/components/schemas/Filter.Gtpv2'
+          x-field-uid: 14
+        arp:
+          $ref: '../flow/packet-headers/arp.yaml#/components/schemas/Filter.Arp'
+          x-field-uid: 15
+        icmp:
+          $ref: '../flow/packet-headers/icmp.yaml#/components/schemas/Filter.Icmp'
+          x-field-uid: 16
+        icmpv6:
+          $ref: '../flow/packet-headers/icmpv6.yaml#/components/schemas/Filter.Icmpv6'
+          x-field-uid: 17
+        ppp:
+          $ref: '../flow/packet-headers/ppp.yaml#/components/schemas/Filter.Ppp'
+          x-field-uid: 18
+        igmpv1:
+          $ref: '../flow/packet-headers/igmpv1.yaml#/components/schemas/Filter.Igmpv1'
+          x-field-uid: 19
+        mpls:
+          $ref: '../flow/packet-headers/mpls.yaml#/components/schemas/Filter.Mpls'
+          x-field-uid: 20
+        snmpv2c:
+          $ref: '../flow/packet-headers/snmpv2c.yaml#/components/schemas/Filter.Snmpv2c'
+          x-field-uid: 21
+        rsvp:
+          $ref: '../flow/packet-headers/rsvp.yaml#/components/schemas/Filter.Rsvp'
+          x-field-uid: 22
+
+    Filter.Field.Custom:
+      type: object
+      properties:
+        offset:
+          type: string
+          format: hex
+          default: "00"
+          x-field-uid: 1
+        value:
+          x-include: '#/components/schemas/Filter.Field/properties/value'
+          x-field-uid: 2
+        mask:
+          x-include: '#/components/schemas/Filter.Field/properties/mask'
+          x-field-uid: 3
+
+    Filter.Field:
+      type: object
+      properties:
+        value:
+          type: string
+          format: hex
+          default: "00"
+          x-field-uid: 1
+        mask:
+          type: string
+          format: hex
+          default: "00"
+          x-field-uid: 2

--- a/filter_metrics/filter_metrics.yaml
+++ b/filter_metrics/filter_metrics.yaml
@@ -13,8 +13,6 @@ components:
           description: >-
             Association.
           $ref: '#/components/schemas/FilterMetric.Association'
-          minItems: 1
-          maxItems: 32
           x-field-uid: 1
         receive_filters:
           description: >-

--- a/flow/packet-headers/arp.yaml
+++ b/flow/packet-headers/arp.yaml
@@ -89,3 +89,35 @@ components:
             default: 0.0.0.0
             features: [count, metric_tags]
           x-field-uid: 9
+
+    Filter.Arp:
+      description: ARP packet header
+      type: object
+      properties:
+        hardware_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        protocol_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        hardware_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        protocol_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        operation:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        sender_hardware_addr:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        sender_protocol_addr:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        target_hardware_addr:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8
+        target_protocol_addr:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 9

--- a/flow/packet-headers/ethernet.yaml
+++ b/flow/packet-headers/ethernet.yaml
@@ -44,3 +44,20 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 4
+
+    Filter.Ethernet:
+      description: Ethernet packet header
+      type: object
+      properties:
+        dst:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        src:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        ether_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        pfc_queue:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4

--- a/flow/packet-headers/ethernetpause.yaml
+++ b/flow/packet-headers/ethernetpause.yaml
@@ -50,3 +50,23 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 5
+    
+    Filter.EthernetPause:
+      description: IEEE 802.3x global ethernet pause packet header
+      type: object
+      properties:
+        dst:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        src:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        ether_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        control_op_code:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        time:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5

--- a/flow/packet-headers/gre.yaml
+++ b/flow/packet-headers/gre.yaml
@@ -62,3 +62,26 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 6
+    
+    Filter.Gre:
+      description: Standard GRE packet header (RFC2784)
+      type: object
+      properties:
+        checksum_present:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        reserved0:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        version:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        protocol:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        checksum:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        reserved1:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6

--- a/flow/packet-headers/gtp.yaml
+++ b/flow/packet-headers/gtp.yaml
@@ -162,3 +162,43 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 3
+    
+    Filter.Gtpv1:
+      type: object
+      properties:
+        version:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        protocol_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        reserved:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        e_flag:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        s_flag:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        pn_flag:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        message_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        message_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8
+        teid:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 9
+        squence_number:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 10
+        n_pdu_number:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 11
+        next_extension_header_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 12

--- a/flow/packet-headers/gtpv2.yaml
+++ b/flow/packet-headers/gtpv2.yaml
@@ -93,3 +93,34 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 9
+    
+    Filter.Gtpv2:
+      type: object
+      properties:
+        version:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        piggybacking_flag:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        teid_flag:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        spare1:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        message_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        message_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        teid:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        sequence_number:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8
+        spare2:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 9

--- a/flow/packet-headers/icmp.yaml
+++ b/flow/packet-headers/icmp.yaml
@@ -85,3 +85,36 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 2
+    
+    Filter.Icmp:
+      description: ICMP packet header
+      type: object
+      properties:
+        choice:
+          type: string
+          default: echo
+          x-field-uid: 1
+          x-enum:
+            echo:
+              x-field-uid: 1
+        echo:
+          $ref: '#/components/schemas/Filter.Icmp.Echo'
+          x-field-uid: 2
+    Filter.Icmp.Echo:
+      type: object
+      properties:
+        type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        code:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        checksum:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        identifier:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        sequence_number:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5

--- a/flow/packet-headers/icmpv6.yaml
+++ b/flow/packet-headers/icmpv6.yaml
@@ -72,3 +72,36 @@ components:
             format: checksum
             length: 16
           x-field-uid: 1
+    
+    Filter.Icmpv6:
+      description: ICMPv6 packet header
+      type: object
+      properties:
+        choice:
+          type: string
+          default: echo
+          x-field-uid: 1
+          x-enum:
+            echo:
+              x-field-uid: 1
+        echo:
+          $ref: '#/components/schemas/Filter.Icmpv6.Echo'
+          x-field-uid: 2
+    Filter.Icmpv6.Echo:
+      type: object
+      properties:
+        type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        code:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        identifier:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        sequence_number:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        checksum:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5

--- a/flow/packet-headers/igmpv1.yaml
+++ b/flow/packet-headers/igmpv1.yaml
@@ -49,3 +49,22 @@ components:
             default: 0.0.0.0
             features: [count, metric_tags]
           x-field-uid: 5
+
+    Filter.Igmpv1:
+      type: object
+      properties:
+        version:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 1
+        type:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 2
+        unused:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 3
+        checksum:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 4
+        group_address:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 5

--- a/flow/packet-headers/ipv4.yaml
+++ b/flow/packet-headers/ipv4.yaml
@@ -403,3 +403,106 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 6
+
+    Filter.Ipv4:
+      description: IPv4 packet header
+      type: object
+      properties:
+        version:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        header_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        priority:
+          $ref: "#/components/schemas/Filter.Ipv4.Priority"
+          x-field-uid: 3
+        total_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        identification:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        reserved:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        dont_fragment:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        more_fragments:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8
+        fragment_offset:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 9
+        time_to_live:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 10
+        protocol:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 11
+        header_checksum:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 12
+        src:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 13
+        dst:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 14
+    Filter.Ipv4.Priority:
+      description: A container for ipv4 raw, tos, dscp ip priorities.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: dscp
+          x-field-uid: 1
+          x-enum:
+            raw:
+              x-field-uid: 1
+            tos:
+              x-field-uid: 2
+            dscp:
+              x-field-uid: 3
+        raw:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        tos:
+          $ref: "#/components/schemas/Filter.Ipv4.Tos"
+          x-field-uid: 3
+        dscp:
+          $ref: "#/components/schemas/Filter.Ipv4.Dscp"
+          x-field-uid: 4
+    Filter.Ipv4.Dscp:
+      description: Differentiated services code point (DSCP) packet field.
+      type: object
+      properties:
+        phb:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        ecn:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+    Filter.Ipv4.Tos:
+      description: Type of service (TOS) packet field.
+      type: object
+      properties:
+        precedence:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        delay:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        throughput:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        reliability:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        monetary:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        unused:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6

--- a/flow/packet-headers/ipv6.yaml
+++ b/flow/packet-headers/ipv6.yaml
@@ -86,3 +86,32 @@ components:
             default: ::0
             features: [count, metric_tags]
           x-field-uid: 8
+
+    Filter.Ipv6:
+      description: IPv6 packet header
+      type: object
+      properties:
+        version:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        traffic_class:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        flow_label:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        payload_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        next_header:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        hop_limit:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        src:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        dst:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8

--- a/flow/packet-headers/mpls.yaml
+++ b/flow/packet-headers/mpls.yaml
@@ -41,3 +41,19 @@ components:
             default: 64
             features: [count, metric_tags]
           x-field-uid: 4
+
+    Filter.Mpls:
+      type: object
+      properties:
+        label:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 1
+        traffic_class:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 2
+        bottom_of_stack:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 3
+        time_to_live:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 4

--- a/flow/packet-headers/pfcpause.yaml
+++ b/flow/packet-headers/pfcpause.yaml
@@ -122,3 +122,47 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 13
+    
+    Filter.PfcPause:
+      description: IEEE 802.1Qbb PFC Pause packet header.
+      type: object
+      properties:
+        dst:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        src:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        ether_type:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        control_op_code:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        class_enable_vector:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        pause_class_0:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        pause_class_1:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        pause_class_2:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8
+        pause_class_3:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 9
+        pause_class_4:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 10
+        pause_class_5:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 11
+        pause_class_6:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 12
+        pause_class_7:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 13

--- a/flow/packet-headers/ppp.yaml
+++ b/flow/packet-headers/ppp.yaml
@@ -35,3 +35,16 @@ components:
             length: 16
             features: [auto, count, metric_tags]
           x-field-uid: 3
+
+    Filter.Ppp:
+      type: object
+      properties:
+        address:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 1
+        control:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 2
+        protocol_type:
+          $ref: ../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field
+          x-field-uid: 3

--- a/flow/packet-headers/rsvp.yaml
+++ b/flow/packet-headers/rsvp.yaml
@@ -1321,3 +1321,575 @@ components:
           maxLength: 131050
           default: '0000'
           x-field-uid: 3
+    
+    Filter.Rsvp:
+      type: object
+      properties:
+        version:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        flag:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        rsvp_checksum:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        time_to_live:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        reserved:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        rsvp_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        message_type:
+          $ref: "#/components/schemas/Filter.RSVP.Message"
+          x-field-uid: 7
+    Filter.RSVP.Message:
+      type: object
+      properties:
+        choice:
+          type: string
+          default: path
+          x-enum:
+            path:
+              x-field-uid: 1
+          x-field-uid: 1
+        path:
+          $ref: '#/components/schemas/Filter.RSVP.PathMessage'
+          x-field-uid: 2
+    Filter.RSVP.PathMessage:
+      description: >-
+        "Path" message requires the following list of objects in order as defined in https://www.rfc-editor.org/rfc/rfc3209.html#page-15:
+        1. SESSION
+        2. RSVP_HOP
+        3. TIME_VALUES
+        4. EXPLICIT_ROUTE [optional]
+        5. LABEL_REQUEST
+        6. SESSION_ATTRIBUTE [optional]
+        7. SENDER_TEMPLATE
+        8. SENDER_TSPEC
+        9. RECORD_ROUTE [optional]
+      type: object
+      properties:
+        objects:
+          description: >-
+            "Path" message requires atleast SESSION, RSVP_HOP, TIME_VALUES, LABEL_REQUEST, SENDER_TEMPLATE and SENDER_TSPEC objects in order.
+          type: array
+          items:
+            $ref: '#/components/schemas/Filter.RSVP.PathObjects'
+          x-field-uid: 1
+    Filter.RSVP.PathObjects:
+      description: >-
+        Every RSVP object encapsulated in an RSVP message consists of a 32-bit word header and the object's contents.
+      type: object
+      properties:
+        class_num:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClass'
+          x-field-uid: 1
+    Filter.RSVP.PathObjectsClass:
+      description: >-
+        The class number is used to identify the class of an object. Defined in https://www.iana.org/assignments/rsvp-parameters/rsvp-parameters.xhtml#rsvp-parameters-4 .
+        Curently supported class numbers are for "Path" message type.
+        "Path" message:
+        Supported Class numbers and it's value: SESSION: 1, RSVP_HOP: 3, TIME_VALUES: 5, EXPLICIT_ROUTE: 20, LABEL_REQUEST: 19, SESSION_ATTRIBUTE: 207, SENDER_TEMPLATE: 11, SENDER_TSPEC: 12, RECORD_ROUTE: 21, Custom: User defined bytes based on class and c-types not supported in above options.
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          x-enum:
+            session:
+              x-field-uid: 1
+            rsvp_hop:
+              x-field-uid: 2
+            time_values:
+              x-field-uid: 3
+            explicit_route:
+              x-field-uid: 4
+            label_request:
+              x-field-uid: 5
+            session_attribute:
+              x-field-uid: 6
+            sender_template:
+              x-field-uid: 7
+            sender_tspec:
+              x-field-uid: 8
+            record_route:
+              x-field-uid: 9
+            custom:
+              x-field-uid: 10
+        session:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassSession'
+          x-field-uid: 2
+        rsvp_hop:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassRsvpHop'
+          x-field-uid: 3
+        time_values:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassTimeValues'
+          x-field-uid: 4
+        explicit_route:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassExplicitRoute'
+          x-field-uid: 5
+        label_request:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassLabelRequest'
+          x-field-uid: 6
+        session_attribute:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassSessionAttribute'
+          x-field-uid: 7
+        sender_template:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassSenderTemplate'
+          x-field-uid: 8
+        sender_tspec:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassSenderTspec'
+          x-field-uid: 9
+        record_route:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassRecordRoute'
+          x-field-uid: 10
+    Filter.RSVP.PathObjectsClassSession:
+      type: object
+      properties:
+        length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        c_type:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsSessionCType'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsSessionCType:
+      description: >-
+        The body of an object corresponding to the class number and c-type.
+        Currently supported c-type for SESSION object is LSP Tunnel IPv4 (7).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: lsp_tunnel_ipv4
+          x-enum:
+            lsp_tunnel_ipv4:
+              x-field-uid: 1
+        lsp_tunnel_ipv4:
+          $ref: '#/components/schemas/Filter.RSVP.PathSessionLspTunnelIpv4'
+          x-field-uid: 2
+    Filter.RSVP.PathSessionLspTunnelIpv4:
+      type: object
+      properties:
+        ipv4_tunnel_end_point_address:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        reserved:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        tunnel_id:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        extended_tunnel_id:
+          description: >-
+            A 32-bit identifier used in the SESSION that remains constant over the life of the tunnel. Normally set to all zeros.
+            Ingress nodes that wish to narrow the scope of a SESSION to the ingress-egress pair may place their IPv4 address here as a globally unique identifier.
+          $ref: '#/components/schemas/Filter.RSVP.PathSessionExtTunnelId'
+          x-field-uid: 4
+    Filter.RSVP.PathSessionExtTunnelId:
+      type: object
+      properties:
+        choice:
+          description: 32 bit integer or IPv4 address.
+          type: string
+          default: as_integer
+          x-field-uid: 1
+          x-enum:
+            as_integer:
+              x-field-uid: 1
+            as_ipv4:
+              x-field-uid: 2
+        as_integer:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        as_ipv4:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+    Filter.RSVP.PathObjectsClassRsvpHop:
+      type: object
+      properties:
+        length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        c_type:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsRsvpHopCType'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsRsvpHopCType:
+      description: >-
+        Object for RSVP_HOP class.
+        Currently supported c-type is IPv4 (1).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: ipv4
+          x-enum:
+            ipv4:
+              x-field-uid: 1
+        ipv4:
+          $ref: '#/components/schemas/Filter.RSVP.PathRsvpHopIpv4'
+          x-field-uid: 2
+    Filter.RSVP.PathRsvpHopIpv4:
+      type: object
+      properties:
+        ipv4_address:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        logical_interface_handle:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsClassTimeValues:
+      description: >-
+        Object for TIME_VALUES class.
+        Currently supported c-type is Type 1 Time Value (1).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: type_1
+          x-enum:
+            type_1:
+              x-field-uid: 1
+        type_1:
+          $ref: '#/components/schemas/Filter.RSVP.PathTimeValuesType1'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsTimeValuesCType:
+      description: >-
+        Object for TIME_VALUES class.
+        Currently supported c-type is Type 1 Time Value (1).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: type_1
+          x-enum:
+            type_1:
+              x-field-uid: 1
+        type_1:
+          $ref: '#/components/schemas/Filter.RSVP.PathTimeValuesType1'
+          x-field-uid: 2
+    Filter.RSVP.PathTimeValuesType1:
+      type: object
+      properties:
+        refresh_period_r:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+    Filter.RSVP.PathObjectsClassExplicitRoute:
+      description: >-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        c_type:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsClassExplicitRouteCType'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsClassExplicitRouteCType:
+      description: >-
+        Object for EXPLICIT_ROUTE class and c-type is Type 1 Explicit Route (1).
+      type: object
+      properties:
+        choice:
+          type: string
+          default: type_1
+          x-field-uid: 1
+          x-enum:
+            type_1:
+              x-field-uid: 1
+        type_1:
+          $ref: '#/components/schemas/Filter.RSVP.PathExplicitRouteType1'
+          x-field-uid: 2
+    Filter.RSVP.PathExplicitRouteType1:
+      type: object
+      properties:
+        subobjects:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+    Filter.RSVP.PathObjectsClassLabelRequest:
+      description: >-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        c_type:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsLabelRequestCType'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsLabelRequestCType:
+      description: >-
+        Object for LABEL_REQUEST class.
+        Currently supported c-type is Without Label Range (1).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: without_label_range
+          x-enum:
+            without_label_range:
+              x-field-uid: 1
+        without_label_range:
+          $ref: '#/components/schemas/Filter.RSVP.PathLabelRequestWithoutLabelRange'
+          x-field-uid: 2
+    Filter.RSVP.PathLabelRequestWithoutLabelRange:
+      type: object
+      properties:
+        reserved:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        l3pid:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsClassSessionAttribute:
+      description: >-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        c_type:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsSessionAttributeCType'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsSessionAttributeCType:
+      description: >-
+        Object for SESSION_ATTRIBUTE class.
+        Currently supported c-type is LSP_Tunnel_RA (1) and LSP_Tunnel (7).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: lsp_tunnel
+          x-enum:
+            lsp_tunnel:
+              x-field-uid: 1
+            lsp_tunnel_ra:
+              x-field-uid: 2
+        lsp_tunnel:
+          $ref: '#/components/schemas/Filter.RSVP.PathSessionAttributeLspTunnel'
+          x-field-uid: 2
+        lsp_tunnel_ra:
+          $ref: '#/components/schemas/Filter.RSVP.PathSessionAttributeLspTunnelRa'
+          x-field-uid: 3
+    Filter.RSVP.PathSessionAttributeLspTunnel:
+      type: object
+      properties:
+        setup_priority:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        holding_priority:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        flags:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        name_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        session_name:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+    Filter.RSVP.PathSessionAttributeLspTunnelRa:
+      type: object
+      properties:
+        exclude_any:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        include_any:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        include_all:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        setup_priority:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        holding_priority:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        flags:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        name_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        session_name:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8
+    Filter.RSVP.PathObjectsClassSenderTemplate:
+      description: >-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        c_type:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsSenderTemplateCType'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsSenderTemplateCType:
+      description: >-
+        Object for SENDER_TEMPLATE class.
+        Currently supported c-type is LSP Tunnel IPv4 (7).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: lsp_tunnel_ipv4
+          x-enum:
+            lsp_tunnel_ipv4:
+              x-field-uid: 1
+        lsp_tunnel_ipv4:
+          $ref: '#/components/schemas/Filter.RSVP.PathSenderTemplateLspTunnelIpv4'
+          x-field-uid: 2
+    Filter.RSVP.PathSenderTemplateLspTunnelIpv4:
+      type: object
+      properties:
+        ipv4_tunnel_sender_address:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        reserved:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        lsp_id:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+    Filter.RSVP.PathObjectsClassSenderTspec:
+      description: >-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        c_type:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsSenderTspecCType'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsSenderTspecCType:
+      description: >-
+        Object for SENDER_TSPEC class.
+        Currently supported c-type is int-serv (2).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          default: int_serv
+          x-enum:
+            int_serv:
+              x-field-uid: 1
+        int_serv:
+          $ref: '#/components/schemas/Filter.RSVP.PathSenderTspecIntServ'
+          x-field-uid: 2
+    Filter.RSVP.PathSenderTspecIntServ:
+      type: object
+      properties:
+        version:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        reserved1:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        overall_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        service_header:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        zero_bit:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        reserved2:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        length_of_service_data:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        parameter_id_token_bucket_tspec:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8
+        parameter_127_flag:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 9
+        parameter_127_length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 10
+        token_bucket_rate:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 11
+        token_bucket_size:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 12
+        peak_data_rate:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 13
+        minimum_policed_unit:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 14
+        maximum_packet_size:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 15
+    Filter.RSVP.PathObjectsClassRecordRoute:
+      description: >-
+        C-Type is specific to a class num.
+      type: object
+      properties:
+        length:
+          description: >-
+            A 16-bit field containing the total object length in bytes. 
+            Must always be a multiple of 4 or at least 4.
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        c_type:
+          $ref: '#/components/schemas/Filter.RSVP.PathObjectsRecordRouteCType'
+          x-field-uid: 2
+    Filter.RSVP.PathObjectsRecordRouteCType:
+      description: >-
+        Object for RECORD_ROUTE class.
+        c-type is Type 1 Route Record (1).
+      type: object
+      properties:
+        choice:
+          type: string
+          default: type_1
+          x-field-uid: 1
+          x-enum:
+            type_1:
+              x-field-uid: 1
+        type_1:
+          $ref: '#/components/schemas/Filter.RSVP.PathRecordRouteType1'
+          x-field-uid: 2
+    Filter.RSVP.PathRecordRouteType1:
+      type: object
+      properties:
+        subobjects:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1

--- a/flow/packet-headers/snmpv2c.yaml
+++ b/flow/packet-headers/snmpv2c.yaml
@@ -368,3 +368,105 @@ components:
 
         
     
+    Filter.Snmpv2c:
+      description: SNMPv2C packet header as defined in RFC1901 and RFC3416.
+      type: object
+      properties:
+        version:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        community:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        data:
+          $ref: '#/components/schemas/Filter.Snmpv2c.Data'
+          x-field-uid: 3
+    Filter.Snmpv2c.Data:
+      description: |-
+        This contains the body of the SNMPv2C message.
+        
+        - Encoding of subsequent fields follow ASN.1 specification.
+          Refer: http://www.itu.int/ITU-T/asn1/
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          x-enum:
+            get_request:
+              x-field-uid: 1
+            get_next_request:
+              x-field-uid: 2
+            response:
+              x-field-uid: 3
+            set_request:
+              x-field-uid: 4
+            get_bulk_request:
+              x-field-uid: 5
+            inform_request:
+              x-field-uid: 6
+            snmpv2_trap:
+              x-field-uid: 7
+            report:
+              x-field-uid: 8
+        get_request:
+          $ref: '#/components/schemas/Filter.Snmpv2c.PDU'
+          x-field-uid: 2
+        get_next_request:
+          $ref: '#/components/schemas/Filter.Snmpv2c.PDU'
+          x-field-uid: 3
+        response:
+          $ref: '#/components/schemas/Filter.Snmpv2c.PDU'
+          x-field-uid: 4
+        set_request:
+          $ref: '#/components/schemas/Filter.Snmpv2c.PDU'
+          x-field-uid: 5
+        get_bulk_request:
+          $ref: '#/components/schemas/Filter.Snmpv2c.BulkPDU'
+          x-field-uid: 6
+        inform_request:
+          $ref: '#/components/schemas/Filter.Snmpv2c.PDU'
+          x-field-uid: 7
+        snmpv2_trap:
+          $ref: '#/components/schemas/Filter.Snmpv2c.PDU'
+          x-field-uid: 8
+        report:
+          $ref: '#/components/schemas/Filter.Snmpv2c.PDU'
+          x-field-uid: 9
+    Filter.Snmpv2c.PDU:
+      description: This contains the body of the SNMPv2C PDU.
+      type: object
+      properties:
+        request_id:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        error_status:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        error_index:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        variable_bindings:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+    Filter.Snmpv2c.BulkPDU:
+      description: The purpose of the GetBulkRequest-PDU is to request the transfer of
+        a potentially large amount of data, including, but not limited to, the efficient
+        and rapid retrieval of large tables.
+      type: object
+      properties:
+        request_id:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        non_repeaters:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        max_repetitions:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        variable_bindings:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+

--- a/flow/packet-headers/tcp.yaml
+++ b/flow/packet-headers/tcp.yaml
@@ -143,3 +143,53 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 15
+    
+    Filter.Tcp:
+      description: TCP packet header
+      type: object
+      properties:
+        src_port:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        dst_port:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        seq_num:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        ack_num:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4
+        data_offset:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 5
+        ecn_ns:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 6
+        ecn_cwr:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 7
+        ecn_echo:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 8
+        ctl_urg:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 9
+        ctl_ack:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 10
+        ctl_psh:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 11
+        ctl_rst:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 12
+        ctl_syn:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 13
+        ctl_fin:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 14
+        window:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 15

--- a/flow/packet-headers/udp.yaml
+++ b/flow/packet-headers/udp.yaml
@@ -38,3 +38,20 @@ components:
             format: checksum
             length: 16
           x-field-uid: 4
+
+    Filter.Udp:
+      description: UDP packet header
+      type: object
+      properties:
+        src_port:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        dst_port:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        length:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        checksum:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4

--- a/flow/packet-headers/vlan.yaml
+++ b/flow/packet-headers/vlan.yaml
@@ -46,3 +46,20 @@ components:
             default: 65535
             features: [count, metric_tags]
           x-field-uid: 4
+
+    Filter.Vlan:
+      description: VLAN packet header
+      type: object
+      properties:
+        priority:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        cfi:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        id:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        tpid:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4

--- a/flow/packet-headers/vxlan.yaml
+++ b/flow/packet-headers/vxlan.yaml
@@ -43,3 +43,20 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 4
+
+    Filter.Vxlan:
+      description: VXLAN packet header
+      type: object
+      properties:
+        flags:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 1
+        reserved0:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 2
+        vni:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 3
+        reserved1:
+          $ref: "../../filter_metrics/filter_metrics.yaml#/components/schemas/Filter.Field"
+          x-field-uid: 4

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -28,6 +28,8 @@ components:
               x-field-uid: 8
             rsvp:
               x-field-uid: 9
+            user_defined_metrics:
+              x-field-uid: 10
         port:
           $ref: './port.yaml#/components/schemas/Port.Metrics.Request'
           x-field-uid: 2
@@ -55,6 +57,9 @@ components:
         rsvp:
           $ref: './rsvp.yaml#/components/schemas/Rsvp.Metrics.Request'
           x-field-uid: 10
+        user_defined:
+          $ref: './uds.yaml#/components/schemas/User.Defined.Metrics.Request'
+          x-field-uid: 11
     Metrics.Response:
       description: >-
         Response containing chosen traffic generator metrics.
@@ -83,6 +88,8 @@ components:
               x-field-uid: 8
             rsvp_metrics:
               x-field-uid: 9
+            user_defined_metrics:
+              x-field-uid: 10
         port_metrics:
           type: array
           items:
@@ -128,3 +135,8 @@ components:
           items:
             $ref: './rsvp.yaml#/components/schemas/Rsvp.Metric'
           x-field-uid: 10
+        user_defined_metrics:
+          type: array
+          items:
+            $ref: './uds.yaml#/components/schemas/User.Defined.Metric'
+          x-field-uid: 11

--- a/result/uds.yaml
+++ b/result/uds.yaml
@@ -7,9 +7,8 @@ components:
       properties:
         choice:
           description: |-
-            The
+            The type
           type: string
-          default: port_names
           x-field-uid: 1
           x-enum:
             port_names:

--- a/result/uds.yaml
+++ b/result/uds.yaml
@@ -1,0 +1,102 @@
+components:
+  schemas:
+    User.Defined.Metrics.Request:
+      description: |-
+        The user defined metrics result request to the traffic generator
+      type: object
+      properties:
+        choice:
+          description: |-
+            The
+          type: string
+          default: port_names
+          x-field-uid: 1
+          x-enum:
+            port_names:
+              x-field-uid: 1
+            flow_names:
+              x-field-uid: 2
+        port_names:
+          description: |-
+            Names of ports for which to return results.
+            An empty list will return all port row results.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Port/properties/name'
+          x-field-uid: 2
+        flow_names:
+          description: |-
+            Names of flows for which to return results.
+            An empty list will return all flow row results.
+          type: array
+          items:
+            type: string
+          x-constraint:
+            - '/components/schemas/Flow/properties/name'
+          x-field-uid: 3
+        column_names:
+          description: >-
+            The list of column names that the returned result set will contain.
+            If the list is empty then all columns will be returned.
+            The name of the port cannot be excluded.
+          type: array
+          items:
+            type: string
+            x-enum:
+              frames_tx:
+                x-field-uid: 1
+              frames_rx:
+                x-field-uid: 2
+          x-field-uid: 4
+    User.Defined.Metric:
+      type: object
+      properties:
+        name:
+          description: >-
+            The name of a configured port/flow
+          type: string
+          x-constraint:
+          - '/components/schemas/Port/properties/name'
+          - '/components/schemas/Flow/properties/name'
+          x-field-uid: 1
+        frames_tx:
+          description: >-
+            The current total number of frames transmitted
+          type: integer
+          format: uint64
+          x-field-uid: 2
+        frames_rx:
+          description: >-
+            The current total number of valid frames received
+          type: integer
+          format: uint64
+          x-field-uid: 3
+        filtered_metrics:
+          description: |-
+            List of metrics corresponding to a set of values applicable
+            for configured filter metrics object in the corresponding port or flow.
+            The container is keyed by list of tag-value pairs.
+          type: array
+          items:
+            $ref: '#/components/schemas/User.Defined.Filter.Metric'
+          x-field-uid: 4
+    User.Defined.Filter.Metric:
+      description: |-
+        Metrics for each set of values applicable for configured
+        metric tags in ingress or egress packet header fields of corresponding flow.
+        The container is keyed by list of tag-value pairs.
+      type: object
+      properties:
+        filter_name:
+          description: |-
+            Name of the filter metrics
+          type: string
+          x-field-uid: 1
+        filter_value:
+          description: |-
+            The current total number of frames adhering to the filter condition
+          type: integer
+          format: uint64
+          x-field-uid: 2


### PR DESCRIPTION
**Redocly View**
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-uds/artifacts/openapi.yaml&nocors#tag/Monitor)

New Objects at:
- `set_config/filter_metrics`
- `get_metrics/user_defined`


**Requirement**
Offer a means for users to configure and retrieve metrics based on custom conditions established by the user on packets generated by the test tool. These filters can be specified either on a per-port or per-flow basis.

**Usage**
```go
// configure filter metrics
config := gosnappi.NewConfig()
f1 := config.FilterMetrics().Add()
f1.SetName("filter_ip").Association().SetPortNames([]string{"p1", "p2"})
f1.ReceiveFilters().Add().Ipv4().Dst().SetValue("01010101").SetMask("00000000")
f1.ReceiveFilters().Add().Custom().SetValue("01010101").SetMask("00000000").SetOffset(18)

// rest of the script

mr := gosnappi.NewMetricsRequest()
mr.UserDefined().SetPortNames([]string{"p1", "p2"})
api.GetMetrics(mr)

/*

Result structure
------------------------------------
Response:
	- name: p1
	  frames_tx: 1000
	  frames_rx: 0
	  filtered_metrics:
	    -  filter_name: "filter_ip"
	       filter_value: 0
	- name: p2
	  frames_tx: 0
	  frames_rx: 1000
	  filtered_metrics:
	    -  filter_name: "filter_ip"
	       filter_value: 500

Result of the metrics
-------------------------------------
Name	frames_tx	    frames_rx	filter_ip
p1	        1000	    0			0
p2		0		   1000		500

*/
```