### PR TITLE
Dhcpv6 l1 fixes to make client learned infos as array

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19187,57 +19187,74 @@ components:
             The name of a DHCPv6 Client.
           type: string
           x-field-uid: 1
-        ipv6_iapd_addresses:
+        iapds:
           description: |-
-            The IPv6 IAPD addresses associated with this DHCP Client session.
+            The IPv6 IAPD addresses and prefixes associated with this DHCP Client session.
           type: array
           items:
-            type: string
-            format: ipv6
+            $ref: '#/components/schemas/Dhcpv6Interface.Iapd'
           x-field-uid: 2
-        iapd_prefix_lengths:
+        addresses:
           description: |-
-            The prefix lengths of the IPv6 IAPD addresses associated with this DHCP Client session.
+            The IPv6 addresses and gateways associated with this DHCP Client session.
           type: array
           items:
-            type: integer
-            format: uint32
-            maximum: 128
+            $ref: '#/components/schemas/Dhcpv6Interface.AddressInfo'
           x-field-uid: 3
-        ipv6_addresses:
-          description: |-
-            The IPv6 addresses associated with this DHCP Client session.
-          type: array
-          items:
-            type: string
-            format: ipv6
-          x-field-uid: 4
-        gateway_addresses:
-          description: |-
-            The Gateway IPV6 addresses associated with this DHCP Client session.
-          type: array
-          items:
-            type: string
-            format: ipv6
-          x-field-uid: 5
         lease_time:
           description: |-
             The duration of the IPv6 address lease, in seconds.
           type: integer
           format: uint32
-          x-field-uid: 6
+          x-field-uid: 4
         renew_time:
           description: |-
             Time in seconds until the DHCPv6 client starts renewing the lease.
           type: integer
           format: uint32
-          x-field-uid: 7
+          x-field-uid: 5
         rebind_time:
           description: |-
             Time in seconds until the DHCPv6 client starts rebinding.
           type: integer
           format: uint32
-          x-field-uid: 8
+          x-field-uid: 6
+    Dhcpv6Interface.Iapd:
+      description: |-
+        The IPv6 IAPD addresse and prefix length associated with this DHCP Client session.
+      type: object
+      properties:
+        address:
+          description: |-
+            The IAPD address associated with this DHCPv6 Client session.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        prefix_length:
+          description: |-
+            The prefix length of the IAPD address associated with this DHCPv6 Client session.
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 2
+    Dhcpv6Interface.AddressInfo:
+      description: |-
+        The IPv6 addresse and gateway associated with this DHCP Client session.
+      type: object
+      properties:
+        address:
+          description: |-
+            The address associated with this DHCPv6 Client session.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        gateway:
+          description: |-
+            The Gateway address associated with this DHCPv6 Client session.
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 2
     Dhcpv6Lease.State.Request:
       description: |-
         The request to retrieve DHCP Server host allocated status.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19221,7 +19221,7 @@ components:
           x-field-uid: 6
     Dhcpv6Interface.Iapd:
       description: |-
-        The IPv6 IAPD addresse and prefix length associated with this DHCP Client session.
+        The IPv6 IAPD address and prefix length associated with this DHCP Client session.
       type: object
       properties:
         address:
@@ -19239,7 +19239,7 @@ components:
           x-field-uid: 2
     Dhcpv6Interface.AddressInfo:
       description: |-
-        The IPv6 addresse and gateway associated with this DHCP Client session.
+        The IPv6 address and gateway associated with this DHCP Client session.
       type: object
       properties:
         address:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19187,27 +19187,38 @@ components:
             The name of a DHCPv6 Client.
           type: string
           x-field-uid: 1
-        ipv6_iapd_address:
+        ipv6_iapd_addresses:
           description: |-
-            The IPv6 IAPD address associated with this DHCP Client session.
-          type: string
+            The IPv6 IAPD addresses associated with this DHCP Client session.
+          type: array
+          items:
+            type: string
+            format: ipv6
           x-field-uid: 2
-        iapd_prefix_length:
+        iapd_prefix_lengths:
           description: |-
-            The prefix length of the IPv6 IAPD address associated with this DHCP Client session.
-          type: integer
-          format: uint32
-          maximum: 128
+            The prefix lengths of the IPv6 IAPD addresses associated with this DHCP Client session.
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 128
           x-field-uid: 3
-        ipv6_address:
+        ipv6_addresses:
           description: |-
-            The IPv6 address associated with this DHCP Client session.
-          type: string
+            The IPv6 addresses associated with this DHCP Client session.
+          type: array
+          items:
+            type: string
+            format: ipv6
           x-field-uid: 4
-        gateway_address:
+        gateway_addresses:
           description: |-
-            The Gateway IPV6 address associated with this DHCP Client session.
-          type: string
+            The Gateway IPV6 addresses associated with this DHCP Client session.
+          type: array
+          items:
+            type: string
+            format: ipv6
           x-field-uid: 5
         lease_time:
           description: |-

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14088,7 +14088,7 @@ message Dhcpv6InterfaceState {
   optional uint32 rebind_time = 6;
 }
 
-// The IPv6 IAPD addresse and prefix length associated with this DHCP Client session.
+// The IPv6 IAPD address and prefix length associated with this DHCP Client session.
 message Dhcpv6InterfaceIapd {
 
   // The IAPD address associated with this DHCPv6 Client session.
@@ -14098,7 +14098,7 @@ message Dhcpv6InterfaceIapd {
   optional uint32 prefix_length = 2;
 }
 
-// The IPv6 addresse and gateway associated with this DHCP Client session.
+// The IPv6 address and gateway associated with this DHCP Client session.
 message Dhcpv6InterfaceAddressInfo {
 
   // The address associated with this DHCPv6 Client session.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14072,17 +14072,17 @@ message Dhcpv6InterfaceState {
   // The name of a DHCPv6 Client.
   optional string dhcp_client_name = 1;
 
-  // The IPv6 IAPD address associated with this DHCP Client session.
-  optional string ipv6_iapd_address = 2;
+  // The IPv6 IAPD addresses associated with this DHCP Client session.
+  repeated string ipv6_iapd_addresses = 2;
 
-  // The prefix length of the IPv6 IAPD address associated with this DHCP Client session.
-  optional uint32 iapd_prefix_length = 3;
+  // The prefix lengths of the IPv6 IAPD addresses associated with this DHCP Client session.
+  repeated uint32 iapd_prefix_lengths = 3;
 
-  // The IPv6 address associated with this DHCP Client session.
-  optional string ipv6_address = 4;
+  // The IPv6 addresses associated with this DHCP Client session.
+  repeated string ipv6_addresses = 4;
 
-  // The Gateway IPV6 address associated with this DHCP Client session.
-  optional string gateway_address = 5;
+  // The Gateway IPV6 addresses associated with this DHCP Client session.
+  repeated string gateway_addresses = 5;
 
   // The duration of the IPv6 address lease, in seconds.
   optional uint32 lease_time = 6;

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14072,26 +14072,40 @@ message Dhcpv6InterfaceState {
   // The name of a DHCPv6 Client.
   optional string dhcp_client_name = 1;
 
-  // The IPv6 IAPD addresses associated with this DHCP Client session.
-  repeated string ipv6_iapd_addresses = 2;
+  // The IPv6 IAPD addresses and prefixes associated with this DHCP Client session.
+  repeated Dhcpv6InterfaceIapd iapds = 2;
 
-  // The prefix lengths of the IPv6 IAPD addresses associated with this DHCP Client session.
-  repeated uint32 iapd_prefix_lengths = 3;
-
-  // The IPv6 addresses associated with this DHCP Client session.
-  repeated string ipv6_addresses = 4;
-
-  // The Gateway IPV6 addresses associated with this DHCP Client session.
-  repeated string gateway_addresses = 5;
+  // The IPv6 addresses and gateways associated with this DHCP Client session.
+  repeated Dhcpv6InterfaceAddressInfo addresses = 3;
 
   // The duration of the IPv6 address lease, in seconds.
-  optional uint32 lease_time = 6;
+  optional uint32 lease_time = 4;
 
   // Time in seconds until the DHCPv6 client starts renewing the lease.
-  optional uint32 renew_time = 7;
+  optional uint32 renew_time = 5;
 
   // Time in seconds until the DHCPv6 client starts rebinding.
-  optional uint32 rebind_time = 8;
+  optional uint32 rebind_time = 6;
+}
+
+// The IPv6 IAPD addresse and prefix length associated with this DHCP Client session.
+message Dhcpv6InterfaceIapd {
+
+  // The IAPD address associated with this DHCPv6 Client session.
+  optional string address = 1;
+
+  // The prefix length of the IAPD address associated with this DHCPv6 Client session.
+  optional uint32 prefix_length = 2;
+}
+
+// The IPv6 addresse and gateway associated with this DHCP Client session.
+message Dhcpv6InterfaceAddressInfo {
+
+  // The address associated with this DHCPv6 Client session.
+  optional string address = 1;
+
+  // The Gateway address associated with this DHCPv6 Client session.
+  optional uint32 gateway = 2;
 }
 
 // The request to retrieve DHCP Server host allocated status.

--- a/result/dhcpv6interface.yaml
+++ b/result/dhcpv6interface.yaml
@@ -61,7 +61,7 @@ components:
 
     Dhcpv6Interface.Iapd:
       description: >-
-        The IPv6 IAPD addresse and prefix length associated with this DHCP Client session.
+        The IPv6 IAPD address and prefix length associated with this DHCP Client session.
       type: object
       properties:
         address:
@@ -80,7 +80,7 @@ components:
 
     Dhcpv6Interface.AddressInfo:
       description: >-
-        The IPv6 addresse and gateway associated with this DHCP Client session.
+        The IPv6 address and gateway associated with this DHCP Client session.
       type: object
       properties:
         address:

--- a/result/dhcpv6interface.yaml
+++ b/result/dhcpv6interface.yaml
@@ -25,27 +25,38 @@ components:
             The name of a DHCPv6 Client.
           type: string
           x-field-uid: 1
-        ipv6_iapd_address:
+        ipv6_iapd_addresses:
           description: >-
-            The IPv6 IAPD address associated with this DHCP Client session.
-          type: string
+            The IPv6 IAPD addresses associated with this DHCP Client session.
+          type: array
+          items:
+            type: string
+            format: ipv6
           x-field-uid: 2
-        iapd_prefix_length:
+        iapd_prefix_lengths:
           description: >-
-            The prefix length of the IPv6 IAPD address associated with this DHCP Client session.
-          type: integer
-          format: uint32
-          maximum: 128
+            The prefix lengths of the IPv6 IAPD addresses associated with this DHCP Client session.
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 128
           x-field-uid: 3
-        ipv6_address:
+        ipv6_addresses:
           description: >-
-            The IPv6 address associated with this DHCP Client session.
-          type: string
+            The IPv6 addresses associated with this DHCP Client session.
+          type: array
+          items:
+            type: string
+            format: ipv6
           x-field-uid: 4
-        gateway_address:
+        gateway_addresses:
           description: >-
-            The Gateway IPV6 address associated with this DHCP Client session.
-          type: string
+            The Gateway IPV6 addresses associated with this DHCP Client session.
+          type: array
+          items:
+            type: string
+            format: ipv6
           x-field-uid: 5
         lease_time:
           description: >-

--- a/result/dhcpv6interface.yaml
+++ b/result/dhcpv6interface.yaml
@@ -15,9 +15,10 @@ components:
           x-constraint:
           - "/components/schemas/Device.Dhcpv6client/properties/name"
           x-field-uid: 1
+
     Dhcpv6Interface.State:
       description: >-
-       The IPv6 address associated with this DHCP Client session.
+        The IPv6 address associated with this DHCP Client session.
       type: object
       properties:
         dhcp_client_name:
@@ -25,54 +26,73 @@ components:
             The name of a DHCPv6 Client.
           type: string
           x-field-uid: 1
-        ipv6_iapd_addresses:
+        iapds:
           description: >-
-            The IPv6 IAPD addresses associated with this DHCP Client session.
+            The IPv6 IAPD addresses and prefixes associated with this DHCP Client session.
           type: array
           items:
-            type: string
-            format: ipv6
+            $ref: '#/components/schemas/Dhcpv6Interface.Iapd'
           x-field-uid: 2
-        iapd_prefix_lengths:
+        addresses:
           description: >-
-            The prefix lengths of the IPv6 IAPD addresses associated with this DHCP Client session.
+            The IPv6 addresses and gateways associated with this DHCP Client session.
           type: array
           items:
-            type: integer
-            format: uint32
-            maximum: 128
+            $ref: '#/components/schemas/Dhcpv6Interface.AddressInfo'
           x-field-uid: 3
-        ipv6_addresses:
-          description: >-
-            The IPv6 addresses associated with this DHCP Client session.
-          type: array
-          items:
-            type: string
-            format: ipv6
-          x-field-uid: 4
-        gateway_addresses:
-          description: >-
-            The Gateway IPV6 addresses associated with this DHCP Client session.
-          type: array
-          items:
-            type: string
-            format: ipv6
-          x-field-uid: 5
         lease_time:
           description: >-
             The duration of the IPv6 address lease, in seconds.
           type: integer
           format: uint32
-          x-field-uid: 6
+          x-field-uid: 4
         renew_time:
           description: >-
             Time in seconds until the DHCPv6 client starts renewing the lease.
           type: integer
           format: uint32
-          x-field-uid: 7
+          x-field-uid: 5
         rebind_time:
           description: >-
             Time in seconds until the DHCPv6 client starts rebinding.
           type: integer
           format: uint32
-          x-field-uid: 8
+          x-field-uid: 6
+
+    Dhcpv6Interface.Iapd:
+      description: >-
+        The IPv6 IAPD addresse and prefix length associated with this DHCP Client session.
+      type: object
+      properties:
+        address:
+          description: >-
+            The IAPD address associated with this DHCPv6 Client session.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        prefix_length:
+          description: >-
+            The prefix length of the IAPD address associated with this DHCPv6 Client session.
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 2
+
+    Dhcpv6Interface.AddressInfo:
+      description: >-
+        The IPv6 addresse and gateway associated with this DHCP Client session.
+      type: object
+      properties:
+        address:
+          description: >-
+            The address associated with this DHCPv6 Client session.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        gateway:
+          description: >-
+            The Gateway address associated with this DHCPv6 Client session.
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 2


### PR DESCRIPTION
https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dhvcpv6_l1/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_states

This PR changes the client get states to have a array of learned v6 prefixes,addresses,prefix lens and gateway addresses.

This shows configuration of one dhcpv6 client and server in two different ports

The first eg is of a dhcpv6 client and the next of a dhcpv6 server

// Case-1: DHCPv6 Client
// DHCPv6 Client is configured on connected interface.
#Creating Ports
import otg
api = otg.api(location="https://localhost/")
config = api.config()
p1 = config.ports.port(name='p1', location='172.17.0.2:50071')[-1]

#Create DHCPv6 client running on connected interface port 1.
p1_d1 = config.devices.device(name='p1_d1')[-1]

p1_eth1 = p1_d1.ethernets.ethernet()[-1]
p1_eth1.connection.port_name = p1.name
p1_eth1.name = 'p1_eth1'

p1_eth1.mac = '64:00:00:00:00:01'
p1_dhcp1 = p1_eth1.dhcpv6_interfaces.dhcpv6client(name = 'p1_dhcp1')[-1]
print(config.serialize())

// Case-2: DHCPv6 Server.
#Creating Ports
import otg
api = otg.api(location="https://localhost/")
config = api.config()
p2 = config.ports.port(name='p2', location='172.17.0.3:50071')[-1]

#Create ethernet and ipv6 running on connected ipv6 interface port 2.
p2_d1 = config.devices.device(name='p1_d1')[-1]
p2_eth1 = p2_d1.ethernets.ethernet()[-1]
p2_eth1.connection.port_name = p2.name
p2_eth1.name = 'p1_eth1'
p2_eth1.mac = '64:00:00:00:00:01'
p2_ip1 = p2_eth1.ipv6_addresses.ipv6(name = 'p2_ip1', address = '2000:0:0:1::2', gateway = '2000:0:0:1::1')[-1]

Creating a DHCPv6 server on the connected interface port2.
p2_dhcp1 = p2_d1.dhcp_server.ipv6_interfaces.v6(name='p2_dhcp1',ipv6_name=p2_ip1.name)[-1]
p2_dhcp1_lease = p2_dhcp1.leases.lease()[-1]
p2_dhcp1_lease_iatype = p2_dhcp1_lease.ia_type.choice="iapd"
p2_dhcp1_lease.ia_type.iapd.start_prefix_address = "a1a1::0"
p2_dhcp1_lease.ia_type.iapd.prefix_step = 1
print(config.serialize())
{
"devices": [
{
"ethernets": [
{
"connection": {
"choice": "port_name",
"port_name": "p1"
},
"dhcpv6_interfaces": [
{
"name": "p1_dhcp1",
"rapid_commit": false
}
],
"mac": "64:00:00:00:00:01",
"mtu": 1500,
"name": "p1_eth1"
}
],
"name": "p1_d1"
}
],
"ports": [
{
"location": "172.17.0.2:50071",
"name": "p1"
}
]
}

{
"devices": [
{
"dhcp_server": {
"ipv6_interfaces": [
{
"ipv6_name": "p2_ip1",
"leases": [
{
"ia_type": {
"choice": "iapd",
"iapd": {
"advertised_prefix_len": 64,
"configured_prefix_len": 64,
"prefix_size": 10,
"prefix_step": 1,
"start_prefix_address": "a1a1::0"
}
},
"lease_time": 86400
}
],
"name": "p2_dhcp1",
"rapid_commit": false,
"reconfigure_via_relay_agent": false.
}
]
},
"ethernets": [
{
"connection": {
"choice": "port_name",
"port_name": "p2"
},
"ipv6_addresses": [
{
"address": "2000:0:0:1::2",
"gateway": "2000:0:0:1::1",
"name": "p2_ip1",
"prefix": 64
}
],
"mac": "64:00:00:00:00:01",
"mtu": 1500,
"name": "p1_eth1"
}
],
"name": "p1_d1"
}
],
"ports": [
{
"location": "172.17.0.3:50071",
"name": "p2"
}
]
}
// This example basically focuses on how flows can be created for dhcp configurations

config := gosnappi.NewConfig()

// skipping configuration of ports, devices, and common protocols like ethernet

// Configure a DHCP Client on device 1
d1Eth1.DhcpV6Interfaces().Add().
SetName("p1d1dchpv6client")

// configure ipv4 on device 2
d2Eth1.
Ipv4Addresses().
Add().
SetName("p2d1ipv6").
SetAddress("2000:0:0:1::2").
SetGateway("2000:0:0:1::1").
SetPrefix(64)

// Configure a DHCP Server on device 2
d2Dhcpv6Server := d6.DhcpServer().Ipv6Interfaces().Add().SetName("p2d2dhcpv6server")

d2Dhcpv6Server.SetIpv6Name("p2d1ipv6").Leases().Add().
SetName("pool1").
SetLeaseTime(3600).
IaType("iapd").
SetStartPrefixAddrress("a1a1::0").
SetStep("0:0:0:1:0:0:0:0")

// configure flow from dhcp client to ipv4 interface on dhcp server side
f1 := config.Flows().Items()[0]
f1.SetName(p1.Name() + " -> " + p2.Name()).
TxRx().Device().
SetTxNames([]string{"p1d1dhcpv6client"}).
SetRxNames([]string{"p2d1ipv6"})

f1Eth := f1.Packet().Add().Ethernet()
f1Eth.Src().SetValue(d1Eth1.Mac())
f1Eth.Dst().Auto()

f1Ip := f1.Packet().Add().Ipv6()
// will be populated automatically with the the dynamically allocated Ip to DHCP client
f1Ip.Src().Auto().Dhcp()
f1Ip.Dst().SetValue("2000:0:0:1::2")

// configure flow from ipv4 interface on the dhcp server side to DHCP client
f2 := config.Flows().Items()[1]
f2.SetName(p2.Name() + " -> " + p1.Name()).
TxRx().Device().
SetTxNames([]string{"p2d1ipv6")}).
SetRxNames([]string{"p1d1dhcpv6client"})

f2Eth := f2.Packet().Add().Ethernet()
f2Eth.Src().SetValue(d2Eth1.Mac())
f2Eth.Dst().Auto()

f2Ip := f2.Packet().Add().Ipv6()
f2Ip.Src().SetValue("2000:0:0:1::2")
// will be populated automatically with the the dynamically allocated Ip to DHCP client
f2Ip.Dst().Auto().Dhcp()