### PR TITLE
Update openapiart version to 0.3.13

### DIFF
--- a/api/info.yaml
+++ b/api/info.yaml
@@ -8,7 +8,7 @@ info:
     Contributions can be made in the following ways:
     - [open an issue](https://github.com/open-traffic-generator/models/issues) in the models repository
     - [fork the models repository](https://github.com/open-traffic-generator/models) and submit a PR
-  version: 1.5.0
+  version: 1.5.1
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.5.0
+  version: 1.5.1
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.5.0
+/* Open Traffic Generator API 1.5.1
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 click==8.0.4
-openapiart==0.3.12
+openapiart==0.3.13


### PR DESCRIPTION
This openapairt version fixes the issue where warnings are being printed in STDOUT, now all the warnings are redirected in STDERR