### PR TITLE
Dhcpv6 enhancements

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -1078,7 +1078,7 @@ components:
         associated_dhcp_messages:
           description: |-
             The list of dhcpv6 client messages where this option is included.
-          $ref: '#/components/schemas/Dhcpv6ClientOptions.OptionsRequestIncludedMessages'
+          $ref: '#/components/schemas/Dhcpv6ClientOptions.IncludedMessages'
           x-field-uid: 2
     Device.Dhcpv6Client.Options:
       description: |-
@@ -1522,30 +1522,6 @@ components:
             The dhcpv6 client messages where this option is included.
           $ref: '#/components/schemas/Dhcpv6ClientOptions.IncludedMessages'
           x-field-uid: 3
-    Dhcpv6ClientOptions.OptionsRequestIncludedMessages:
-      description: |-
-        The dhcpv6 client messages where the option will be included. If all is selected the selected option will be added in the all the Dhcpv6 client messages, else based on the selection in particular Dhcpv6 client messages the option will be included.
-      type: object
-      properties:
-        choice:
-          description: |-
-            The client message name where the option is included, by default it is all.
-          type: string
-          default: all
-          x-field-uid: 1
-          x-enum:
-            all:
-              x-field-uid: 1
-            msg_types:
-              x-field-uid: 2
-          enum:
-          - all
-          - msg_types
-        msg_types:
-          description: |-
-            User must specify the Dhcpv6 message type.
-          $ref: '#/components/schemas/Dhcpv6ClientOptions.MessageType'
-          x-field-uid: 2
     Dhcpv6ClientOptions.IncludedMessages:
       description: |-
         The dhcpv6 client messages where the option will be included. If all is selected the selected option will be added in the all the Dhcpv6 client messages, else based on the selection in particular Dhcpv6 client messages the option will be included.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -592,7 +592,7 @@ message DeviceDhcpv6ClientOptionsRequest {
 
   // The list of dhcpv6 client messages where this option is included.
   // required = true
-  Dhcpv6ClientOptionsOptionsRequestIncludedMessages associated_dhcp_messages = 2;
+  Dhcpv6ClientOptionsIncludedMessages associated_dhcp_messages = 2;
 }
 
 // DHCP client options, these configured options are sent in Dhcp client messages.
@@ -937,26 +937,6 @@ message Dhcpv6ClientOptionsVendorClass {
   // The dhcpv6 client messages where this option is included.
   // required = true
   Dhcpv6ClientOptionsIncludedMessages associated_dhcp_messages = 3;
-}
-
-// The dhcpv6 client messages where the option will be included. If all is selected
-// the selected option will be added in the all the Dhcpv6 client messages, else based
-// on the selection in particular Dhcpv6 client messages the option will be included.
-message Dhcpv6ClientOptionsOptionsRequestIncludedMessages {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      all = 1;
-      msg_types = 2;
-    }
-  }
-  // The client message name where the option is included, by default it is all.
-  // default = Choice.Enum.all
-  optional Choice.Enum choice = 1;
-
-  // User must specify the Dhcpv6 message type.
-  Dhcpv6ClientOptionsMessageType msg_types = 2;
 }
 
 // The dhcpv6 client messages where the option will be included. If all is selected

--- a/device/dhcp/clients/v6/dhcpv6client.yaml
+++ b/device/dhcp/clients/v6/dhcpv6client.yaml
@@ -58,10 +58,8 @@ components:
         associated_dhcp_messages: 
           description: >-
             The list of dhcpv6 client messages where this option is included.
-          $ref: '#/components/schemas/Dhcpv6ClientOptions.OptionsRequestIncludedMessages'
+          $ref: '#/components/schemas/Dhcpv6ClientOptions.IncludedMessages'
           x-field-uid: 2
-
-
 
     Device.Dhcpv6Client.Options:
       description: >-

--- a/device/dhcp/common/dhcpv6options.yaml
+++ b/device/dhcp/common/dhcpv6options.yaml
@@ -286,31 +286,6 @@ components:
           $ref: '#/components/schemas/Dhcpv6ClientOptions.IncludedMessages'
           x-field-uid: 3
 
-    Dhcpv6ClientOptions.OptionsRequestIncludedMessages:
-      description: >-
-        The dhcpv6 client messages where the option will be included. If all is selected the selected option will be
-        added in the all the Dhcpv6 client messages, else based on the selection in particular Dhcpv6 client messages
-        the option will be included.
-      type: object
-      properties:
-        choice:
-          description: >-
-            The client message name where the option is included, by default it is all.
-          type: string
-          default: all
-          x-field-uid: 1
-          x-enum:
-            all:
-              x-field-uid: 1
-            msg_types:
-              x-field-uid: 2
-        msg_types:
-          description: >-
-            User must specify the Dhcpv6 message type.
-          $ref: '#/components/schemas/Dhcpv6ClientOptions.MessageType'
-          x-field-uid: 2
-
-
     Dhcpv6ClientOptions.IncludedMessages:
       description: >-
         The dhcpv6 client messages where the option will be included. If all is selected the selected option will be


### PR DESCRIPTION
https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dhcpv6_enhancements/artifacts/openapi.yaml&nocors

This PR changes the client options request to include a list of possible dhcp client messages where the options request will be included, previously it was not a array.

This shows configuration of one dhcpv6 client and server in two different ports

The first eg is of a dhcpv6 client and the next of a dhcpv6 server

// Case-1: DHCPv6 Client
// DHCPv6 Client is configured on connected interface.
#Creating Ports
import otg
api = otg.api(location="https://localhost")
config = api.config()
p1 = config.ports.port(name='p1', location='172.17.0.2:50071')[-1]

#Create DHCPv6 client running on connected interface port 1.
p1_d1 = config.devices.device(name='p1_d1')[-1]

p1_eth1 = p1_d1.ethernets.ethernet()[-1]
p1_eth1.connection.port_name = p1.name
p1_eth1.name = 'p1_eth1'

p1_eth1.mac = '64:00:00:00:00:01'
p1_dhcp1 = p1_eth1.dhcpv6_interfaces.dhcpv6client(name = 'p1_dhcp1')[-1]
print(config.serialize())

// Case-2: DHCPv6 Server.
#Creating Ports
import otg
api = otg.api(location="https://localhost")
config = api.config()
p2 = config.ports.port(name='p2', location='172.17.0.3:50071')[-1]

#Create ethernet and ipv6  running on connected ipv6 interface port 2.
p2_d1 = config.devices.device(name='p1_d1')[-1]
p2_eth1 = p2_d1.ethernets.ethernet()[-1]
p2_eth1.connection.port_name = p2.name
p2_eth1.name = 'p1_eth1'
p2_eth1.mac = '64:00:00:00:00:01'
p2_ip1 = p2_eth1.ipv6_addresses.ipv6(name = 'p2_ip1', address = '2000:0:0:1::2', gateway = '2000:0:0:1::1')[-1]

# Creating a DHCPv6  server on the connected interface port2.
p2_dhcp1 = p2_d1.dhcp_server.ipv6_interfaces.v6(name='p2_dhcp1',ipv6_name=p2_ip1.name)[-1]
p2_dhcp1_lease = p2_dhcp1.leases.lease()[-1]
p2_dhcp1_lease_iatype = p2_dhcp1_lease.ia_type.choice="iapd"
p2_dhcp1_lease.ia_type.iapd.start_prefix_address = "a1a1::0"
p2_dhcp1_lease.ia_type.iapd.prefix_step = 1
print(config.serialize())
{
  "devices": [
    {
      "ethernets": [
        {
          "connection": {
            "choice": "port_name",
            "port_name": "p1"
          },
          "dhcpv6_interfaces": [
            {
              "name": "p1_dhcp1",
              "rapid_commit": false
            }
          ],
          "mac": "64:00:00:00:00:01",
          "mtu": 1500,
          "name": "p1_eth1"
        }
      ],
      "name": "p1_d1"
    }
  ],
  "ports": [
    {
      "location": "172.17.0.2:50071",
      "name": "p1"
    }
  ]
}



{
  "devices": [
    {
      "dhcp_server": {
        "ipv6_interfaces": [
          {
            "ipv6_name": "p2_ip1",
            "leases": [
              {
                "ia_type": {
                  "choice": "iapd",
                  "iapd": {
                    "advertised_prefix_len": 64,
                    "configured_prefix_len": 64,
                    "prefix_size": 10,
                    "prefix_step": 1,
                    "start_prefix_address": "a1a1::0"
                  }
                },
                "lease_time": 86400
              }
            ],
            "name": "p2_dhcp1",
            "rapid_commit": false,
            "reconfigure_via_relay_agent": false.
          }
        ]
      },
      "ethernets": [
        {
          "connection": {
            "choice": "port_name",
            "port_name": "p2"
          },
          "ipv6_addresses": [
            {
              "address": "2000:0:0:1::2",
              "gateway": "2000:0:0:1::1",
              "name": "p2_ip1",
              "prefix": 64
            }
          ],
          "mac": "64:00:00:00:00:01",
          "mtu": 1500,
          "name": "p1_eth1"
        }
      ],
      "name": "p1_d1"
    }
  ],
  "ports": [
    {
      "location": "172.17.0.3:50071",
      "name": "p2"
    }
  ]
}
// This example basically focuses on how flows can be created for dhcp configurations

config := gosnappi.NewConfig()

// skipping configuration of ports, devices, and common protocols like ethernet


// Configure a DHCP Client on device 1
d1Eth1.DhcpV6Interfaces().Add().
  SetName("p1d1dchpv6client")

// configure ipv4 on device 2
d2Eth1.
  Ipv4Addresses().
  Add().
  SetName("p2d1ipv6").
  SetAddress("2000:0:0:1::2").
  SetGateway("2000:0:0:1::1").
  SetPrefix(64)

// Configure a DHCP Server on device 2
d2Dhcpv6Server := d6.DhcpServer().Ipv6Interfaces().Add().SetName("p2d2dhcpv6server")

d2Dhcpv6Server.SetIpv6Name("p2d1ipv6").Leases().Add().
  SetName("pool1").
  SetLeaseTime(3600).
  IaType("iapd").
  SetStartPrefixAddrress("a1a1::0").
  SetStep("0:0:0:1:0:0:0:0")

// configure flow from dhcp client to ipv4 interface on dhcp server side
f1 := config.Flows().Items()[0]
f1.SetName(p1.Name() + " -> " + p2.Name()).
	TxRx().Device().
	SetTxNames([]string{"p1d1dhcpv6client"}).
	SetRxNames([]string{"p2d1ipv6"})

f1Eth := f1.Packet().Add().Ethernet()
f1Eth.Src().SetValue(d1Eth1.Mac())
f1Eth.Dst().Auto()

f1Ip := f1.Packet().Add().Ipv6()
// will be populated automatically with the the dynamically allocated Ip to DHCP client
f1Ip.Src().Auto().Dhcp()
f1Ip.Dst().SetValue("2000:0:0:1::2")

// configure flow from ipv4 interface on the dhcp server side to DHCP client
f2 := config.Flows().Items()[1]
f2.SetName(p2.Name() + " -> " + p1.Name()).
	TxRx().Device().
	SetTxNames([]string{"p2d1ipv6")}).
	SetRxNames([]string{"p1d1dhcpv6client"})

f2Eth := f2.Packet().Add().Ethernet()
f2Eth.Src().SetValue(d2Eth1.Mac())
f2Eth.Dst().Auto()

f2Ip := f2.Packet().Add().Ipv6()
f2Ip.Src().SetValue("2000:0:0:1::2")
// will be populated automatically with the the dynamically allocated Ip to DHCP client
f2Ip.Dst().Auto().Dhcp()