### PR TITLE
Dhcp iapd, change configured prefix len default from 64 to 128

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -9744,11 +9744,11 @@ components:
         configured_prefix_len:
           description: "The IPv6 network prefix length is used for incrementing the\
             \ lease address within the lease pool where multiple addresses are configured\
-            \ by using the size field. The address is incremented using the configured\
-            \ Prefix Length and Step. "
+            \ by using the size field. The address is incremented using the configured_prefix_len\
+            \ and prefix_step. "
           type: integer
           format: uint32
-          default: 64
+          default: 128
           maximum: 128
           x-field-uid: 2
         prefix_size:
@@ -9762,7 +9762,7 @@ components:
           x-field-uid: 3
         prefix_step:
           description: |-
-            The increment value for the lease address within the lease pool where multiple addresses are present. The value is incremented according to the Prefix Length and Step.
+            The increment value for the lease address within the lease pool where multiple addresses are present. The value is incremented according to the configured_prefix_len and prefix_step.
           type: integer
           format: uint32
           default: 1

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -9707,7 +9707,7 @@ components:
           x-field-uid: 1
         prefix_len:
           description: |-
-            The IPv6 network prefix length is used for incrementing the lease address within the lease pool where multiple addresses are configured by using the size field. The address is incremented using the configured Prefix Length and Step.
+            The prefix_len ( in conjunction with the step) can be used to increment the IPv6 lease addresses  to be assigned to the requested clients when multiple addresses are configured by using the size field  in the pool. The address is incremented using the prefix_len and step.
           type: integer
           format: uint32
           default: 64
@@ -9724,7 +9724,7 @@ components:
           x-field-uid: 3
         step:
           description: |-
-            The increment value for the lease address within the lease pool where multiple addresses are present. The value is incremented according to the configured Prefix Length and Step.
+            The increment value for the lease address within the lease pool where multiple addresses are present.  The value of the advertised IPv6 prefixes are incremented according to the prefix_len and step.
           type: integer
           format: uint32
           default: 1
@@ -9742,10 +9742,8 @@ components:
           format: ipv6
           x-field-uid: 1
         configured_prefix_len:
-          description: "The IPv6 network prefix length is used for incrementing the\
-            \ lease address within the lease pool where multiple addresses are configured\
-            \ by using the size field. The address is incremented using the configured_prefix_len\
-            \ and prefix_step. "
+          description: |-
+            The configured_prefix_len ( in conjunction with the prefix_step) can be used to increment the IPv6 lease addresses  to be assigned to the requested clients when multiple addresses are configured by using the size field in the pool.  e.g. This can be used to assign multiple IPv6 host addresses within the same IPv6 subnet ( defined by advertised_prefix_len )  to multiple requesting clients.
           type: integer
           format: uint32
           default: 128
@@ -9762,7 +9760,7 @@ components:
           x-field-uid: 3
         prefix_step:
           description: |-
-            The increment value for the lease address within the lease pool where multiple addresses are present. The value is incremented according to the configured_prefix_len and prefix_step.
+            The increment value for the lease address within the lease pool where multiple addresses are present.  The value of the advertised IPv6 prefixes are incremented according to the configured_prefix_len and prefix_step.
           type: integer
           format: uint32
           default: 1

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -7277,8 +7277,8 @@ message Dhcpv6ServerIapdPoolInfo {
 
   // The IPv6 network prefix length is used for incrementing the lease address within
   // the lease pool where multiple addresses are configured by using the size field. The
-  // address is incremented using the configured Prefix Length and Step.
-  // default = 64
+  // address is incremented using the configured_prefix_len and prefix_step.
+  // default = 128
   optional uint32 configured_prefix_len = 2;
 
   // The total number of addresses in the pool.
@@ -7286,7 +7286,8 @@ message Dhcpv6ServerIapdPoolInfo {
   optional uint32 prefix_size = 3;
 
   // The increment value for the lease address within the lease pool where multiple addresses
-  // are present. The value is incremented according to the Prefix Length and Step.
+  // are present. The value is incremented according to the configured_prefix_len and
+  // prefix_step.
   // default = 1
   optional uint32 prefix_step = 4;
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -7252,9 +7252,10 @@ message Dhcpv6ServerPoolInfo {
   // The first IP address of the lease pool.
   optional string start_address = 1;
 
-  // The IPv6 network prefix length is used for incrementing the lease address within
-  // the lease pool where multiple addresses are configured by using the size field. The
-  // address is incremented using the configured Prefix Length and Step.
+  // The prefix_len ( in conjunction with the step) can be used to increment the IPv6
+  // lease addresses  to be assigned to the requested clients when multiple addresses
+  // are configured by using the size field  in the pool. The address is incremented using
+  // the prefix_len and step.
   // default = 64
   optional uint32 prefix_len = 2;
 
@@ -7263,8 +7264,8 @@ message Dhcpv6ServerPoolInfo {
   optional uint32 size = 3;
 
   // The increment value for the lease address within the lease pool where multiple addresses
-  // are present. The value is incremented according to the configured Prefix Length and
-  // Step.
+  // are present.  The value of the advertised IPv6 prefixes are incremented according
+  // to the prefix_len and step.
   // default = 1
   optional uint32 step = 4;
 }
@@ -7275,9 +7276,11 @@ message Dhcpv6ServerIapdPoolInfo {
   // The first IP address of the prefix pool.
   optional string start_prefix_address = 1;
 
-  // The IPv6 network prefix length is used for incrementing the lease address within
-  // the lease pool where multiple addresses are configured by using the size field. The
-  // address is incremented using the configured_prefix_len and prefix_step.
+  // The configured_prefix_len ( in conjunction with the prefix_step) can be used to increment
+  // the IPv6 lease addresses  to be assigned to the requested clients when multiple addresses
+  // are configured by using the size field in the pool.  e.g. This can be used to assign
+  // multiple IPv6 host addresses within the same IPv6 subnet ( defined by advertised_prefix_len
+  // )  to multiple requesting clients.
   // default = 128
   optional uint32 configured_prefix_len = 2;
 
@@ -7286,8 +7289,8 @@ message Dhcpv6ServerIapdPoolInfo {
   optional uint32 prefix_size = 3;
 
   // The increment value for the lease address within the lease pool where multiple addresses
-  // are present. The value is incremented according to the configured_prefix_len and
-  // prefix_step.
+  // are present.  The value of the advertised IPv6 prefixes are incremented according
+  // to the configured_prefix_len and prefix_step.
   // default = 1
   optional uint32 prefix_step = 4;
 

--- a/device/dhcp/servers/v6/dhcpv6server.yaml
+++ b/device/dhcp/servers/v6/dhcpv6server.yaml
@@ -130,8 +130,9 @@ components:
           x-field-uid: 1
         prefix_len:
           description: >-
-            The IPv6 network prefix length is used for incrementing the lease address within the lease pool where multiple
-            addresses are configured by using the size field. The address is incremented using the configured Prefix Length and Step.
+            The prefix_len ( in conjunction with the step) can be used to increment the IPv6 lease addresses 
+            to be assigned to the requested clients when multiple addresses are configured by using the size field 
+            in the pool. The address is incremented using the prefix_len and step.
           type: integer
           format: uint32
           default: 64
@@ -148,9 +149,8 @@ components:
           x-field-uid: 3
         step:
           description: >-
-            The increment value for the lease address within the lease pool where multiple
-            addresses are present. The value is incremented according to the configured Prefix
-            Length and Step.
+            The increment value for the lease address within the lease pool where multiple addresses are present. 
+            The value of the advertised IPv6 prefixes are incremented according to the prefix_len and step.
           type: integer
           format: uint32
           default: 1
@@ -170,8 +170,10 @@ components:
           x-field-uid: 1
         configured_prefix_len:
           description: >-
-            The IPv6 network prefix length is used for incrementing the lease address within the lease pool where multiple
-            addresses are configured by using the size field. The address is incremented using the configured_prefix_len and prefix_step. 
+           The configured_prefix_len ( in conjunction with the prefix_step) can be used to increment the IPv6 lease addresses 
+           to be assigned to the requested clients when multiple addresses are configured by using the size field in the pool. 
+           e.g. This can be used to assign multiple IPv6 host addresses within the same IPv6 subnet ( defined by advertised_prefix_len ) 
+           to multiple requesting clients.
           type: integer
           format: uint32
           default: 128
@@ -188,8 +190,8 @@ components:
           x-field-uid: 3
         prefix_step:
           description: >-
-            The increment value for the lease address within the lease pool where multiple
-            addresses are present. The value is incremented according to the configured_prefix_len and prefix_step.
+            The increment value for the lease address within the lease pool where multiple addresses are present. 
+            The value of the advertised IPv6 prefixes are incremented according to the configured_prefix_len and prefix_step.
           type: integer
           format: uint32
           default: 1

--- a/device/dhcp/servers/v6/dhcpv6server.yaml
+++ b/device/dhcp/servers/v6/dhcpv6server.yaml
@@ -171,10 +171,10 @@ components:
         configured_prefix_len:
           description: >-
             The IPv6 network prefix length is used for incrementing the lease address within the lease pool where multiple
-            addresses are configured by using the size field. The address is incremented using the configured Prefix Length and Step. 
+            addresses are configured by using the size field. The address is incremented using the configured_prefix_len and prefix_step. 
           type: integer
           format: uint32
-          default: 64
+          default: 128
           maximum: 128
           x-field-uid: 2
         prefix_size:
@@ -189,8 +189,7 @@ components:
         prefix_step:
           description: >-
             The increment value for the lease address within the lease pool where multiple
-            addresses are present. The value is incremented according to the Prefix
-            Length and Step.
+            addresses are present. The value is incremented according to the configured_prefix_len and prefix_step.
           type: integer
           format: uint32
           default: 1


### PR DESCRIPTION
https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dhcp_iapd/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config

This PR changes the server lease pool configured prefix len from 64 to 128

This shows configuration of one dhcpv6 client and server in two different ports

The first eg is of a dhcpv6 client and the next of a dhcpv6 server

// Case-1: DHCPv6 Client
// DHCPv6 Client is configured on connected interface.
#Creating Ports
import otg
api = otg.api(location="https://localhost/")
config = api.config()
p1 = config.ports.port(name='p1', location='172.17.0.2:50071')[-1]

#Create DHCPv6 client running on connected interface port 1.
p1_d1 = config.devices.device(name='p1_d1')[-1]

p1_eth1 = p1_d1.ethernets.ethernet()[-1]
p1_eth1.connection.port_name = p1.name
p1_eth1.name = 'p1_eth1'

p1_eth1.mac = '64:00:00:00:00:01'
p1_dhcp1 = p1_eth1.dhcpv6_interfaces.dhcpv6client(name = 'p1_dhcp1')[-1]
print(config.serialize())

// Case-2: DHCPv6 Server.
#Creating Ports
import otg
api = otg.api(location="https://localhost/")
config = api.config()
p2 = config.ports.port(name='p2', location='172.17.0.3:50071')[-1]

#Create ethernet and ipv6 running on connected ipv6 interface port 2.
p2_d1 = config.devices.device(name='p1_d1')[-1]
p2_eth1 = p2_d1.ethernets.ethernet()[-1]
p2_eth1.connection.port_name = p2.name
p2_eth1.name = 'p1_eth1'
p2_eth1.mac = '64:00:00:00:00:01'
p2_ip1 = p2_eth1.ipv6_addresses.ipv6(name = 'p2_ip1', address = '2000:0:0:1::2', gateway = '2000:0:0:1::1')[-1]

Creating a DHCPv6 server on the connected interface port2.
p2_dhcp1 = p2_d1.dhcp_server.ipv6_interfaces.v6(name='p2_dhcp1',ipv6_name=p2_ip1.name)[-1]
p2_dhcp1_lease = p2_dhcp1.leases.lease()[-1]
p2_dhcp1_lease_iatype = p2_dhcp1_lease.ia_type.choice="iapd"
p2_dhcp1_lease.ia_type.iapd.start_prefix_address = "a1a1::0"
p2_dhcp1_lease.ia_type.iapd.prefix_step = 1
print(config.serialize())
{
"devices": [
{
"ethernets": [
{
"connection": {
"choice": "port_name",
"port_name": "p1"
},
"dhcpv6_interfaces": [
{
"name": "p1_dhcp1",
"rapid_commit": false
}
],
"mac": "64:00:00:00:00:01",
"mtu": 1500,
"name": "p1_eth1"
}
],
"name": "p1_d1"
}
],
"ports": [
{
"location": "172.17.0.2:50071",
"name": "p1"
}
]
}

{
"devices": [
{
"dhcp_server": {
"ipv6_interfaces": [
{
"ipv6_name": "p2_ip1",
"leases": [
{
"ia_type": {
"choice": "iapd",
"iapd": {
"advertised_prefix_len": 64,
"configured_prefix_len": 128,
"prefix_size": 10,
"prefix_step": 1,
"start_prefix_address": "a1a1::0"
}
},
"lease_time": 86400
}
],
"name": "p2_dhcp1",
"rapid_commit": false,
"reconfigure_via_relay_agent": false.
}
]
},
"ethernets": [
{
"connection": {
"choice": "port_name",
"port_name": "p2"
},
"ipv6_addresses": [
{
"address": "2000:0:0:1::2",
"gateway": "2000:0:0:1::1",
"name": "p2_ip1",
"prefix": 64
}
],
"mac": "64:00:00:00:00:01",
"mtu": 1500,
"name": "p1_eth1"
}
],
"name": "p1_d1"
}
],
"ports": [
{
"location": "172.17.0.3:50071",
"name": "p2"
}
]
}
// This example basically focuses on how flows can be created for dhcp configurations

config := gosnappi.NewConfig()

// skipping configuration of ports, devices, and common protocols like ethernet

// Configure a DHCP Client on device 1
d1Eth1.DhcpV6Interfaces().Add().
SetName("p1d1dchpv6client")

// configure ipv4 on device 2
d2Eth1.
Ipv4Addresses().
Add().
SetName("p2d1ipv6").
SetAddress("2000:0:0:1::2").
SetGateway("2000:0:0:1::1").
SetPrefix(64)

// Configure a DHCP Server on device 2
d2Dhcpv6Server := d6.DhcpServer().Ipv6Interfaces().Add().SetName("p2d2dhcpv6server")

d2Dhcpv6Server.SetIpv6Name("p2d1ipv6").Leases().Add().
SetName("pool1").
SetLeaseTime(3600).
IaType("iapd").
SetStartPrefixAddrress("a1a1::0").
SetStep("0:0:0:1:0:0:0:0")

// configure flow from dhcp client to ipv4 interface on dhcp server side
f1 := config.Flows().Items()[0]
f1.SetName(p1.Name() + " -> " + p2.Name()).
TxRx().Device().
SetTxNames([]string{"p1d1dhcpv6client"}).
SetRxNames([]string{"p2d1ipv6"})

f1Eth := f1.Packet().Add().Ethernet()
f1Eth.Src().SetValue(d1Eth1.Mac())
f1Eth.Dst().Auto()

f1Ip := f1.Packet().Add().Ipv6()
// will be populated automatically with the the dynamically allocated Ip to DHCP client
f1Ip.Src().Auto().Dhcp()
f1Ip.Dst().SetValue("2000:0:0:1::2")

// configure flow from ipv4 interface on the dhcp server side to DHCP client
f2 := config.Flows().Items()[1]
f2.SetName(p2.Name() + " -> " + p1.Name()).
TxRx().Device().
SetTxNames([]string{"p2d1ipv6")}).
SetRxNames([]string{"p1d1dhcpv6client"})

f2Eth := f2.Packet().Add().Ethernet()
f2Eth.Src().SetValue(d2Eth1.Mac())
f2Eth.Dst().Auto()

f2Ip := f2.Packet().Add().Ipv6()
f2Ip.Src().SetValue("2000:0:0:1::2")
// will be populated automatically with the the dynamically allocated Ip to DHCP client
f2Ip.Dst().Auto().Dhcp()