### PR TITLE
FCS-part of Ethernet header

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -9221,6 +9221,43 @@ components:
         pfc_queue:
           x-field-uid: 4
           $ref: '#/components/schemas/Pattern.Flow.Ethernet.PfcQueue'
+        fcs:
+          $ref: '#/components/schemas/Flow.Ethernet.FCS'
+          x-field-uid: 5
+    Flow.Ethernet.FCS:
+      description: |-
+        The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon  the address fields, Ethertype, and data to detect errors in transmission.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: generated
+          x-enum:
+            generated:
+              x-field-uid: 1
+          x-field-uid: 1
+          enum:
+          - generated
+        generated:
+          $ref: '#/components/schemas/Flow.Ethernet.Generated'
+          x-field-uid: 2
+    Flow.Ethernet.Generated:
+      description: |-
+        A system generated checksum value.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: good
+          x-field-uid: 1
+          x-enum:
+            good:
+              x-field-uid: 1
+            bad:
+              x-field-uid: 2
+          enum:
+          - good
+          - bad
     Flow.Vlan:
       description: |-
         VLAN packet header

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -6810,6 +6810,42 @@ message FlowEthernet {
 
   // Description missing in models
   PatternFlowEthernetPfcQueue pfc_queue = 4;
+
+  // Description missing in models
+  FlowEthernetFCS fcs = 5;
+}
+
+// The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon  the address
+// fields, Ethertype, and data to detect errors in transmission.
+message FlowEthernetFCS {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      generated = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.generated
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowEthernetGenerated generated = 2;
+}
+
+// A system generated checksum value.
+message FlowEthernetGenerated {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      good = 1;
+      bad = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.good
+  optional Choice.Enum choice = 1;
 }
 
 // VLAN packet header

--- a/flow/packet-headers/ethernet.yaml
+++ b/flow/packet-headers/ethernet.yaml
@@ -44,3 +44,36 @@ components:
             default: 0
             features: [count, metric_tags]
           x-field-uid: 4
+        fcs :
+          $ref: '#/components/schemas/Flow.Ethernet.FCS'
+          x-field-uid: 5
+    Flow.Ethernet.FCS:
+      description: >-
+          The Frame Check Sequence (FCS) is a checksum computed by a CRC based upon 
+          the address fields, Ethertype, and data to detect errors in transmission.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: generated
+          x-enum:
+            generated:
+              x-field-uid: 1
+          x-field-uid: 1
+        generated:
+          $ref: '#/components/schemas/Flow.Ethernet.Generated'
+          x-field-uid: 2
+    Flow.Ethernet.Generated:
+      description: >-
+          A system generated checksum value.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: good
+          x-field-uid: 1
+          x-enum:
+            good:
+              x-field-uid: 1
+            bad:
+              x-field-uid: 2


### PR DESCRIPTION
**Redocly View**
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-fcs-2/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config)

New Objects:
flows/packet/ethernet/fcs

Objective:
Support FCS in ethernet header to generate good as well as bad packet using raw traffic.