### PR TITLE
Custom tlv info support

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19987,11 +19987,12 @@ components:
         oui_subtype:
           description: |-
             The organizationally defined subtype field shall contain a unique subtype value assigned by the defining organization.
-          type: string
+          type: integer
+          format: uint32
           x-field-uid: 3
         information:
           description: |-
-            Contains either the Alpha-numeric information encoded in UTF-8 (as specified in IETF RFC 3629) or include one or more information fields with their associated field-type identifiers designators.
+            Contains information on the remaining bytes of the received Organization-Specific TLV after the sub-type field. The value must be returned in lowercase hexadecimal format.
           type: string
           x-field-uid: 4
     LldpCapability.State:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19989,6 +19989,11 @@ components:
             The organizationally defined subtype field shall contain a unique subtype value assigned by the defining organization.
           type: string
           x-field-uid: 3
+        information:
+          description: |-
+            The organization specific information that is advertised by the neighbor.
+          type: string
+          x-field-uid: 4
     LldpCapability.State:
       description: |-
         LLDP system capability advertised by the neighbor

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19991,7 +19991,7 @@ components:
           x-field-uid: 3
         information:
           description: |-
-            The organization specific information that is advertised by the neighbor.
+            Contains either the Alpha-numeric information encoded in UTF-8 (as specified in IETF RFC 3629) or include one or more information fields with their associated field-type identifiers designators.
           type: string
           x-field-uid: 4
     LldpCapability.State:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14627,7 +14627,9 @@ message LldpCustomTLVState {
   // by the defining organization.
   optional string oui_subtype = 3;
 
-  // The organization specific information that is advertised by the neighbor.
+  // Contains either the Alpha-numeric information encoded in UTF-8 (as specified in IETF
+  // RFC 3629) or include one or more information fields with their associated field-type
+  // identifiers designators.
   optional string information = 4;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14625,11 +14625,11 @@ message LldpCustomTLVState {
 
   // The organizationally defined subtype field shall contain a unique subtype value assigned
   // by the defining organization.
-  optional string oui_subtype = 3;
+  optional uint32 oui_subtype = 3;
 
-  // Contains either the Alpha-numeric information encoded in UTF-8 (as specified in IETF
-  // RFC 3629) or include one or more information fields with their associated field-type
-  // identifiers designators.
+  // Contains information on the remaining bytes of the received Organization-Specific
+  // TLV after the sub-type field. The value must be returned in lowercase hexadecimal
+  // format.
   optional string information = 4;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14626,6 +14626,9 @@ message LldpCustomTLVState {
   // The organizationally defined subtype field shall contain a unique subtype value assigned
   // by the defining organization.
   optional string oui_subtype = 3;
+
+  // The organization specific information that is advertised by the neighbor.
+  optional string information = 4;
 }
 
 // LLDP system capability advertised by the neighbor

--- a/result/lldpneighbors.yaml
+++ b/result/lldpneighbors.yaml
@@ -182,11 +182,12 @@ components:
         oui_subtype:
           description: >-
             The organizationally defined subtype field shall contain a unique subtype value assigned by the defining organization.
-          type: string
+          type: integer
+          format: unit32
           x-field-uid: 3
         information:
           description: >-
-            Contains either the Alpha-numeric information encoded in UTF-8 (as specified in IETF RFC 3629) or include one or more information fields with their associated field-type identifiers designators.
+            Contains information on the remaining bytes of the received Organization-Specific TLV after the sub-type field. The value must be returned in lowercase hexadecimal format.
           type: string
           x-field-uid: 4
 

--- a/result/lldpneighbors.yaml
+++ b/result/lldpneighbors.yaml
@@ -183,7 +183,7 @@ components:
           description: >-
             The organizationally defined subtype field shall contain a unique subtype value assigned by the defining organization.
           type: integer
-          format: unit32
+          format: uint32
           x-field-uid: 3
         information:
           description: >-

--- a/result/lldpneighbors.yaml
+++ b/result/lldpneighbors.yaml
@@ -184,6 +184,11 @@ components:
             The organizationally defined subtype field shall contain a unique subtype value assigned by the defining organization.
           type: string
           x-field-uid: 3
+        information:
+          description: >-
+            The organization specific information that is advertised by the neighbor.
+          type: string
+          x-field-uid: 4
 
     LldpCapability.State:
       description: >-

--- a/result/lldpneighbors.yaml
+++ b/result/lldpneighbors.yaml
@@ -186,7 +186,7 @@ components:
           x-field-uid: 3
         information:
           description: >-
-            The organization specific information that is advertised by the neighbor.
+            Contains either the Alpha-numeric information encoded in UTF-8 (as specified in IETF RFC 3629) or include one or more information fields with their associated field-type identifiers designators.
           type: string
           x-field-uid: 4
 


### PR DESCRIPTION
Fixes #393 
### Change of oui-subtype field in get_states LLDP Custom TLV node from `string` to `unit32`

### Adding support for information field in LLDP custom TLV learned info 
[Redocly Link](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/custom_tlv_info_support/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_states) 

basically everything remains same just an addition of property `information` in path `States.Response/LldpNeighbhors.State/LldpCustomTLV.State`

snappi-snippet
```python
# request
request = api.states_request()
request.lldp_neighbors.lldp_names = []
response = api.get_states(request)

# response
neighbors = response.lldp_neighbors
neighbor = neighbors [0]
neighbor.custom_type  # type: unit32 example_value- 0
neighbor.oui  # type: hex_string example_value- "0:80:C2"
neighbor.oui_subtype  # type: uint32 example_value- 1 
# newly added
neighbor.information # type hex_string example_value- "0030ae"

```