### PR TITLE
FCS support

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -8794,8 +8794,12 @@ components:
           description: "Flow metrics. "
           $ref: '#/components/schemas/Flow.Metrics'
           x-field-uid: 6
-        name:
+        fcs:
+          description: "Frame checksum. "
+          $ref: '#/components/schemas/Flow.Fcs'
           x-field-uid: 7
+        name:
+          x-field-uid: 8
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
@@ -9221,43 +9225,6 @@ components:
         pfc_queue:
           x-field-uid: 4
           $ref: '#/components/schemas/Pattern.Flow.Ethernet.PfcQueue'
-        fcs:
-          $ref: '#/components/schemas/Flow.Ethernet.FCS'
-          x-field-uid: 5
-    Flow.Ethernet.FCS:
-      description: |-
-        The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon  the address fields, Ethertype, and data to detect errors in transmission.
-      type: object
-      properties:
-        choice:
-          type: string
-          default: generated
-          x-enum:
-            generated:
-              x-field-uid: 1
-          x-field-uid: 1
-          enum:
-          - generated
-        generated:
-          $ref: '#/components/schemas/Flow.Ethernet.Generated'
-          x-field-uid: 2
-    Flow.Ethernet.Generated:
-      description: |-
-        A system generated checksum value.
-      type: object
-      properties:
-        choice:
-          type: string
-          default: good
-          x-field-uid: 1
-          x-enum:
-            good:
-              x-field-uid: 1
-            bad:
-              x-field-uid: 2
-          enum:
-          - good
-          - bad
     Flow.Vlan:
       description: |-
         VLAN packet header
@@ -11997,6 +11964,40 @@ components:
       description: |-
         This is for cases where one copy of Tx packet is received on all Rx ports and so the sum total of Rx packets
         received across all Rx ports is a multiple of Rx port count and Tx packets.
+    Flow.Fcs:
+      description: |-
+        The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon  the address fields, Ethertype, and data to detect errors in transmission.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: generated
+          x-enum:
+            generated:
+              x-field-uid: 1
+          x-field-uid: 1
+          enum:
+          - generated
+        generated:
+          $ref: '#/components/schemas/Flow.Ethernet.Generated'
+          x-field-uid: 2
+    Flow.Ethernet.Generated:
+      description: |-
+        A system generated checksum value.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: good
+          x-field-uid: 1
+          x-enum:
+            good:
+              x-field-uid: 1
+            bad:
+              x-field-uid: 2
+          enum:
+          - good
+          - bad
     Event:
       description: |-
         The optional container for event configuration.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -9223,7 +9223,7 @@ components:
           $ref: '#/components/schemas/Pattern.Flow.Ethernet.PfcQueue'
         fcs:
           description: |-
-            The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon  the address fields, Ethertype, and data to detect errors in transmission.
+            FCS is a checksum computed by a CRC based uponthe address fields, Ethertype, and data to detect errors in transmission.
           $ref: '#/components/schemas/Flow.Ethernet.FCS'
           x-field-uid: 5
     Flow.Ethernet.FCS:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6811,8 +6811,8 @@ message FlowEthernet {
   // Description missing in models
   PatternFlowEthernetPfcQueue pfc_queue = 4;
 
-  // The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon  the address
-  // fields, Ethertype, and data to detect errors in transmission.
+  // FCS is a checksum computed by a CRC based uponthe address fields, Ethertype, and
+  // data to detect errors in transmission.
   FlowEthernetFCS fcs = 5;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6512,10 +6512,13 @@ message Flow {
   // Flow metrics.
   FlowMetrics metrics = 6;
 
+  // Frame checksum.
+  FlowFcs fcs = 7;
+
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
   // required = true
-  optional string name = 7;
+  optional string name = 8;
 }
 
 // A container for different types of transmit and receive
@@ -6810,42 +6813,6 @@ message FlowEthernet {
 
   // Description missing in models
   PatternFlowEthernetPfcQueue pfc_queue = 4;
-
-  // Description missing in models
-  FlowEthernetFCS fcs = 5;
-}
-
-// The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon  the address
-// fields, Ethertype, and data to detect errors in transmission.
-message FlowEthernetFCS {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      generated = 1;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.generated
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  FlowEthernetGenerated generated = 2;
-}
-
-// A system generated checksum value.
-message FlowEthernetGenerated {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      good = 1;
-      bad = 2;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.good
-  optional Choice.Enum choice = 1;
 }
 
 // VLAN packet header
@@ -9151,6 +9118,39 @@ message FlowRxTxRatio {
 // the sum total of Rx packets
 // received across all Rx ports is a multiple of Rx port count and Tx packets.
 message FlowRxTxRatioRxCount {
+}
+
+// The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon  the address
+// fields, Ethertype, and data to detect errors in transmission.
+message FlowFcs {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      generated = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.generated
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowEthernetGenerated generated = 2;
+}
+
+// A system generated checksum value.
+message FlowEthernetGenerated {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      good = 1;
+      bad = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.good
+  optional Choice.Enum choice = 1;
 }
 
 // The optional container for event configuration.

--- a/flow/fcs.yaml
+++ b/flow/fcs.yaml
@@ -1,0 +1,32 @@
+components:
+  schemas:
+    Flow.FCS:
+      description: >-
+          The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
+          the address fields, Ethertype, and data to detect errors in transmission.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: generated
+          x-enum:
+            generated:
+              x-field-uid: 1
+          x-field-uid: 1
+        generated:
+          $ref: '#/components/schemas/Flow.Ethernet.Generated'
+          x-field-uid: 2
+    Flow.Ethernet.Generated:
+      description: >-
+          A system generated checksum value.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: good
+          x-field-uid: 1
+          x-enum:
+            good:
+              x-field-uid: 1
+            bad:
+              x-field-uid: 2

--- a/flow/fcs.yaml
+++ b/flow/fcs.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Flow.FCS:
+    Flow.Fcs:
       description: >-
           The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
           the address fields, Ethertype, and data to detect errors in transmission.

--- a/flow/flow.yaml
+++ b/flow/flow.yaml
@@ -69,7 +69,7 @@ components:
         fcs:
           description: |-
             Frame checksum. 
-          $ref: './metrics.yaml#/components/schemas/Flow.FCS'
+          $ref: './fcs.yaml#/components/schemas/Flow.Fcs'
           x-field-uid: 7
         name:
           x-include: ../common/common.yaml#/components/schemas/Named.Object/properties/name

--- a/flow/flow.yaml
+++ b/flow/flow.yaml
@@ -66,6 +66,11 @@ components:
             Flow metrics. 
           $ref: './metrics.yaml#/components/schemas/Flow.Metrics'
           x-field-uid: 6
+        fcs:
+          description: |-
+            Frame checksum. 
+          $ref: './metrics.yaml#/components/schemas/Flow.FCS'
+          x-field-uid: 7
         name:
           x-include: ../common/common.yaml#/components/schemas/Named.Object/properties/name
-          x-field-uid: 7
+          x-field-uid: 8

--- a/flow/packet-headers/ethernet.yaml
+++ b/flow/packet-headers/ethernet.yaml
@@ -64,10 +64,11 @@ components:
           $ref: '#/components/schemas/Flow.Ethernet.Generated'
           x-field-uid: 2
     Flow.Ethernet.Generated:
+      description: >-
+          A system generated checksum value.
       type: object
       properties:
         choice:
-          description: good or bad value.
           type: string
           default: good
           x-field-uid: 1

--- a/flow/packet-headers/ethernet.yaml
+++ b/flow/packet-headers/ethernet.yaml
@@ -44,3 +44,35 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 4
+        fcs :
+          description: >-
+            The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
+            the address fields, Ethertype, and data to detect errors in transmission.
+          $ref: '#/components/schemas/Flow.Ethernet.FCS'
+          x-field-uid: 5
+    Flow.Ethernet.FCS:
+      type: object
+      properties:
+        choice:
+          type: string
+          default: generated
+          x-enum:
+            generated:
+              x-field-uid: 1
+          x-field-uid: 1
+        generated:
+          $ref: '#/components/schemas/Flow.Ethernet.Generated'
+          x-field-uid: 2
+    Flow.Ethernet.Generated:
+      type: object
+      properties:
+        choice:
+          description: good or bad value.
+          type: string
+          default: good
+          x-field-uid: 1
+          x-enum:
+            good:
+              x-field-uid: 1
+            bad:
+              x-field-uid: 2

--- a/flow/packet-headers/ethernet.yaml
+++ b/flow/packet-headers/ethernet.yaml
@@ -44,36 +44,4 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 4
-        fcs :
-          $ref: '#/components/schemas/Flow.Ethernet.FCS'
-          x-field-uid: 5
-    Flow.Ethernet.FCS:
-      description: >-
-          The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
-          the address fields, Ethertype, and data to detect errors in transmission.
-      type: object
-      properties:
-        choice:
-          type: string
-          default: generated
-          x-enum:
-            generated:
-              x-field-uid: 1
-          x-field-uid: 1
-        generated:
-          $ref: '#/components/schemas/Flow.Ethernet.Generated'
-          x-field-uid: 2
-    Flow.Ethernet.Generated:
-      description: >-
-          A system generated checksum value.
-      type: object
-      properties:
-        choice:
-          type: string
-          default: good
-          x-field-uid: 1
-          x-enum:
-            good:
-              x-field-uid: 1
-            bad:
-              x-field-uid: 2
+    

--- a/flow/packet-headers/ethernet.yaml
+++ b/flow/packet-headers/ethernet.yaml
@@ -45,9 +45,7 @@ components:
             features: [count, metric_tags]
           x-field-uid: 4
         fcs :
-          description: >-
-              The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
-              the address fields, Ethertype, and data to detect errors in transmission.
+          description: FCS is a checksum computed by a CRC based uponthe address fields, Ethertype, and data to detect errors in transmission.
           $ref: '#/components/schemas/Flow.Ethernet.FCS'
           x-field-uid: 5
     Flow.Ethernet.FCS:

--- a/flow/packet-headers/ethernet.yaml
+++ b/flow/packet-headers/ethernet.yaml
@@ -45,10 +45,12 @@ components:
             features: [count, metric_tags]
           x-field-uid: 4
         fcs :
-          description: FCS is a checksum computed by a CRC based uponthe address fields, Ethertype, and data to detect errors in transmission.
           $ref: '#/components/schemas/Flow.Ethernet.FCS'
           x-field-uid: 5
     Flow.Ethernet.FCS:
+      description: >-
+          The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
+          the address fields, Ethertype, and data to detect errors in transmission.
       type: object
       properties:
         choice:

--- a/flow/packet-headers/ethernet.yaml
+++ b/flow/packet-headers/ethernet.yaml
@@ -46,8 +46,8 @@ components:
           x-field-uid: 4
         fcs :
           description: >-
-            The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
-            the address fields, Ethertype, and data to detect errors in transmission.
+              The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
+              the address fields, Ethertype, and data to detect errors in transmission.
           $ref: '#/components/schemas/Flow.Ethernet.FCS'
           x-field-uid: 5
     Flow.Ethernet.FCS:


### PR DESCRIPTION
**Redocly View**
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-fcs/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config)

New Objects:
flows/packet/ethernet/fcs

Objective:
Support FCS in ethernet header to generate good as well as bad packet using raw traffic.
