### PR TITLE
Support for Port link state change timestamp

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -15673,6 +15673,8 @@ components:
                 x-field-uid: 11
               bytes_rx_rate:
                 x-field-uid: 12
+              last_link_state_change_time:
+                x-field-uid: 13
             enum:
             - transmit
             - location
@@ -15686,6 +15688,7 @@ components:
             - frames_rx_rate
             - bytes_tx_rate
             - bytes_rx_rate
+            - last_link_state_change_time
           x-field-uid: 2
     Port.Metric:
       type: object
@@ -15788,6 +15791,11 @@ components:
           enum:
           - started
           - stopped
+        last_link_state_change_time:
+          description: |-
+            The timestamp of the last link-state change event
+          type: string
+          x-field-uid: 14
     Flow.Metrics.Request:
       description: |-
         The container for a flow metric request.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -15791,10 +15791,13 @@ components:
           enum:
           - started
           - stopped
-        last_link_state_change_time:
-          description: |-
-            The timestamp of the last link-state change event
-          type: string
+        last_change:
+          description: "The timestamp indicates the absolute time of the last \nlink\
+            \ state change of the test port (e.g., up-to-down transition).\n\nThe\
+            \ value is the timestamp in nanoseconds relative to\nthe Unix Epoch (Jan\
+            \ 1, 1970 00:00:00 UTC)."
+          type: integer
+          format: uint64
           x-field-uid: 14
     Flow.Metrics.Request:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -15673,7 +15673,7 @@ components:
                 x-field-uid: 11
               bytes_rx_rate:
                 x-field-uid: 12
-              last_link_state_change_time:
+              last_change:
                 x-field-uid: 13
             enum:
             - transmit
@@ -15688,7 +15688,7 @@ components:
             - frames_rx_rate
             - bytes_tx_rate
             - bytes_rx_rate
-            - last_link_state_change_time
+            - last_change
           x-field-uid: 2
     Port.Metric:
       type: object

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12047,8 +12047,12 @@ message PortMetric {
   // The transmit state of the flow.
   optional Transmit.Enum transmit = 13;
 
-  // The timestamp of the last link-state change event
-  optional string last_link_state_change_time = 14;
+  // The timestamp indicates the absolute time of the last
+  // link state change of the test port (e.g., up-to-down transition).
+  // 
+  // The value is the timestamp in nanoseconds relative to
+  // the Unix Epoch (Jan 1, 1970 00:00:00 UTC).
+  optional uint64 last_change = 14;
 }
 
 // The container for a flow metric request.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -11970,6 +11970,7 @@ message PortMetricsRequest {
       frames_rx_rate = 10;
       bytes_tx_rate = 11;
       bytes_rx_rate = 12;
+      last_link_state_change_time = 13;
     }
   }
   // The list of column names that the returned result set will contain. If the list is
@@ -12045,6 +12046,9 @@ message PortMetric {
   }
   // The transmit state of the flow.
   optional Transmit.Enum transmit = 13;
+
+  // The timestamp of the last link-state change event
+  optional string last_link_state_change_time = 14;
 }
 
 // The container for a flow metric request.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -11970,7 +11970,7 @@ message PortMetricsRequest {
       frames_rx_rate = 10;
       bytes_tx_rate = 11;
       bytes_rx_rate = 12;
-      last_link_state_change_time = 13;
+      last_change = 13;
     }
   }
   // The list of column names that the returned result set will contain. If the list is

--- a/result/port.yaml
+++ b/result/port.yaml
@@ -48,6 +48,8 @@ components:
                 x-field-uid: 11
               bytes_rx_rate:
                 x-field-uid: 12
+              last_link_state_change_time:
+                x-field-uid: 13
           x-field-uid: 2
     Port.Metric:
       type: object
@@ -142,3 +144,8 @@ components:
               x-field-uid: 1
             stopped:
               x-field-uid: 2
+        last_link_state_change_time:
+          description: >-
+            The timestamp of the last link-state change event
+          type: string
+          x-field-uid: 14

--- a/result/port.yaml
+++ b/result/port.yaml
@@ -48,7 +48,7 @@ components:
                 x-field-uid: 11
               bytes_rx_rate:
                 x-field-uid: 12
-              last_link_state_change_time:
+              last_change:
                 x-field-uid: 13
           x-field-uid: 2
     Port.Metric:

--- a/result/port.yaml
+++ b/result/port.yaml
@@ -144,8 +144,13 @@ components:
               x-field-uid: 1
             stopped:
               x-field-uid: 2
-        last_link_state_change_time:
-          description: >-
-            The timestamp of the last link-state change event
-          type: string
+        last_change:
+          description: |-
+            The timestamp indicates the absolute time of the last 
+            link state change of the test port (e.g., up-to-down transition).
+      
+            The value is the timestamp in nanoseconds relative to
+            the Unix Epoch (Jan 1, 1970 00:00:00 UTC).
+          type: integer
+          format: uint64
           x-field-uid: 14


### PR DESCRIPTION
https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/port-timestamp/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_metrics

Added new metric to retrieve timestamp for the last port link state change event