### PR TITLE
OTG Model to support different RoCE speed

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -309,10 +309,8 @@ components:
           $ref: '#/components/schemas/Protocol.Options'
           x-field-uid: 2
         vendor_options:
-          description: "This is a backdoor access to underlying OTG solution.  This\
-            \ will allow to access Vendor specific option type with it respective\
-            \ value. e,g OTG underlying solution is deviating xyz feature. Then option\
-            \ `type=feature` and `value=xyz`         "
+          description: "This is a backdoor access to underlying OTG application. \
+            \      "
           type: array
           items:
             $ref: '#/components/schemas/Vendor.Options'
@@ -2495,26 +2493,27 @@ components:
           x-field-uid: 1
     Vendor.Options:
       type: object
-      required:
-      - type
-      - value
       properties:
-        type:
-          description: |-
-            Option type (e,g, `feature`) which is specific to the underlying OTG implimentation.
-          type: string
-          x-field-uid: 1
-        value:
-          description: |-
-            Value of the secific option type.
-          type: string
-          x-field-uid: 2
-        names:
-          description: |-
-            Names of the vendor. Option type and value will applicable for all vendor if this field is not defined.
+        additional_features:
+          description: "OTG Application require some additional property to run the\
+            \ config. That additional property may not be generic enough to address\
+            \ in OTG model. So, OTG expose this backdoor access to define a feature\
+            \ name must be understandable by OTG application.            "
           type: array
           items:
             type: string
+          x-field-uid: 1
+        deviations:
+          description: |-
+            Name of the deviating feature names when OTG model deviates from the application requirements.
+          type: array
+          items:
+            type: string
+          x-field-uid: 2
+        vendor:
+          description: |-
+            Names of the vendor.  Vendor specific options will be applicable for all vendor if this field is not defined.
+          type: string
           x-field-uid: 3
     Device.IsisRouter:
       description: |-

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -62,9 +62,7 @@ message ConfigOptions {
   // Description missing in models
   ProtocolOptions protocol_options = 2;
 
-  // This is a backdoor access to underlying OTG solution.  This will allow to access
-  // Vendor specific option type with it respective value. e,g OTG underlying solution
-  // is deviating xyz feature. Then option `type=feature` and `value=xyz`
+  // This is a backdoor access to underlying OTG application.
   repeated VendorOptions vendor_options = 3;
 }
 
@@ -1703,17 +1701,19 @@ message ProtocolOptions {
 // Description missing in models
 message VendorOptions {
 
-  // Option type (e,g, `feature`) which is specific to the underlying OTG implimentation.
-  // required = true
-  optional string type = 1;
+  // OTG Application require some additional property to run the config. That additional
+  // property may not be generic enough to address in OTG model. So, OTG expose this backdoor
+  // access to define a feature name must be understandable by OTG application.
+  // 
+  repeated string additional_features = 1;
 
-  // Value of the secific option type.
-  // required = true
-  optional string value = 2;
+  // Name of the deviating feature names when OTG model deviates from the application
+  // requirements.
+  repeated string deviations = 2;
 
-  // Names of the vendor. Option type and value will applicable for all vendor if this
-  // field is not defined.
-  repeated string names = 3;
+  // Names of the vendor.  Vendor specific options will be applicable for all vendor if
+  // this field is not defined.
+  optional string vendor = 3;
 }
 
 // A container of properties for an ISIS router and its interfaces.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -75,3 +75,8 @@ components:
         protocol_options:
           $ref: '../device/device.yaml#/components/schemas/Protocol.Options'
           x-field-uid: 2
+        vendor_options:
+          type: array
+          items:
+            $ref: '../device/device.yaml#/components/schemas/Vendor.Options'
+          x-field-uid: 3         

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,7 +78,8 @@ components:
         vendor_options:
           description: >-
             This is a backdoor access to underlying OTG solution. 
-            OTG has a provision to specify vendor specific options with value.        
+            This will allow to access Vendor specific option type with it respective value.
+            e,g OTG underlying solution is deviating xyz feature. Then option type='feature' and value=`xyz`         
           type: array
           items:
             $ref: '../device/device.yaml#/components/schemas/Vendor.Options'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -76,6 +76,9 @@ components:
           $ref: '../device/device.yaml#/components/schemas/Protocol.Options'
           x-field-uid: 2
         vendor_options:
+          description: >-
+            This is a backdoor access to underlying OTG solution. 
+            OTG has a provision to specify vendor specific options with value.        
           type: array
           items:
             $ref: '../device/device.yaml#/components/schemas/Vendor.Options'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -79,7 +79,7 @@ components:
           description: >-
             This is a backdoor access to underlying OTG solution. 
             This will allow to access Vendor specific option type with it respective value.
-            e,g OTG underlying solution is deviating xyz feature. Then option type='feature' and value=`xyz`         
+            e,g OTG underlying solution is deviating xyz feature. Then option `type=feature` and `value=xyz`         
           type: array
           items:
             $ref: '../device/device.yaml#/components/schemas/Vendor.Options'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -77,9 +77,7 @@ components:
           x-field-uid: 2
         vendor_options:
           description: >-
-            This is a backdoor access to underlying OTG solution. 
-            This will allow to access Vendor specific option type with it respective value.
-            e,g OTG underlying solution is deviating xyz feature. Then option `type=feature` and `value=xyz`         
+            This is a backdoor access to underlying OTG application.       
           type: array
           items:
             $ref: '../device/device.yaml#/components/schemas/Vendor.Options'

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -95,22 +95,26 @@ components:
           x-field-uid: 1
     Vendor.Options:
       type: object
-      required: [type, value]
       properties:
-        type:
+        additional_features:
           description: >-
-            Option type (e,g, `feature`) which is specific to the underlying OTG implimentation.
-          type: string
-          x-field-uid: 1
-        value:
-          description: >-
-            Value of the secific option type.
-          type: string
-          x-field-uid: 2
-        names:
-          description: >-
-            Names of the vendor. Option type and value will applicable for all vendor if this field is not defined.
+            OTG Application require some additional property to run the config.
+            That additional property may not be generic enough to address in OTG model.
+            So, OTG expose this backdoor access to define a feature name must be understandable by OTG application.            
           type: array
           items:
             type: string
+          x-field-uid: 1
+        deviations:
+          description: >-
+            Name of the deviating feature names when OTG model deviates from the application requirements.
+          type: array
+          items:
+            type: string
+          x-field-uid: 2
+        vendor:
+          description: >-
+            Names of the vendor. 
+            Vendor specific options will be applicable for all vendor if this field is not defined.
+          type: string
           x-field-uid: 3

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -94,9 +94,6 @@ components:
           default: true
           x-field-uid: 1
     Vendor.Options:
-      description: >-
-        Vendor specific option with it respective value.
-        e,g OTG underlying solution is deviating xyz feature. Then option type='feature' and value=`xyz` 
       type: object
       required: [type, value]
       properties:
@@ -112,7 +109,7 @@ components:
           x-field-uid: 2
         names:
           description: >-
-            Names of the vendor. key and value will applicable for all vendor if this field is not defined.
+            Names of the vendor. Option type and value will applicable for all vendor if this field is not defined.
           type: array
           items:
             type: string

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -113,4 +113,6 @@ components:
           description: >-
             Names of the vendor. key and value will applicable for all vendor if this field is specify.
           type: array
-          x-field-uid: 3      
+          items:
+            type: string
+          x-field-uid: 3

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -97,6 +97,7 @@ components:
       description: >-
         Vendor specific key and value pair. 
       type: object
+      required: [key, value]
       properties:
         key:
           description: >-
@@ -108,3 +109,8 @@ components:
             Value secific to the vandor.
           type: string
           x-field-uid: 2
+        name:
+          description: >-
+            Name of the specific vendor. key and valuie will applicable for all vendor if this field is not set.
+          type: string
+          x-field-uid: 2        

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -109,8 +109,8 @@ components:
             Value secific to the vandor.
           type: string
           x-field-uid: 2
-        name:
+        names:
           description: >-
-            Name of the specific vendor. key and valuie will applicable for all vendor if this field is not set.
-          type: string
+            Names of the vendor. key and value will applicable for all vendor if this field is specify.
+          type: array
           x-field-uid: 3      

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -98,7 +98,7 @@ components:
         Vendor specific option with it respective value.
         e,g OTG underlying solution is deviating xyz feature. Then option type='feature' and value=`xyz` 
       type: object
-      required: [key, value]
+      required: [type, value]
       properties:
         type:
           description: >-

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -95,23 +95,24 @@ components:
           x-field-uid: 1
     Vendor.Options:
       description: >-
-        Vendor specific key and value pair. 
+        Vendor specific option with it respective value.
+        e,g OTG underlying solution is deviating xyz feature. Then option type='feature' and value=`xyz` 
       type: object
       required: [key, value]
       properties:
-        key:
+        type:
           description: >-
-            key secific to the vandor.
+            Option type (e,g, `feature`) which is specific to the underlying OTG implimentation.
           type: string
           x-field-uid: 1
         value:
           description: >-
-            Value secific to the vandor.
+            Value of the secific option type.
           type: string
           x-field-uid: 2
         names:
           description: >-
-            Names of the vendor. key and value will applicable for all vendor if this field is specify.
+            Names of the vendor. key and value will applicable for all vendor if this field is not defined.
           type: array
           items:
             type: string

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -113,4 +113,4 @@ components:
           description: >-
             Name of the specific vendor. key and valuie will applicable for all vendor if this field is not set.
           type: string
-          x-field-uid: 2        
+          x-field-uid: 3      

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -93,3 +93,18 @@ components:
           type: boolean
           default: true
           x-field-uid: 1
+    Vendor.Options:
+      description: >-
+        Vendor specific key and value pair. 
+      type: object
+      properties:
+        key:
+          description: >-
+            key secific to the vandor.
+          type: string
+          x-field-uid: 1
+        value:
+          description: >-
+            Value secific to the vandor.
+          type: string
+          x-field-uid: 2

--- a/layer1/layer1.yaml
+++ b/layer1/layer1.yaml
@@ -49,6 +49,13 @@ components:
               x-field-uid: 12
             speed_800_gbps:
               x-field-uid: 13
+            custom_speed:
+              x-field-uid: 14
+        custom_speed:
+          description: >-
+            Vendor specific custom speed.
+          type: string
+          x-field-uid: 11
         media:
           description: |-
             Set the type of media for test interface if supported. When no media


### PR DESCRIPTION
**Problem Statement:**
We have one OTG based solution call `snappi_ixnetwork` which is a client-side solution. So, entire conversion ( OTG to IxNetwork REST API) is happening in the client side and communicate with IxNetwork Server through REST API (RestPy library).
As this is a client-side solution, so we can access IxNetwork API handle from test and configure others IxNetwork parameters. 
We are configuring RoCE using RestPy though OTG model is not support that protocol. But we need to change the speed with specific format ( say `fourhundredgigrocev2`) which is not support to our current OTG model.

We have these two solutions:
**Solution-1:**
```
Add another Enum as “custom_speed” . So, user will specify vendor specific speed.
 l1 = config.layer1.add(name="l1")
 l1.speed = "custom_speed"
 l1.custom_speed = " fourhundredgigrocev2"
```

Note: Little annoying as “speed” is not a choice, so directly setting as `custom_speed` may be debatable.

Solution-2: 
This solution is not specific to speed. We will utilize it for generic purpose. This is like open config deviations. I have added more options to handle different use cases.

In this following example we are saying that OTG application should additionally handle `rocev2` feature  and deviate `isis-sr` functionality defined in OTG.
```
ven_optn = config.options.vendor_options.add()
ven_optn.additional_features = ["rocev2"]
ven_optn.deviations = ["isis-sr"]
ven_optn.vendor = "keysight"
```