### PR TITLE
Support of retrieval of Extended Community in BGP Learned Information.

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -15727,8 +15727,15 @@ components:
           x-field-uid: 2
           $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity'
     BgpPrefix.ExtendedCommunity:
-      description: |-
-        The Extended Communities Attribute is a optional BGP attribute,defined in RFC4360 with the Type Code 16.  Community and Extended Communities  attributes are utilized to trigger routing decisions, such as acceptance, rejection,  preference, or redistribution.  An extended community is an 8-bytes value. It is divided into two main parts. The first 2 bytes of the community  encode a type and optonal sub-type field. The last 6 bytes (or 7 bytes for types without a sub-type) carry a unique set of data in a format defined by the type and optional sub-type field.  Extended communities provide a larger  range for grouping or categorizing communities.
+      description: "The Extended Communities Attribute is a optional BGP attribute,defined\
+        \ in RFC4360 with the Type Code 16. \nCommunity and Extended Communities \
+        \ attributes are utilized to trigger routing decisions, such as acceptance,\
+        \ rejection,  preference, or redistribution. \nAn extended community is an\
+        \ 8-bytes value. It is divided into two main parts. The first 2 bytes of the\
+        \ community  encode a type and optonal sub-type field.\nThe last 6 bytes (or\
+        \ 7 bytes for types without a sub-type) carry a unique set of data in a format\
+        \ defined by the type and optional sub-type field. \nExtended communities\
+        \ provide a larger  range for grouping or categorizing communities."
       type: object
       properties:
         choice:
@@ -15960,7 +15967,7 @@ components:
           format: uint32
           description: "The color value is user defined and configured locally and\
             \ used to determine whether a data packet can be transmitted on a certain\
-            \ tunnel or not in conjunction with the Encapsulation attribute. It is\
+            \ tunnel or not\nin conjunction with the Encapsulation attribute. It is\
             \ defined in RFC9012.           "
           x-field-uid: 2
     BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Encapsulation:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -15614,7 +15614,7 @@ components:
             Optional received Extended Community attributes. Each received Extended Community attribute is available for retrieval in two forms. Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use. In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the  'structured' format which is an optional field.
           type: array
           items:
-            $ref: '#/components/schemas/BgpPrefix.RecvExtendedCommunity'
+            $ref: '#/components/schemas/Result.ExtendedCommunity'
           x-field-uid: 11
         as_path:
           x-field-uid: 8
@@ -15694,7 +15694,7 @@ components:
             Optional received Extended Community attributes. Each received Extended Community attribute is available for retrieval in two forms. Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use. In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the  'structured' format which is an optional field.
           type: array
           items:
-            $ref: '#/components/schemas/BgpPrefix.RecvExtendedCommunity'
+            $ref: '#/components/schemas/Result.ExtendedCommunity'
           x-field-uid: 11
         as_path:
           x-field-uid: 8
@@ -15711,7 +15711,7 @@ components:
             The multi exit discriminator (MED) is an optional non-transitive attribute and the value is used for route selection. The route with the lowest MED value is preferred.
           type: integer
           format: uint32
-    BgpPrefix.RecvExtendedCommunity:
+    Result.ExtendedCommunity:
       description: |-
         Each received Extended Community attribute is available for retrieval in two forms. Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use. In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the 'structured' format which is an optional field.
       type: object
@@ -15725,8 +15725,8 @@ components:
           x-field-uid: 1
         structured:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity'
-    BgpPrefix.ExtendedCommunity:
+          $ref: '#/components/schemas/Result.ExtendedCommunityStructured'
+    Result.ExtendedCommunityStructured:
       description: "The Extended Communities Attribute is a optional BGP attribute,defined\
         \ in RFC4360 with the Type Code 16. \nCommunity and Extended Communities \
         \ attributes are utilized to trigger routing decisions, such as acceptance,\
@@ -15760,23 +15760,23 @@ components:
           - non_transitive_2octet_as_type
         transitive_2octet_as_type:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive2OctetAsType'
         transitive_ipv4_address_type:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveIpv4AddressType'
         transitive_4octet_as_type:
           x-field-uid: 4
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive4OctetAsType'
         transitive_opaque_type:
           x-field-uid: 5
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveOpaqueType'
         non_transitive_2octet_as_type:
           x-field-uid: 6
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType'
-    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteTarget:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.NonTransitive2OctetAsType'
+    Result.ExtendedCommunity.Transitive2OctetAsType.RouteTarget:
       description: "The Route Target Community identifies one or more routers that\
-        \ may receive a set of routes (that carry this Community) carried by BGP.\
-        \  It is sent with sub-type as 0x02.            "
+        \ may receive a set of routes (that carry this Community) carried by BGP Update\
+        \ message.  It is sent with sub-type as 0x02.            "
       type: object
       properties:
         global_2byte_as:
@@ -15792,7 +15792,7 @@ components:
           description: |-
             The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which the Autonomous System number carried in the Global Administrator sub-field has been assigned by an appropriate authority.
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin:
+    Result.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin:
       description: |-
         The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP. It is sent with sub-type as 0x03 .
       type: object
@@ -15810,7 +15810,7 @@ components:
           type: integer
           format: uint32
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType:
+    Result.ExtendedCommunity.Transitive2OctetAsType:
       description: "The Transitive Two-Octet AS-Specific Extended Community is sent\
         \ as type 0x00 .         "
       type: object
@@ -15828,11 +15828,11 @@ components:
           - route_origin_subtype
         route_target_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteTarget'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive2OctetAsType.RouteTarget'
         route_origin_subtype:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin'
-    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin'
+    Result.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin:
       description: |-
         The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP It is sent with sub-type as 0x03.
       type: object
@@ -15850,7 +15850,7 @@ components:
           format: uint32
           maximum: 65535
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget:
+    Result.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget:
       description: "The Route Target Community identifies one or more routers that\
         \ may receive a set of routes (that carry this Community) carried by BGP.\
         \  It is sent with sub-type as 0x02.             "
@@ -15868,7 +15868,7 @@ components:
           description: |-
             The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which  the IP address carried in the Global Administrator sub-field has been assigned by an appropriate authority.
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType:
+    Result.ExtendedCommunity.TransitiveIpv4AddressType:
       description: |-
         The Transitive IPv4 Address Specific Extended Community is sent as type 0x01.
       type: object
@@ -15886,11 +15886,11 @@ components:
           - route_origin_subtype
         route_target_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget'
         route_origin_subtype:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin'
-    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteTarget:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin'
+    Result.ExtendedCommunity.Transitive4OctetAsType.RouteTarget:
       description: "The Route Target Community identifies one or more routers that\
         \ may receive a set of routes (that carry this Community) carried by BGP.\
         \  It is sent with sub-type as 0x02              "
@@ -15909,7 +15909,7 @@ components:
           description: |-
             The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which the Autonomous System number carried in the Global Administrator sub-field has been assigned by an appropriate authority.
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin:
+    Result.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin:
       description: |-
         The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP. It is sent with sub-type as 0x03.
       type: object
@@ -15927,7 +15927,7 @@ components:
           format: uint32
           maximum: 65535
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType:
+    Result.ExtendedCommunity.Transitive4OctetAsType:
       description: "The Transitive Four-Octet AS-Specific Extended Community is sent\
         \ as type 0x02. It is defined in RFC 5668.       "
       type: object
@@ -15945,11 +15945,11 @@ components:
           - route_origin_subtype
         route_target_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteTarget'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive4OctetAsType.RouteTarget'
         route_origin_subtype:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin'
-    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Color:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin'
+    Result.ExtendedCommunity.TransitiveOpaqueType.Color:
       description: "The Color Community contains locally administrator defined 'color'\
         \ value which is used in conjunction with Encapsulation  attribute to decide\
         \ whether a data packet can be transmitted on a certain tunnel or not. It\
@@ -15970,7 +15970,7 @@ components:
             \ tunnel or not\nin conjunction with the Encapsulation attribute. It is\
             \ defined in RFC9012.           "
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Encapsulation:
+    Result.ExtendedCommunity.TransitiveOpaqueType.Encapsulation:
       description: |-
         This identifies the type of tunneling technology being signalled. It is defined in RFC9012 and sent with sub-type as 0x0c.
       type: object
@@ -15993,7 +15993,7 @@ components:
           format: uint32
           maximum: 65535
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType:
+    Result.ExtendedCommunity.TransitiveOpaqueType:
       description: |-
         The Transitive Opaque Extended Community is sent as type 0x03.
       type: object
@@ -16011,11 +16011,11 @@ components:
           - encapsulation_subtype
         color_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Color'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveOpaqueType.Color'
         encapsulation_subtype:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Encapsulation'
-    BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveOpaqueType.Encapsulation'
+    Result.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth:
       description: |-
         The Link Bandwidth Extended Community attribute is defined in draft-ietf-idr-link-bandwidth. It is sent with sub-type as 0x04.
       type: object
@@ -16033,7 +16033,7 @@ components:
           type: number
           format: float
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType:
+    Result.ExtendedCommunity.NonTransitive2OctetAsType:
       description: "The Non-Transitive Two-Octet AS-Specific Extended Community is\
         \ sent as type 0x40.         "
       type: object
@@ -16048,7 +16048,7 @@ components:
           - link_bandwidth_subtype
         link_bandwidth_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth'
     Result.BgpCommunity:
       description: |-
         BGP communities provide additional capability for tagging routes and  for modifying BGP routing policy on upstream and downstream routers. BGP community is a 32-bit number which is broken into 16-bit AS number and  a 16-bit custom value.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -11572,7 +11572,7 @@ message BgpPrefixIpv4UnicastState {
   // which all 8 bytes (16 hex characters) is always present and available for use. In
   // addition, if supported by the implementation, the Extended Community attribute may
   // also be retrieved in the  'structured' format which is an optional field.
-  repeated BgpPrefixRecvExtendedCommunity extended_communities = 11;
+  repeated ResultExtendedCommunity extended_communities = 11;
 
   // Description missing in models
   ResultBgpAsPath as_path = 8;
@@ -11623,7 +11623,7 @@ message BgpPrefixIpv6UnicastState {
   // which all 8 bytes (16 hex characters) is always present and available for use. In
   // addition, if supported by the implementation, the Extended Community attribute may
   // also be retrieved in the  'structured' format which is an optional field.
-  repeated BgpPrefixRecvExtendedCommunity extended_communities = 11;
+  repeated ResultExtendedCommunity extended_communities = 11;
 
   // Description missing in models
   ResultBgpAsPath as_path = 8;
@@ -11642,14 +11642,14 @@ message BgpPrefixIpv6UnicastState {
 // and available for use. In addition, if supported by the implementation, the Extended
 // Community attribute may also be retrieved in the 'structured' format which is an
 // optional field.
-message BgpPrefixRecvExtendedCommunity {
+message ResultExtendedCommunity {
 
   // The raw byte contents of the 8 bytes received in the Extended Community as 16 hex
   // characters.
   optional string raw = 1;
 
   // Description missing in models
-  BgpPrefixExtendedCommunity structured = 2;
+  ResultExtendedCommunityStructured structured = 2;
 }
 
 // The Extended Communities Attribute is a optional BGP attribute,defined in RFC4360
@@ -11661,7 +11661,7 @@ message BgpPrefixRecvExtendedCommunity {
 // The last 6 bytes (or 7 bytes for types without a sub-type) carry a unique set of
 // data in a format defined by the type and optional sub-type field.
 // Extended communities provide a larger  range for grouping or categorizing communities.
-message BgpPrefixExtendedCommunity {
+message ResultExtendedCommunityStructured {
 
   message Choice {
     enum Enum {
@@ -11677,25 +11677,25 @@ message BgpPrefixExtendedCommunity {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitive2OctetAsType transitive_2octet_as_type = 2;
+  ResultExtendedCommunityTransitive2OctetAsType transitive_2octet_as_type = 2;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitiveIpv4AddressType transitive_ipv4_address_type = 3;
+  ResultExtendedCommunityTransitiveIpv4AddressType transitive_ipv4_address_type = 3;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitive4OctetAsType transitive_4octet_as_type = 4;
+  ResultExtendedCommunityTransitive4OctetAsType transitive_4octet_as_type = 4;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitiveOpaqueType transitive_opaque_type = 5;
+  ResultExtendedCommunityTransitiveOpaqueType transitive_opaque_type = 5;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityNonTransitive2OctetAsType non_transitive_2octet_as_type = 6;
+  ResultExtendedCommunityNonTransitive2OctetAsType non_transitive_2octet_as_type = 6;
 }
 
 // The Route Target Community identifies one or more routers that may receive a set
-// of routes (that carry this Community) carried by BGP.  It is sent with sub-type as
-// 0x02.
-message BgpPrefixExtendedCommunityTransitive2OctetAsTypeRouteTarget {
+// of routes (that carry this Community) carried by BGP Update message.  It is sent
+// with sub-type as 0x02.
+message ResultExtendedCommunityTransitive2OctetAsTypeRouteTarget {
 
   // The two octet IANA assigned AS value assigned to the Autonomous System.
   optional uint32 global_2byte_as = 1;
@@ -11708,7 +11708,7 @@ message BgpPrefixExtendedCommunityTransitive2OctetAsTypeRouteTarget {
 
 // The Route Origin Community identifies one or more routers that inject a set of routes
 // (that carry this Community) into BGP. It is sent with sub-type as 0x03 .
-message BgpPrefixExtendedCommunityTransitive2OctetAsTypeRouteOrigin {
+message ResultExtendedCommunityTransitive2OctetAsTypeRouteOrigin {
 
   // The two octet IANA assigned AS value assigned to the Autonomous System.
   optional uint32 global_2byte_as = 1;
@@ -11721,7 +11721,7 @@ message BgpPrefixExtendedCommunityTransitive2OctetAsTypeRouteOrigin {
 
 // The Transitive Two-Octet AS-Specific Extended Community is sent as type 0x00 .
 // 
-message BgpPrefixExtendedCommunityTransitive2OctetAsType {
+message ResultExtendedCommunityTransitive2OctetAsType {
 
   message Choice {
     enum Enum {
@@ -11734,15 +11734,15 @@ message BgpPrefixExtendedCommunityTransitive2OctetAsType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitive2OctetAsTypeRouteTarget route_target_subtype = 2;
+  ResultExtendedCommunityTransitive2OctetAsTypeRouteTarget route_target_subtype = 2;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitive2OctetAsTypeRouteOrigin route_origin_subtype = 3;
+  ResultExtendedCommunityTransitive2OctetAsTypeRouteOrigin route_origin_subtype = 3;
 }
 
 // The Route Origin Community identifies one or more routers that inject a set of routes
 // (that carry this Community) into BGP It is sent with sub-type as 0x03.
-message BgpPrefixExtendedCommunityTransitiveIpv4AddressTypeRouteOrigin {
+message ResultExtendedCommunityTransitiveIpv4AddressTypeRouteOrigin {
 
   // An IPv4 unicast address assigned by one of the Internet registries.
   optional string global_ipv4_admin = 1;
@@ -11756,7 +11756,7 @@ message BgpPrefixExtendedCommunityTransitiveIpv4AddressTypeRouteOrigin {
 // The Route Target Community identifies one or more routers that may receive a set
 // of routes (that carry this Community) carried by BGP.  It is sent with sub-type as
 // 0x02.
-message BgpPrefixExtendedCommunityTransitiveIpv4AddressTypeRouteTarget {
+message ResultExtendedCommunityTransitiveIpv4AddressTypeRouteTarget {
 
   // An IPv4 unicast address assigned by one of the Internet registries.
   optional string global_ipv4_admin = 1;
@@ -11768,7 +11768,7 @@ message BgpPrefixExtendedCommunityTransitiveIpv4AddressTypeRouteTarget {
 }
 
 // The Transitive IPv4 Address Specific Extended Community is sent as type 0x01.
-message BgpPrefixExtendedCommunityTransitiveIpv4AddressType {
+message ResultExtendedCommunityTransitiveIpv4AddressType {
 
   message Choice {
     enum Enum {
@@ -11781,16 +11781,16 @@ message BgpPrefixExtendedCommunityTransitiveIpv4AddressType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitiveIpv4AddressTypeRouteTarget route_target_subtype = 2;
+  ResultExtendedCommunityTransitiveIpv4AddressTypeRouteTarget route_target_subtype = 2;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitiveIpv4AddressTypeRouteOrigin route_origin_subtype = 3;
+  ResultExtendedCommunityTransitiveIpv4AddressTypeRouteOrigin route_origin_subtype = 3;
 }
 
 // The Route Target Community identifies one or more routers that may receive a set
 // of routes (that carry this Community) carried by BGP.  It is sent with sub-type as
 // 0x02
-message BgpPrefixExtendedCommunityTransitive4OctetAsTypeRouteTarget {
+message ResultExtendedCommunityTransitive4OctetAsTypeRouteTarget {
 
   // The four octet IANA assigned AS value assigned to the Autonomous System.
   optional uint32 global_4byte_as = 1;
@@ -11803,7 +11803,7 @@ message BgpPrefixExtendedCommunityTransitive4OctetAsTypeRouteTarget {
 
 // The Route Origin Community identifies one or more routers that inject a set of routes
 // (that carry this Community) into BGP. It is sent with sub-type as 0x03.
-message BgpPrefixExtendedCommunityTransitive4OctetAsTypeRouteOrigin {
+message ResultExtendedCommunityTransitive4OctetAsTypeRouteOrigin {
 
   // The four octet IANA assigned AS value assigned to the Autonomous System.
   optional uint32 global_4byte_as = 1;
@@ -11816,7 +11816,7 @@ message BgpPrefixExtendedCommunityTransitive4OctetAsTypeRouteOrigin {
 
 // The Transitive Four-Octet AS-Specific Extended Community is sent as type 0x02. It
 // is defined in RFC 5668.
-message BgpPrefixExtendedCommunityTransitive4OctetAsType {
+message ResultExtendedCommunityTransitive4OctetAsType {
 
   message Choice {
     enum Enum {
@@ -11829,17 +11829,17 @@ message BgpPrefixExtendedCommunityTransitive4OctetAsType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitive4OctetAsTypeRouteTarget route_target_subtype = 2;
+  ResultExtendedCommunityTransitive4OctetAsTypeRouteTarget route_target_subtype = 2;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitive4OctetAsTypeRouteOrigin route_origin_subtype = 3;
+  ResultExtendedCommunityTransitive4OctetAsTypeRouteOrigin route_origin_subtype = 3;
 }
 
 // The Color Community contains locally administrator defined 'color' value which is
 // used in conjunction with Encapsulation  attribute to decide whether a data packet
 // can be transmitted on a certain tunnel or not. It is defined in RFC9012 and sent
 // with sub-type as 0x0b.
-message BgpPrefixExtendedCommunityTransitiveOpaqueTypeColor {
+message ResultExtendedCommunityTransitiveOpaqueTypeColor {
 
   // Two octet flag values.
   optional uint32 flags = 1;
@@ -11853,7 +11853,7 @@ message BgpPrefixExtendedCommunityTransitiveOpaqueTypeColor {
 
 // This identifies the type of tunneling technology being signalled. It is defined in
 // RFC9012 and sent with sub-type as 0x0c.
-message BgpPrefixExtendedCommunityTransitiveOpaqueTypeEncapsulation {
+message ResultExtendedCommunityTransitiveOpaqueTypeEncapsulation {
 
   // Four bytes of reserved values. Normally set to 0 on transmit and ignored on receive.
   // 
@@ -11874,7 +11874,7 @@ message BgpPrefixExtendedCommunityTransitiveOpaqueTypeEncapsulation {
 }
 
 // The Transitive Opaque Extended Community is sent as type 0x03.
-message BgpPrefixExtendedCommunityTransitiveOpaqueType {
+message ResultExtendedCommunityTransitiveOpaqueType {
 
   message Choice {
     enum Enum {
@@ -11887,15 +11887,15 @@ message BgpPrefixExtendedCommunityTransitiveOpaqueType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitiveOpaqueTypeColor color_subtype = 2;
+  ResultExtendedCommunityTransitiveOpaqueTypeColor color_subtype = 2;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityTransitiveOpaqueTypeEncapsulation encapsulation_subtype = 3;
+  ResultExtendedCommunityTransitiveOpaqueTypeEncapsulation encapsulation_subtype = 3;
 }
 
 // The Link Bandwidth Extended Community attribute is defined in draft-ietf-idr-link-bandwidth.
 // It is sent with sub-type as 0x04.
-message BgpPrefixExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth {
+message ResultExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth {
 
   // The value of the Global Administrator subfield should represent the Autonomous System
   // of the router that attaches the Link Bandwidth Community. If four octet AS numbering
@@ -11909,7 +11909,7 @@ message BgpPrefixExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth {
 
 // The Non-Transitive Two-Octet AS-Specific Extended Community is sent as type 0x40.
 // 
-message BgpPrefixExtendedCommunityNonTransitive2OctetAsType {
+message ResultExtendedCommunityNonTransitive2OctetAsType {
 
   message Choice {
     enum Enum {
@@ -11921,7 +11921,7 @@ message BgpPrefixExtendedCommunityNonTransitive2OctetAsType {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  BgpPrefixExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth link_bandwidth_subtype = 2;
+  ResultExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth link_bandwidth_subtype = 2;
 }
 
 // BGP communities provide additional capability for tagging routes and  for modifying

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -11653,13 +11653,14 @@ message BgpPrefixRecvExtendedCommunity {
 }
 
 // The Extended Communities Attribute is a optional BGP attribute,defined in RFC4360
-// with the Type Code 16.  Community and Extended Communities  attributes are utilized
-// to trigger routing decisions, such as acceptance, rejection,  preference, or redistribution.
+// with the Type Code 16.
+// Community and Extended Communities  attributes are utilized to trigger routing decisions,
+// such as acceptance, rejection,  preference, or redistribution.
 // An extended community is an 8-bytes value. It is divided into two main parts. The
-// first 2 bytes of the community  encode a type and optonal sub-type field. The last
-// 6 bytes (or 7 bytes for types without a sub-type) carry a unique set of data in a
-// format defined by the type and optional sub-type field.  Extended communities provide
-// a larger  range for grouping or categorizing communities.
+// first 2 bytes of the community  encode a type and optonal sub-type field.
+// The last 6 bytes (or 7 bytes for types without a sub-type) carry a unique set of
+// data in a format defined by the type and optional sub-type field.
+// Extended communities provide a larger  range for grouping or categorizing communities.
 message BgpPrefixExtendedCommunity {
 
   message Choice {
@@ -11844,8 +11845,9 @@ message BgpPrefixExtendedCommunityTransitiveOpaqueTypeColor {
   optional uint32 flags = 1;
 
   // The color value is user defined and configured locally and used to determine whether
-  // a data packet can be transmitted on a certain tunnel or not in conjunction with the
-  // Encapsulation attribute. It is defined in RFC9012.
+  // a data packet can be transmitted on a certain tunnel or not
+  // in conjunction with the Encapsulation attribute. It is defined in RFC9012.
+  // 
   optional uint32 color = 2;
 }
 

--- a/result/bgpprefix.yaml
+++ b/result/bgpprefix.yaml
@@ -169,6 +169,17 @@ components:
         communities:
           x-include: '#/components/schemas/BgpPrefix.State/properties/communities'
           x-field-uid: 7
+        extended_communities:
+          description: >-
+            Optional received Extended Community attributes.
+            Each received Extended Community attribute is available for retrieval in two forms.
+            Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use.
+            In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the 
+            'structured' format which is an optional field.
+          type: array
+          items:
+            $ref: '#/components/schemas/BgpPrefix.RecvExtendedCommunity'          
+          x-field-uid: 11
         as_path:
           x-include: '#/components/schemas/BgpPrefix.State/properties/as_path'
           x-field-uid: 8
@@ -206,6 +217,17 @@ components:
         communities:
           x-include: '#/components/schemas/BgpPrefix.State/properties/communities'
           x-field-uid: 7
+        extended_communities:
+          description: >-
+            Optional received Extended Community attributes.
+            Each received Extended Community attribute is available for retrieval in two forms.
+            Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use.
+            In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the 
+            'structured' format which is an optional field.
+          type: array
+          items:
+            $ref: '#/components/schemas/BgpPrefix.RecvExtendedCommunity'          
+          x-field-uid: 11
         as_path:
           x-include: '#/components/schemas/BgpPrefix.State/properties/as_path'
           x-field-uid: 8
@@ -281,3 +303,340 @@ components:
           type: integer
           format : uint32
           x-field-uid: 9
+    BgpPrefix.RecvExtendedCommunity:
+      description:
+        Each received Extended Community attribute is available for retrieval in two forms.
+        Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use.
+        In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the 
+        'structured' format which is an optional field. 
+      type: object
+      properties:
+        raw:
+          description: >-
+            The raw byte contents of the 8 bytes received in the Extended Community as 16 hex characters.              
+          type: string
+          format: hex
+          maxLength: 16
+          x-field-uid: 1  
+        structured:
+          x-field-uid: 2
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity'
+
+    BgpPrefix.ExtendedCommunity:
+      description: >-
+        The Extended Communities Attribute is a optional BGP attribute,defined in RFC4360 with the Type Code 16. 
+        Community and Extended Communities  attributes are utilized to trigger routing decisions, such as acceptance, rejection,  preference, or redistribution. 
+        An extended community is an 8-bytes value. It is divided into two main parts. The first 2 bytes of the community  encode a type and optonal sub-type field.
+        The last 6 bytes (or 7 bytes for types without a sub-type) carry a unique set of data in a format defined by the type and optional sub-type field. 
+        Extended communities provide a larger  range for grouping or categorizing communities.
+      type: object
+      properties:        
+        choice:
+          type: string             
+          x-enum:
+            transitive_2octet_as_type:
+              x-field-uid: 1
+            transitive_ipv4_address_type:
+              x-field-uid: 2
+            transitive_4octet_as_type:
+              x-field-uid: 3
+            transitive_opaque_type:
+              x-field-uid: 4         
+            non_transitive_2octet_as_type:
+              x-field-uid: 5         
+          x-field-uid: 1
+        transitive_2octet_as_type:        
+          x-field-uid: 2
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType'
+        transitive_ipv4_address_type:        
+          x-field-uid: 3
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType'
+        transitive_4octet_as_type:        
+          x-field-uid: 4
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType'
+        transitive_opaque_type:        
+          x-field-uid: 5
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType'
+        non_transitive_2octet_as_type:        
+          x-field-uid: 6
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType'
+    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteTarget:
+      description: >-
+        The Route Target Community identifies one or more routers that may receive a set of routes (that carry this Community) carried by BGP. 
+        It is sent with sub-type as 0x02.            
+      type: object
+      properties:
+        global_2byte_as:
+          description: >-
+            The two octet IANA assigned AS value assigned to the Autonomous System.
+          type: integer
+          format: uint32
+          maximum: 65535
+          x-field-uid: 1
+        local_4byte_admin:
+          type: integer
+          format: uint32
+          description: >-
+            The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which the
+            Autonomous System number carried in the Global Administrator sub-field has been assigned by an appropriate authority.
+          x-field-uid: 2
+    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin:
+      description: >-          
+        The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP.
+        It is sent with sub-type as 0x03 .
+      type: object
+      properties:
+        global_2byte_as:
+          description: >-
+            The two octet IANA assigned AS value assigned to the Autonomous System.
+          type: integer
+          format: uint32
+          maximum: 65535      
+          x-field-uid: 1
+        local_4byte_admin:
+          description: >-
+            The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which the
+            Autonomous System number carried in the Global Administrator sub-field has been assigned by an appropriate authority.
+          type: integer
+          format: uint32      
+          x-field-uid: 2
+    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType:
+      description: >-
+        The Transitive Two-Octet AS-Specific Extended Community is sent as type 0x00 .         
+      type: object
+      properties:        
+        choice:
+          type: string   
+          x-enum:
+            route_target_subtype:
+              x-field-uid: 1
+            route_origin_subtype:
+              x-field-uid: 2
+          x-field-uid: 1
+        route_target_subtype:
+          x-field-uid: 2
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteTarget'
+        route_origin_subtype:
+          x-field-uid: 3
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin'
+    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin:
+      description: >-          
+        The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP
+        It is sent with sub-type as 0x03.
+      type: object
+      properties:
+        global_ipv4_admin:
+          description: >-
+            An IPv4 unicast address assigned by one of the Internet registries.            
+          type: string
+          format: ipv4             
+          x-field-uid: 1
+        local_2byte_admin:
+          description: >-
+            The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which 
+            the IP address carried in the Global Administrator sub-field has been assigned by an appropriate authority.
+          type: integer
+          format: uint32      
+          maximum: 65535
+          x-field-uid: 2
+    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget:
+      description: >-
+        The Route Target Community identifies one or more routers that may receive a set of routes (that carry this Community) carried by BGP. 
+        It is sent with sub-type as 0x02.             
+      type: object
+      properties:
+        global_ipv4_admin:
+          description: >-
+            An IPv4 unicast address assigned by one of the Internet registries. 
+          type: string
+          format: ipv4               
+          x-field-uid: 1
+        local_2byte_admin:
+          type: integer
+          format: uint32
+          maximum: 65535        
+          description: >-
+            The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which 
+            the IP address carried in the Global Administrator sub-field has been assigned by an appropriate authority.
+          x-field-uid: 2
+    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType:
+      description: >-
+        The Transitive IPv4 Address Specific Extended Community is sent as type 0x01.
+      type: object
+      properties:        
+        choice:
+          type: string   
+          x-enum:
+            route_target_subtype:
+              x-field-uid: 1
+            route_origin_subtype:
+              x-field-uid: 2
+          x-field-uid: 1
+        route_target_subtype:
+          x-field-uid: 2
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget'
+        route_origin_subtype:
+          x-field-uid: 3
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin'
+    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteTarget:
+      description: >-
+        The Route Target Community identifies one or more routers that may receive a set of routes (that carry this Community) carried by BGP. 
+        It is sent with sub-type as 0x02              
+      type: object
+      properties:
+        global_4byte_as:
+          description: >-
+            The four octet IANA assigned AS value assigned to the Autonomous System.
+          type: integer
+          format: uint32       
+          x-field-uid: 1
+        local_2byte_admin:
+          type: integer
+          format: uint32      
+          maximum: 65535
+          description: >-
+            The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which the
+            Autonomous System number carried in the Global Administrator sub-field has been assigned by an appropriate authority.
+          x-field-uid: 2
+    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin:
+      description: >-          
+        The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP.
+        It is sent with sub-type as 0x03.
+      type: object
+      properties:
+        global_4byte_as:
+          description: >-
+            The four octet IANA assigned AS value assigned to the Autonomous System.
+          type: integer
+          format: uint32             
+          x-field-uid: 1
+        local_2byte_admin:
+          description: >-
+            The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which the
+            Autonomous System number carried in the Global Administrator sub-field has been assigned by an appropriate authority.
+          type: integer
+          format: uint32       
+          maximum: 65535
+          x-field-uid: 2
+    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType:
+      description: >-
+        The Transitive Four-Octet AS-Specific Extended Community is sent as type 0x02. It is defined in RFC 5668.       
+      type: object
+      properties:        
+        choice:
+          type: string     
+          x-enum:
+            route_target_subtype:
+              x-field-uid: 1
+            route_origin_subtype:
+              x-field-uid: 2
+          x-field-uid: 1
+        route_target_subtype:
+          x-field-uid: 2
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteTarget'
+        route_origin_subtype:
+          x-field-uid: 3
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin'
+    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Color:
+      description: >-
+        The Color Community contains locally administrator defined 'color' value which is used in conjunction with Encapsulation 
+        attribute to decide whether a data packet can be transmitted on a certain tunnel or not.
+        It is defined in RFC9012 and sent with sub-type as 0x0b.             
+      type: object
+      properties:
+        flags:
+          description: >-
+            Two octet flag values. 
+          type: integer
+          format: uint32         
+          maximum: 65535              
+          x-field-uid: 1
+        color:
+          type: integer
+          format: uint32         
+          description: >-
+            The color value is user defined and configured locally and used to determine whether a data packet can be transmitted on a certain tunnel or not
+            in conjunction with the Encapsulation attribute. It is defined in RFC9012.           
+          x-field-uid: 2
+    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Encapsulation:
+      description: >-          
+        This identifies the type of tunneling technology being signalled.
+        It is defined in RFC9012 and sent with sub-type as 0x0c.
+      type: object
+      properties:
+        reserved:
+          description: >-
+            Four bytes of reserved values. Normally set to 0 on transmit and ignored on receive. 
+          type: integer
+          format: uint32               
+          x-field-uid: 1
+        tunnel_type:
+          description: |-
+            Identifies the type of tunneling technology being signalled. Initially defined in RFC5512 and extended in RFC9012.
+            Some of the important tunnel types include 
+            - 1 L2TPv3 over IP	[RFC9012],           
+            - 2	GRE	[RFC9012],          
+            - 7	IP in IP	[RFC9012],
+            - 8	VXLAN Encapsulation	[RFC8365],
+            - 9	NVGRE Encapsulation	[RFC8365],
+            - 10	MPLS Encapsulation	[RFC8365],
+            - 15	SR TE Policy Type	[draft-ietf-idr-segment-routing-te-policy],
+            - 19	Geneve Encapsulation	[RFC8926]
+          type: integer
+          format: uint32
+          maximum: 65535       
+          x-field-uid: 2
+    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType:
+      description: >-
+        The Transitive Opaque Extended Community is sent as type 0x03.
+      type: object
+      properties:        
+        choice:
+          type: string    
+          x-enum:
+            color_subtype:
+              x-field-uid: 1
+            encapsulation_subtype:
+              x-field-uid: 2
+          x-field-uid: 1
+        color_subtype:
+          x-field-uid: 2
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Color'
+        encapsulation_subtype:
+          x-field-uid: 3
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Encapsulation'  
+    BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth:
+      description: >-          
+        The Link Bandwidth Extended Community attribute is defined in draft-ietf-idr-link-bandwidth.
+        It is sent with sub-type as 0x04.
+      type: object
+      properties:
+        global_2byte_as:
+          description: >-
+            The value of the Global Administrator subfield should represent the Autonomous System of the router that
+            attaches the Link Bandwidth Community. If four octet AS numbering scheme is used, AS_TRANS (23456) should be used.
+          type: integer
+          format: uint32        
+          maximum: 65535          
+          x-field-uid: 1
+        bandwidth:
+          description: >-
+            Bandwidth of the link in bytes per second.
+            ( 1 Kbps is 1000 bytes per second and 1 Mbps is 1000 Kbps per second )
+          type: number
+          format: float            
+          x-field-uid: 2      
+    BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType:
+      description: >-
+        The Non-Transitive Two-Octet AS-Specific Extended Community is sent as type 0x40.         
+      type: object
+      properties:        
+        choice:
+          type: string      
+          x-enum:
+            link_bandwidth_subtype:
+              x-field-uid: 1            
+          x-field-uid: 1
+        link_bandwidth_subtype:
+          x-field-uid: 2
+          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth'   

--- a/result/bgpprefix.yaml
+++ b/result/bgpprefix.yaml
@@ -178,7 +178,7 @@ components:
             'structured' format which is an optional field.
           type: array
           items:
-            $ref: '#/components/schemas/BgpPrefix.RecvExtendedCommunity'          
+            $ref: '#/components/schemas/Result.ExtendedCommunity'          
           x-field-uid: 11
         as_path:
           x-include: '#/components/schemas/BgpPrefix.State/properties/as_path'
@@ -226,7 +226,7 @@ components:
             'structured' format which is an optional field.
           type: array
           items:
-            $ref: '#/components/schemas/BgpPrefix.RecvExtendedCommunity'          
+            $ref: '#/components/schemas/Result.ExtendedCommunity'          
           x-field-uid: 11
         as_path:
           x-include: '#/components/schemas/BgpPrefix.State/properties/as_path'
@@ -303,7 +303,7 @@ components:
           type: integer
           format : uint32
           x-field-uid: 9
-    BgpPrefix.RecvExtendedCommunity:
+    Result.ExtendedCommunity:
       description:
         Each received Extended Community attribute is available for retrieval in two forms.
         Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use.
@@ -320,9 +320,9 @@ components:
           x-field-uid: 1  
         structured:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity'
+          $ref: '#/components/schemas/Result.ExtendedCommunityStructured'
 
-    BgpPrefix.ExtendedCommunity:
+    Result.ExtendedCommunityStructured:
       description: |-
         The Extended Communities Attribute is a optional BGP attribute,defined in RFC4360 with the Type Code 16. 
         Community and Extended Communities  attributes are utilized to trigger routing decisions, such as acceptance, rejection,  preference, or redistribution. 
@@ -347,22 +347,22 @@ components:
           x-field-uid: 1
         transitive_2octet_as_type:        
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive2OctetAsType'
         transitive_ipv4_address_type:        
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveIpv4AddressType'
         transitive_4octet_as_type:        
           x-field-uid: 4
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive4OctetAsType'
         transitive_opaque_type:        
           x-field-uid: 5
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveOpaqueType'
         non_transitive_2octet_as_type:        
           x-field-uid: 6
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType'
-    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteTarget:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.NonTransitive2OctetAsType'
+    Result.ExtendedCommunity.Transitive2OctetAsType.RouteTarget:
       description: >-
-        The Route Target Community identifies one or more routers that may receive a set of routes (that carry this Community) carried by BGP. 
+        The Route Target Community identifies one or more routers that may receive a set of routes (that carry this Community) carried by BGP Update message. 
         It is sent with sub-type as 0x02.            
       type: object
       properties:
@@ -380,7 +380,7 @@ components:
             The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which the
             Autonomous System number carried in the Global Administrator sub-field has been assigned by an appropriate authority.
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin:
+    Result.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin:
       description: >-          
         The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP.
         It is sent with sub-type as 0x03 .
@@ -400,7 +400,7 @@ components:
           type: integer
           format: uint32      
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.Transitive2OctetAsType:
+    Result.ExtendedCommunity.Transitive2OctetAsType:
       description: >-
         The Transitive Two-Octet AS-Specific Extended Community is sent as type 0x00 .         
       type: object
@@ -415,11 +415,11 @@ components:
           x-field-uid: 1
         route_target_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteTarget'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive2OctetAsType.RouteTarget'
         route_origin_subtype:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin'
-    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive2OctetAsType.RouteOrigin'
+    Result.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin:
       description: >-          
         The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP
         It is sent with sub-type as 0x03.
@@ -439,7 +439,7 @@ components:
           format: uint32      
           maximum: 65535
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget:
+    Result.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget:
       description: >-
         The Route Target Community identifies one or more routers that may receive a set of routes (that carry this Community) carried by BGP. 
         It is sent with sub-type as 0x02.             
@@ -459,7 +459,7 @@ components:
             The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which 
             the IP address carried in the Global Administrator sub-field has been assigned by an appropriate authority.
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType:
+    Result.ExtendedCommunity.TransitiveIpv4AddressType:
       description: >-
         The Transitive IPv4 Address Specific Extended Community is sent as type 0x01.
       type: object
@@ -474,11 +474,11 @@ components:
           x-field-uid: 1
         route_target_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveIpv4AddressType.RouteTarget'
         route_origin_subtype:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin'
-    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteTarget:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveIpv4AddressType.RouteOrigin'
+    Result.ExtendedCommunity.Transitive4OctetAsType.RouteTarget:
       description: >-
         The Route Target Community identifies one or more routers that may receive a set of routes (that carry this Community) carried by BGP. 
         It is sent with sub-type as 0x02              
@@ -498,7 +498,7 @@ components:
             The Local Administrator sub-field contains a number from a numbering space that is administered by the organization to which the
             Autonomous System number carried in the Global Administrator sub-field has been assigned by an appropriate authority.
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin:
+    Result.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin:
       description: >-          
         The Route Origin Community identifies one or more routers that inject a set of routes (that carry this Community) into BGP.
         It is sent with sub-type as 0x03.
@@ -518,7 +518,7 @@ components:
           format: uint32       
           maximum: 65535
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.Transitive4OctetAsType:
+    Result.ExtendedCommunity.Transitive4OctetAsType:
       description: >-
         The Transitive Four-Octet AS-Specific Extended Community is sent as type 0x02. It is defined in RFC 5668.       
       type: object
@@ -533,11 +533,11 @@ components:
           x-field-uid: 1
         route_target_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteTarget'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive4OctetAsType.RouteTarget'
         route_origin_subtype:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin'
-    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Color:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.Transitive4OctetAsType.RouteOrigin'
+    Result.ExtendedCommunity.TransitiveOpaqueType.Color:
       description: >-
         The Color Community contains locally administrator defined 'color' value which is used in conjunction with Encapsulation 
         attribute to decide whether a data packet can be transmitted on a certain tunnel or not.
@@ -558,7 +558,7 @@ components:
             The color value is user defined and configured locally and used to determine whether a data packet can be transmitted on a certain tunnel or not
             in conjunction with the Encapsulation attribute. It is defined in RFC9012.           
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Encapsulation:
+    Result.ExtendedCommunity.TransitiveOpaqueType.Encapsulation:
       description: >-          
         This identifies the type of tunneling technology being signalled.
         It is defined in RFC9012 and sent with sub-type as 0x0c.
@@ -586,7 +586,7 @@ components:
           format: uint32
           maximum: 65535       
           x-field-uid: 2
-    BgpPrefix.ExtendedCommunity.TransitiveOpaqueType:
+    Result.ExtendedCommunity.TransitiveOpaqueType:
       description: >-
         The Transitive Opaque Extended Community is sent as type 0x03.
       type: object
@@ -601,11 +601,11 @@ components:
           x-field-uid: 1
         color_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Color'
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveOpaqueType.Color'
         encapsulation_subtype:
           x-field-uid: 3
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.TransitiveOpaqueType.Encapsulation'  
-    BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth:
+          $ref: '#/components/schemas/Result.ExtendedCommunity.TransitiveOpaqueType.Encapsulation'  
+    Result.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth:
       description: >-          
         The Link Bandwidth Extended Community attribute is defined in draft-ietf-idr-link-bandwidth.
         It is sent with sub-type as 0x04.
@@ -626,7 +626,7 @@ components:
           type: number
           format: float            
           x-field-uid: 2      
-    BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType:
+    Result.ExtendedCommunity.NonTransitive2OctetAsType:
       description: >-
         The Non-Transitive Two-Octet AS-Specific Extended Community is sent as type 0x40.         
       type: object
@@ -639,4 +639,4 @@ components:
           x-field-uid: 1
         link_bandwidth_subtype:
           x-field-uid: 2
-          $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth'   
+          $ref: '#/components/schemas/Result.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth'   

--- a/result/bgpprefix.yaml
+++ b/result/bgpprefix.yaml
@@ -323,7 +323,7 @@ components:
           $ref: '#/components/schemas/BgpPrefix.ExtendedCommunity'
 
     BgpPrefix.ExtendedCommunity:
-      description: >-
+      description: |-
         The Extended Communities Attribute is a optional BGP attribute,defined in RFC4360 with the Type Code 16. 
         Community and Extended Communities  attributes are utilized to trigger routing decisions, such as acceptance, rejection,  preference, or redistribution. 
         An extended community is an 8-bytes value. It is divided into two main parts. The first 2 bytes of the community  encode a type and optonal sub-type field.
@@ -554,7 +554,7 @@ components:
         color:
           type: integer
           format: uint32         
-          description: >-
+          description: |-
             The color value is user defined and configured locally and used to determine whether a data packet can be transmitted on a certain tunnel or not
             in conjunction with the Encapsulation attribute. It is defined in RFC9012.           
           x-field-uid: 2


### PR DESCRIPTION
[Redocli link ](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-extended-community-li/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_state)
monitor/get_state/responses/200/bgp_prefixes/ipv[4|6]_unicast_prefixes/extended_communities

Support is available for both BGPv4 and v6 peers.
Support is needed for both IPv4 and IPv6 prefixes.
Support is required such that the Extended Community is always available as raw 8 bytes ( 16 hex characters ) 
If model and implementation supports it, retrieval should be allowed in a structured format also. This should be doable in an incremental manner by implementation without breaking backward compatibility. Due to this, at minimum , the value as hex characters is always made available. 

go get github.com/open-traffic-generator/snappi/gosnappi@dev-extended-community-li 

Example snippet to use the retrieved Extended Community for validation:
```
 req := gosnappi.NewStatesRequest()
 req.BgpPrefixes().SetBgpPeerNames(peerNames)
 res, err := client.GetStates(req)
 if err != nil {
 	return nil, err
 }
 
 learnedRoutes := res.BgpPrefixes()
 liFirstPeer := actualBGPv4Prefix.Items()[0]
 route := liFirstPeer.Ipv4UnicastPrefixes().Items()[0]
 extComm := route.ExtendedCommunities().Items()[0]
 if extComm.Raw() != "40040064461c4000" {
 	log.Printf ("Expected %s Got %s ", "40040064461c4000" , extComm.Raw())
        t.Fatal("Raw bytes did not match")
 }
 if extComm.Structured() == nil ||
    extComm.Structured().NonTransitive2OctetAsType()== nil  ||
    extComm.Structured().NonTransitive2OctetAsType().LinkBandwidthSubtype() == nil {
       t.Fatal("Structured member expected and missing for Link Bandwidth Extended Community.")
 }
 if ( extComm.Structured().NonTransitive2OctetAsType().LinkBandwidthSubtype().Bandwidth()!= 10000.0 ||
        extComm.Structured().NonTransitive2OctetAsType().LinkBandwidthSubtype().Global2ByteAs() != 100){
        t.Fatal("Bandwidth value / AS value not as expected.")
 }
 ```