### PR TITLE
changed max vlan priority to 7

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.20.0
+  version: 1.22.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -2538,6 +2538,11 @@ components:
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
+        segment_routing:
+          description: |-
+            Optional Segment Routing (SR).
+          $ref: '#/components/schemas/Isis.SegmentRouting'
+          x-field-uid: 10
     Device.IsisMultiInstance:
       description: "This container properties of an Multi-Instance-capable router\
         \ (MI-RTR). "
@@ -2673,6 +2678,13 @@ components:
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
+        adjacency_sids:
+          description: |-
+            List of Adjacency Segment Identifier (Adj-SID) sub-TLVs.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisInterface.AdjacencySid'
+          x-field-uid: 14
     IsisInterface.Level:
       description: |-
         Configuration for the properties of Level 1 Hello.
@@ -2954,6 +2966,104 @@ components:
           type: boolean
           default: false
           x-field-uid: 8
+    IsisInterface.AdjacencySid:
+      description: |-
+        Optional container for segment routing MPLS settings.
+        If the container exists then the adjacency SID (segment identifier)
+        sub TLV will be part of the packet.
+        Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-adjacency-segment-identifie.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Choice of whether Adjacency-SID carries and absolute value or a relative index to the SRGB/SRLB Ranges.
+            Please refer to device.isis.segment_routing.router_capability.sr_capability.srgb_ranges for the Segment Routing Global Block (SRGB) Descriptor and
+            device.isis.segment_routing.router_capability.srlb_ranges for the SR Local Block (SRLB).
+            A user needs to configure at least one entry of SID value or SID index.
+            If no entry is configured, then an implementation may advertise appropriate default SID Value/Index based on the choice. e.g. the first value
+            from the SRGB or SRLB range.
+            - sid_values: Adjacency-SID carries one or more values and then v_flag is set by the implementation.
+            - sid_indices: Adjacency-SID carries one or more indices and then v_flag is unset by the implementation.
+          type: string
+          default: sid_values
+          x-field-uid: 1
+          x-enum:
+            sid_values:
+              x-field-uid: 1
+            sid_indices:
+              x-field-uid: 2
+          enum:
+          - sid_values
+          - sid_indices
+        sid_values:
+          description: |-
+            The corresponding Adjacency SID as one or more absolute Values for the link.
+          type: array
+          items:
+            type: integer
+            format: uint32
+            default: 16
+            minimum: 16
+            maximum: 1048575
+          x-field-uid: 2
+        sid_indices:
+          description: |-
+            One or more adjacency Indices are relative to ranges defined for SRGB or SRLB.
+          type: array
+          items:
+            type: integer
+            format: uint32
+            default: 0
+            minimum: 0
+            maximum: 4294967295
+          x-field-uid: 3
+        f_flag:
+          description: |-
+            The address family flag. If unset, then the Adj-SID refers
+            to an adjacency with outgoing IPv4 encapsulation.  If set then
+            the Adj-SID refers to an adjacency with outgoing IPv6
+            encapsulation.
+          type: boolean
+          default: true
+          x-field-uid: 4
+        b_flag:
+          description: |-
+            The backup flag. If set, the Adj-SID is eligible for protection.
+          type: boolean
+          default: false
+          x-field-uid: 5
+        l_flag:
+          description: |-
+            The local flag.  If set, then the value/index carried by
+            the Adj-SID has local significance. In this case, Adjacency_sid is from device.isis.segment_routing.router_capability.srlb_ranges.
+          type: boolean
+          default: true
+          x-field-uid: 6
+        s_flag:
+          description: |-
+            The set flag. When set, the S-Flag indicates that the
+            Adj-SID refers to a set of adjacencies (and therefore MAY be
+            assigned to other adjacencies as well).
+          type: boolean
+          default: false
+          x-field-uid: 7
+        p_flag:
+          description: |-
+            The persistent flag. When set, the P-Flag indicates that
+            the Adj-SID is persistently allocated, i.e., the Adj-SID value
+            remains consistent across router restart and/or interface flap.
+          type: boolean
+          default: false
+          x-field-uid: 8
+        weight:
+          description: "The value represents the weight of the Adj-SID for the purpose\
+            \ of load balancing. "
+          type: integer
+          format: uint32
+          default: 0
+          minimum: 0
+          maximum: 255
+          x-field-uid: 9
     Isis.Basic:
       description: |-
         This contains ISIS router basic properties.
@@ -3211,6 +3321,13 @@ components:
             Node Flag (Bit 2)
           type: boolean
           default: false
+        prefix_sids:
+          description: |-
+            A list of SID paramters for a group of IPv4 route addresses.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSR.PrefixSid'
+          x-field-uid: 10
       required:
       - name
     V4RouteAddress:
@@ -3323,6 +3440,102 @@ components:
           default: 1
           minimum: 1
           x-field-uid: 4
+    IsisSR.PrefixSid:
+      description: |-
+        This contains the properties of IS-IS Prefix-SID and its attributes for  the extended Ipv4 and Ipv6 reachability. Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-prefix-segment-identifier-p.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Choice of whether Prefix-SID carries and absolute value or a relative index to the SRGB/SRLB Ranges.
+            Please refer to device.isis.segment_routing.router_capability.sr_capability.srgb_ranges for the Segment Routing Global Block (SRGB) Descriptor and
+            device.isis.segment_routing.router_capability.srlb_ranges for the SR Local Block (SRLB).
+            A user needs to configure at least one entry of SID value or SID index.
+            If no entry is configured, then an implementation may advertise appropriate default SID Value/Index based on the choice. e.g. the first value
+            from the SRGB or SRLB range.
+            - sid_values: Prefix-SID carries one or more values and then v_flag is set by the implementation.
+            - sid_indices: Prefix-SID carries one or more indices and then v_flag is unset by the implementation.
+          type: string
+          default: sid_indices
+          x-field-uid: 1
+          x-enum:
+            sid_values:
+              x-field-uid: 1
+            sid_indices:
+              x-field-uid: 2
+          enum:
+          - sid_values
+          - sid_indices
+        sid_values:
+          description: |-
+            SID/Label as one or more absolute values that are associated with the IGP Prefix segment attached to the specific IPv4 or IPv6 prefix.
+          type: array
+          items:
+            type: integer
+            format: uint32
+            default: 16
+            minimum: 16
+            maximum: 1048575
+          x-field-uid: 2
+        sid_indices:
+          description: |-
+            One or more SID/Label Indices that are associated with the IGP Prefix segment attached to the specific IPv4 or IPv6 prefix.
+          type: array
+          items:
+            type: integer
+            format: uint32
+            default: 0
+            minimum: 0
+            maximum: 4294967295
+          x-field-uid: 3
+        r_flag:
+          description: "R-Flag: Re-advertisement Flag. \nIf set, then the prefix to\
+            \ which this Prefix-SID is attached has been propagated by the router\
+            \ \nfrom either another level (i.e., from Level-1 to Level-2 or the opposite)\
+            \ or redistribution (e.g., from another protocol)."
+          type: boolean
+          default: false
+          x-field-uid: 4
+        n_flag:
+          description: "N-Flag: Node-SID flag.  \nIf set, then the Prefix-SID refers\
+            \ to the router identified by the prefix. \nTypically, the N-Flag is set\
+            \ on Prefix-SIDs that are attached to a router loopback address. \nThe\
+            \ N-Flag is set when the Prefix-SID is a Node-SID as described in [RFC8402]."
+          type: boolean
+          default: false
+          x-field-uid: 5
+        p_flag:
+          description: |-
+            P-Flag: No-PHP (No Penultimate Hop-Popping) Flag.
+            If set, then the penultimate hop MUST NOT pop the Prefix-SID before delivering the packet to the node that advertised the Prefix-SID.
+          type: boolean
+          default: false
+          x-field-uid: 6
+        e_flag:
+          description: "E-Flag: Explicit-Null Flag.\nIf set, any upstream neighbor\
+            \ of the Prefix-SID originator MUST replace the Prefix-SID with a Prefix-SID\
+            \ \nthat has an Explicit NULL value (0 for IPv4 and 2 for IPv6) before\
+            \ forwarding the packet."
+          type: boolean
+          default: false
+          x-field-uid: 7
+        l_flag:
+          description: |-
+            The local flag. If set, then the value/index carried by
+            the Prefix-SID has local significance and the Prefix SID is from Please refer to device.isis.segment_routing.router_capability.srlb_ranges.
+          type: boolean
+          default: false
+          x-field-uid: 8
+        algorithm:
+          description: |-
+            The Isis may use various algorithms when calculating reachability to other nodes or to prefixes attached to these nodes.
+            Refernce: https://datatracker.ietf.org/doc/html/rfc8667#SRALGOSUBTLV
+          type: integer
+          format: uint32
+          default: 0
+          minimum: 0
+          maximum: 255
+          x-field-uid: 9
     Isis.V6RouteRange:
       description: |-
         Emulated ISIS IPv6 routes.
@@ -3410,8 +3623,246 @@ components:
             Node Flag (Bit 2)
           type: boolean
           default: false
+        prefix_sids:
+          description: |-
+            A list of SID parameters for a group of IPv6 route addresses.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSR.PrefixSid'
+          x-field-uid: 10
       required:
       - name
+    Isis.SegmentRouting:
+      description: "Segment Routing (SR) allows for a flexible definition of end-to-end\
+        \ paths within IGP topologies by encoding paths as sequences of topological\
+        \ sub-paths, \ncalled \"segments\". These segments are advertised by the link-state\
+        \ routing protocols (IS-IS and OSPF). \nPrefix segments represent an ECMP-aware\
+        \ shortest path to a prefix (or a node), as per the state of the IGP topology.\
+        \ \nAdjacency segments represent a hop over a specific adjacency between two\
+        \ nodes in the IGP. \nA prefix segment is typically a multi-hop path while\
+        \ an adjacency segment, in most of the cases, is a one-hop path. \nThese segments\
+        \ act as topological sub-paths that can be combined together to form the required\
+        \ path.\nReference: https://datatracker.ietf.org/doc/html/rfc8667.:w\nAn implementation\
+        \ may advertise Router Capability with default values if a user does not even\
+        \ set the properties \nof Router Capability and Segment Routing Capability.\
+        \  "
+      type: object
+      properties:
+        router_capability:
+          description: "Optional IS-IS TLV named CAPABILITY, formed of multiple sub-TLVs,\
+            \ which allows a router to announce its\ncapabilities within an IS-IS\
+            \ level or the entire routing domain.        "
+          $ref: '#/components/schemas/Isis.RouterCapability'
+          x-field-uid: 1
+    Isis.RouterCapability:
+      description: |-
+        Container for the configuration of IS-IS Router CAPABILITY TLV.
+        https://datatracker.ietf.org/doc/html/rfc7981#section-2.
+        An implementation should set default values appropriately if any mandatory item is not configured by a user.
+      type: object
+      properties:
+        choice:
+          description: "The Router Capability ID SHOULD be identical to the value\
+            \ advertised in the Traffic Engineering Router ID TLV [RFC5305].\nIf no\
+            \ Traffic Engineering Router ID is assigned, the Router ID SHOULD be identical\
+            \ to an IP Interface Address [RFC1195] \nadvertised by the originating\
+            \ IS.\nIf the originating node does not support IPv4, then the reserved\
+            \ value 0.0.0.0 MUST be used in the Router ID field, \nand the IPv6 TE\
+            \ Router ID sub-TLV [RFC5316] MUST be present in the TLV.\n- ipv4_te_router_id:\
+            \ IPv4 Traffic Engineering(TE) router id (defined in isis.basic.ipv4_te_router_id)\
+            \ to be used as Router Capability ID.\n- interface_ip: When this is chosen\
+            \ the first IPv4 address of the first eth interface associated with this\
+            \ isis router instance should be assigned as the Router Capability ID.\n\
+            - custom_router_cap_id: This option should be chosen when Router Capability\
+            \ ID needs to be configured different from above two options."
+          type: string
+          default: ipv4_te_router_id
+          x-field-uid: 1
+          x-enum:
+            ipv4_te_router_id:
+              x-field-uid: 1
+            interface_ip:
+              x-field-uid: 2
+            custom_router_cap_id:
+              x-field-uid: 3
+          enum:
+          - ipv4_te_router_id
+          - interface_ip
+          - custom_router_cap_id
+        custom_router_cap_id:
+          description: |-
+            Router Capability ID in IPv4 address format.
+          type: string
+          format: ipv4
+          default: 0.0.0.0
+          x-field-uid: 2
+        s_bit:
+          description: |-
+            S bit (0x01): If the S bit is set(1), the IS-IS Router CAPABILITY TLV
+            MUST be flooded across the entire routing domain.  If the S bit is
+            not set(0), the TLV MUST NOT be leaked between levels.  This bit MUST
+            NOT be altered during the TLV leaking.
+          type: string
+          default: not_flood
+          x-enum:
+            flood:
+              x-field-uid: 1
+            not_flood:
+              x-field-uid: 2
+          x-field-uid: 3
+          enum:
+          - flood
+          - not_flood
+        d_bit:
+          description: |-
+            D bit (0x02): When the IS-IS Router CAPABILITY TLV is leaked from
+            Level 2 (L2) to Level 1 (L1), the D bit MUST be set.  Otherwise, this
+            bit MUST be clear.  IS-IS Router CAPABILITY TLVs with the D bit set
+            MUST NOT be leaked from Level 1 to Level 2.  This is to prevent TLV looping.
+          type: string
+          default: not_down
+          x-enum:
+            down:
+              x-field-uid: 1
+            not_down:
+              x-field-uid: 2
+          x-field-uid: 4
+          enum:
+          - down
+          - not_down
+        sr_capability:
+          description: "SR-Capabilities.      "
+          $ref: '#/components/schemas/Isis.SRCapability'
+          x-field-uid: 5
+        algorithms:
+          description: "This contains one or more Segment Routing Algorithm that a\
+            \ router may use various algorithms when calculating \nreachability to\
+            \ other nodes or to prefixes attached to these nodes.\nWhen the originating\
+            \ router does not advertise the SR-Algorithm sub-TLV, it implies that\
+            \ algorithm 0 is the only algorithm supported by the routers.\nWhen the\
+            \ originating router does advertise the SR-Algorithm sub-TLV, then algorithm\
+            \ 0 MUST be present while non-zero algorithms MAY be present."
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSR.Algorithm'
+          x-field-uid: 6
+        srlb_ranges:
+          description: |-
+            This contains the list of SR Local Block (SRLB)
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSR.Srlb'
+          x-field-uid: 7
+    Isis.SRCapability:
+      description: "Container for the configuration of IS-IS SR-CAPABILITY TLV that\
+        \ Segment Routing requires \neach router to advertise its SR data plane capability\
+        \ and the range of MPLS label values \nit uses for Segment Routing in the\
+        \ case where global SIDs are allocated (i.e., global indexes).\nReference:\
+        \ https://datatracker.ietf.org/doc/html/rfc8667#name-sr-capabilities-sub-tlv.\n\
+        An implementation should set default values appropriately if any mandatory\
+        \ item is not configured by a user."
+      type: object
+      properties:
+        flags:
+          description: |-
+            1 octet of flags.
+          $ref: '#/components/schemas/IsisSR.CapabilityFlags'
+          x-field-uid: 1
+        srgb_ranges:
+          description: |-
+            This contains the list of SRGB.
+            If no SRGB range is configured, implementation should send one SRGB range with default values.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSR.Srgb'
+          x-field-uid: 2
+    IsisSR.CapabilityFlags:
+      description: "Container for the configuration of IS-IS SR-CAPABILITY flags.\n\
+        The Router Capability TLV specifies flags that control its advertisement.\
+        \ \nThe SR-Capabilities sub-TLV MUST be propagated throughout the level and\
+        \ MUST NOT be advertised across level boundaries.\nTherefore, Router Capability\
+        \ TLV distribution flags are set accordingly, i.e., \nthe S-Flag in the Router\
+        \ Capability TLV [RFC7981] MUST be unset.\nReference: https://datatracker.ietf.org/doc/html/rfc8667#section-3.1-5.1.1.6.1."
+      type: object
+      properties:
+        ipv4_mpls:
+          description: |-
+            I-Flag for the MPLS IPv4 Flag. If set, then the router is capable of processing SR-MPLS-encapsulated IPv4 packets on all interfaces.
+          type: boolean
+          default: true
+          x-field-uid: 1
+        ipv6_mpls:
+          description: |-
+            V-Flag for the MPLS IPv6 Flag. If set, then the router is capable of processing SR-MPLS-encapsulated IPv6 packets on all interfaces.
+          type: boolean
+          default: true
+          x-field-uid: 2
+    IsisSR.Srgb:
+      description: |-
+        This contains the propeties of Segment Routing Global Block (SRGB) Descriptor. Reference: https://datatracker.ietf.org/doc/html/rfc8667#section-3.1-7.1.1
+      type: object
+      properties:
+        starting_sid:
+          description: |-
+            The SID/Label sub-TLV contains the first value of the SRGB while the range contains the number of SRGB elements.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 4294967295
+          default: 16000
+          x-field-uid: 1
+        range:
+          description: "This represents the number of SID in a SRGB range. "
+          type: integer
+          format: uint32
+          default: 8000
+          minimum: 1
+          maximum: 4294967295
+          x-field-uid: 2
+    IsisSR.Srlb:
+      description: "The SR Local Block (SRLB) sub-TLV contains the range of labels\
+        \ the node has reserved for Local SIDs. \nLocal SIDs are used for Adjacency\
+        \ SIDs or locally significant Prefix SIDs and may also be allocated by components\
+        \ other than the IS-IS protocol. \nAs an example, an application or a controller\
+        \ may instruct the router to allocate a specific Local SID. Therefore, \n\
+        in order for such applications or controllers to know what Local SIDs are\
+        \ available in the router, \nit is required that the router advertises its\
+        \ SRLB.\nReference: https://datatracker.ietf.org/doc/html/rfc8667#name-sr-local-block-sub-tlv."
+      type: object
+      properties:
+        starting_sid:
+          description: |-
+            The SID/Label sub-TLV contains the first value of the SRLB while the range contains the number of SRLB elements.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 4294967295
+          default: 16000
+          x-field-uid: 1
+        range:
+          description: "This represents the number of SIDs in a SRLB range. "
+          type: integer
+          format: uint32
+          default: 8000
+          minimum: 1
+          maximum: 4294967295
+          x-field-uid: 2
+    IsisSR.Algorithm:
+      description: |-
+        Container for SR-Algorithms. The Isis may use various algorithms when calculating reachability to other nodes or to prefixes attached to these
+            nodes. Examples of these algorithms are metric-based SPF, various sorts of Constrained SPF, etc.
+            - 0: SPF algorithm based on link metric.
+            - 1: Strict SPF algorithm based on link metric.
+        Reference: https://datatracker.ietf.org/doc/html/rfc8665#name-igp-algorithm-types-registr.
+      type: object
+      properties:
+        algorithm:
+          type: integer
+          format: uint32
+          default: 0
+          minimum: 0
+          maximum: 255
+          x-field-uid: 1
     Device.BgpRouter:
       description: |-
         Configuration for one or more IPv4 or IPv6 BGP peers.
@@ -15843,6 +16294,26 @@ components:
                 x-field-uid: 6
               frames_rx_rate:
                 x-field-uid: 7
+              tx_l1_rate_bps:
+                x-field-uid: 8
+              rx_l1_rate_bps:
+                x-field-uid: 9
+              tx_rate_bytes:
+                x-field-uid: 10
+              rx_rate_bytes:
+                x-field-uid: 11
+              tx_rate_bps:
+                x-field-uid: 12
+              rx_rate_bps:
+                x-field-uid: 13
+              tx_rate_kbps:
+                x-field-uid: 14
+              rx_rate_kbps:
+                x-field-uid: 15
+              tx_rate_mbps:
+                x-field-uid: 16
+              rx_rate_mbps:
+                x-field-uid: 17
             enum:
             - transmit
             - frames_tx
@@ -15851,6 +16322,16 @@ components:
             - bytes_rx
             - frames_tx_rate
             - frames_rx_rate
+            - tx_l1_rate_bps
+            - rx_l1_rate_bps
+            - tx_rate_bytes
+            - rx_rate_bytes
+            - tx_rate_bps
+            - rx_rate_bps
+            - tx_rate_kbps
+            - rx_rate_kbps
+            - tx_rate_mbps
+            - rx_rate_mbps
           x-field-uid: 3
         tagged_metrics:
           $ref: '#/components/schemas/Flow.TaggedMetrics.Filter'
@@ -15891,6 +16372,26 @@ components:
                 x-field-uid: 5
               frames_rx_rate:
                 x-field-uid: 6
+              tx_l1_rate_bps:
+                x-field-uid: 7
+              rx_l1_rate_bps:
+                x-field-uid: 8
+              tx_rate_bytes:
+                x-field-uid: 9
+              rx_rate_bytes:
+                x-field-uid: 10
+              tx_rate_bps:
+                x-field-uid: 11
+              rx_rate_bps:
+                x-field-uid: 12
+              tx_rate_kbps:
+                x-field-uid: 13
+              rx_rate_kbps:
+                x-field-uid: 14
+              tx_rate_mbps:
+                x-field-uid: 15
+              rx_rate_mbps:
+                x-field-uid: 16
             enum:
             - frames_tx
             - frames_rx
@@ -15898,6 +16399,16 @@ components:
             - bytes_rx
             - frames_tx_rate
             - frames_rx_rate
+            - tx_l1_rate_bps
+            - rx_l1_rate_bps
+            - tx_rate_bytes
+            - rx_rate_bytes
+            - tx_rate_bps
+            - rx_rate_bps
+            - tx_rate_kbps
+            - rx_rate_kbps
+            - tx_rate_mbps
+            - rx_rate_mbps
           x-field-uid: 3
         filters:
           description: |-
@@ -16018,6 +16529,56 @@ components:
           items:
             $ref: '#/components/schemas/Flow.TaggedMetric'
           x-field-uid: 15
+        tx_l1_rate_bps:
+          description: |-
+            The Layer 1 transmission rate in bits per second.
+          type: number
+          x-field-uid: 16
+        rx_l1_rate_bps:
+          description: |-
+            The Layer 1 receive rate in bits per second.
+          type: number
+          x-field-uid: 17
+        tx_rate_bytes:
+          description: |-
+            The transmission rate in bytes per second.
+          type: number
+          x-field-uid: 18
+        rx_rate_bytes:
+          description: |-
+            The receive rate in bytes per second.
+          type: number
+          x-field-uid: 19
+        tx_rate_bps:
+          description: |-
+            The transmission rate in bits per second.
+          type: number
+          x-field-uid: 20
+        rx_rate_bps:
+          description: |-
+            The receive rate in bits per second.
+          type: number
+          x-field-uid: 21
+        tx_rate_kbps:
+          description: |-
+            The transmission rate in Kilobits per second.
+          type: number
+          x-field-uid: 22
+        rx_rate_kbps:
+          description: |-
+            The receive rate in Kilobits per second.
+          type: number
+          x-field-uid: 23
+        tx_rate_mbps:
+          description: |-
+            The transmission rate in Megabits per second.
+          type: number
+          x-field-uid: 24
+        rx_rate_mbps:
+          description: |-
+            The receive rate in Megabits per second.
+          type: number
+          x-field-uid: 25
     Flow.TaggedMetric:
       description: |-
         Metrics for each set of values applicable for configured
@@ -16077,6 +16638,56 @@ components:
         latency:
           $ref: '#/components/schemas/Metric.Latency'
           x-field-uid: 10
+        tx_l1_rate_bps:
+          description: |-
+            The Layer 1 transmission rate in bits per second.
+          type: number
+          x-field-uid: 11
+        rx_l1_rate_bps:
+          description: |-
+            The Layer 1 receive rate in bits per second.
+          type: number
+          x-field-uid: 12
+        tx_rate_bytes:
+          description: |-
+            The transmission rate in bytes per second.
+          type: number
+          x-field-uid: 13
+        rx_rate_bytes:
+          description: |-
+            The receive rate in bytes per second.
+          type: number
+          x-field-uid: 14
+        tx_rate_bps:
+          description: |-
+            The transmission rate in bits per second.
+          type: number
+          x-field-uid: 15
+        rx_rate_bps:
+          description: |-
+            The receive rate in bits per second.
+          type: number
+          x-field-uid: 16
+        tx_rate_kbps:
+          description: |-
+            The transmission rate in Kilobits per second.
+          type: number
+          x-field-uid: 17
+        rx_rate_kbps:
+          description: |-
+            The receive rate in Kilobits per second.
+          type: number
+          x-field-uid: 18
+        tx_rate_mbps:
+          description: |-
+            The transmission rate in Megabits per second.
+          type: number
+          x-field-uid: 19
+        rx_rate_mbps:
+          description: |-
+            The receive rate in Megabits per second.
+          type: number
+          x-field-uid: 20
     Flow.MetricTag:
       type: object
       properties:
@@ -19689,6 +20300,14 @@ components:
           items:
             $ref: '#/components/schemas/IsisLsp.Ipv6ReachabilityTlv'
           x-field-uid: 7
+        router_capabilities:
+          description: |-
+            IS-IS Router Capabilities: TLV 242.
+            This container defines Router Capabilities.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.Capability'
+          x-field-uid: 8
     IsisLsp.Hostname:
       description: |-
         It contains Hostname for the TLV 137.
@@ -19760,7 +20379,7 @@ components:
             This container describes IS neighbors.
           type: array
           items:
-            $ref: '#/components/schemas/IsisLsp.neighbor'
+            $ref: '#/components/schemas/IsisLsp.ExtendedNeighbor'
           x-field-uid: 1
     IsisLsp.neighbor:
       description: |-
@@ -19773,6 +20392,24 @@ components:
           type: string
           format: hex
           x-field-uid: 1
+    IsisLsp.ExtendedNeighbor:
+      description: |-
+        This contains IS neighbors.
+      type: object
+      properties:
+        system_id:
+          description: |-
+            The System ID for this emulated ISIS router, e.g. "640100010000".
+          type: string
+          format: hex
+          x-field-uid: 1
+        adjacency_sids:
+          description: |-
+            List of segment routing adjacency SIDs.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.AdjacencySid'
+          x-field-uid: 2
     IsisLsp.Ipv4InternalReachabilityTlv:
       description: |-
         This container defines list of IPv4 internal reachability information in one IPv4 internal reachability TLV.
@@ -19907,8 +20544,18 @@ components:
           - up
           - down
         prefix_attributes:
+          description: |-
+            Extended Prefix Attribute flags container sub-TLV is type 4.
           $ref: '#/components/schemas/IsisLsp.PrefixAttributes'
           x-field-uid: 5
+        prefix_sids:
+          description: |-
+            Prefix Segment-ID list. IGP-Prefix Segment is an IGP segment attached to an IGP prefix. An IGP-Prefix Segment is global
+            (unless explicitly advertised otherwise) within the SR/IGP domain.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.PrefixSid'
+          x-field-uid: 6
     IsisLsp.Ipv6ReachabilityTlv:
       description: |-
         It defines list of IPv6 extended reachability information in one IPv6 Reachability TLV.
@@ -19977,28 +20624,323 @@ components:
           - internal
           - external
         prefix_attributes:
+          description: |-
+            Extended Prefix Attribute flags container sub-TLV is type 4.
           $ref: '#/components/schemas/IsisLsp.PrefixAttributes'
           x-field-uid: 6
+        prefix_sids:
+          description: |-
+            Prefix Segment-ID list. IGP-Prefix Segment is an IGP segment attached to an IGP prefix. An IGP-Prefix Segment is global
+            (unless explicitly advertised otherwise) within the SR/IGP domain.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.PrefixSid'
+          x-field-uid: 7
     IsisLsp.PrefixAttributes:
       description: |-
-        This contains the properties of ISIS Prefix attributes for  the extended IPv4 and IPv6 reachability. https://www.rfc-editor.org/rfc/rfc7794.html
+        One bit value of ISIS Prefix attributes for the extended IPv4 and IPv6 reachability. https://www.rfc-editor.org/rfc/rfc7794.html.
       type: object
       properties:
         x_flag:
           description: |-
-            External Prefix Flag (Bit 0)
+            External prefix flag (Bit 0). Set if the prefix has been
+            redistributed from another protocol. This includes
+            the case where multiple virtual routers are
+            supported and the source of the redistributed prefix
+            is another IS-IS instance.
           type: boolean
           x-field-uid: 1
         r_flag:
           description: |-
-            Re-advertisement Flag (Bit 1)
+            Readvertisement flag (Bit 1). Set when the prefix has been
+            leaked from one level to another (upwards or
+            downwards).
           type: boolean
           x-field-uid: 2
         n_flag:
           description: |-
-            Node Flag (Bit 2)
+            Node Flag (Bit 2).
+            Set when the prefix identifies the
+            advertising router, i.e., the prefix is a host
+            prefix advertising  a globally reachable address
+            typically associated with a loopback address.
           type: boolean
           x-field-uid: 3
+    IsisLsp.PrefixSid:
+      description: |-
+        This contains the properties of IS-IS Prefix-SID and its attributes for  the extended Ipv4 and Ipv6 reachability. Refernce: https://datatracker.ietf.org/doc/html/rfc8667#name-prefix-segment-identifier-p.
+      type: object
+      properties:
+        sids:
+          description: |-
+            One or more SIDs/Indices are the SID/Label values associated  with the IGP Prefix segment attached to the specific IPv4 or IPv6 prefix.
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 1
+        flags:
+          description: |-
+            Flags associated with Prefix Segment-ID.
+          $ref: '#/components/schemas/IsisLsp.PrefixSidFlags'
+          x-field-uid: 2
+        algorithm:
+          description: "The Isis may use various algorithms when calculating\nreachability\
+            \ to other nodes or to prefixes attached to these\nnodes. "
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          x-field-uid: 3
+    IsisLsp.Capability:
+      description: |-
+        Container of IS-IS Router CAPABILITY TLV.
+      type: object
+      properties:
+        router_cap_id:
+          description: |-
+            Router CapabilityID in IPv4 address format.
+          type: string
+          format: ipv4
+          x-field-uid: 1
+        s_bit:
+          description: |-
+            S bit (0x01): If the S bit is set(1), the IS-IS Router CAPABILITY TLV
+            MUST be flooded across the entire routing domain.  If the S bit is
+            not set(0), the TLV MUST NOT be leaked between levels.  This bit MUST
+            NOT be altered during the TLV leaking.
+          type: string
+          x-enum:
+            flood:
+              x-field-uid: 1
+            not_flood:
+              x-field-uid: 2
+          x-field-uid: 2
+          enum:
+          - flood
+          - not_flood
+        d_bit:
+          description: |-
+            D bit (0x02): When the IS-IS Router CAPABILITY TLV is leaked from
+            Level 2 (L2) to Level 1 (L1), the D bit MUST be set.  Otherwise, this
+            bit MUST be clear.  IS-IS Router CAPABILITY TLVs with the D bit set
+            MUST NOT be leaked from Level 1 to Level 2.  This is to prevent TLV looping.
+          type: string
+          x-enum:
+            down:
+              x-field-uid: 1
+            not_down:
+              x-field-uid: 2
+          x-field-uid: 3
+          enum:
+          - down
+          - not_down
+        sr_capability:
+          description: "SR-Capabilities.      "
+          $ref: '#/components/schemas/IsisLsp.SRCapability'
+          x-field-uid: 4
+        algorithms:
+          description: |-
+            This contains one or more SR-Algorithm.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.Algorithm'
+          x-field-uid: 5
+        srlb_ranges:
+          description: |-
+            This contains the list of SR Local Block (SRLB)
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.Srlb'
+          x-field-uid: 6
+    IsisLsp.SRCapability:
+      description: |-
+        Container of IS-IS SR-CAPABILITY Sub-Tlv.
+      type: object
+      properties:
+        flags:
+          description: |-
+            1 octet of flags.
+          $ref: '#/components/schemas/IsisLsp.CapasFlags'
+          x-field-uid: 1
+        srgb_ranges:
+          description: |-
+            This contains the list of SRGB.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.Srgb'
+          x-field-uid: 2
+    IsisLsp.CapasFlags:
+      description: |-
+        Container for the configuration of IS-IS SR-CAPABILITY flags.
+      type: object
+      properties:
+        ipv4_mpls:
+          description: |-
+            I-Flag for the MPLS IPv4 Flag. If set, then the router is capable of processing SR-MPLS-encapsulated IPv4 packets on all interfaces.
+          type: boolean
+          x-field-uid: 1
+        ipv6_mpls:
+          description: |-
+            V-Flag for the MPLS IPv6 Flag. If set, then the router is capable of processing SR-MPLS-encapsulated IPv6 packets on all interfaces.
+          type: boolean
+          x-field-uid: 2
+    IsisLsp.Srgb:
+      description: |-
+        This contains the propeties of SRGB range. Reference: https://datatracker.ietf.org/doc/html/rfc8667#section-3.1-7.1.1
+      type: object
+      properties:
+        starting_sid:
+          description: |-
+            The SID/Label sub-TLV contains the first value of the SRGB while the range contains the number of SRGB elements.
+          type: integer
+          format: uint32
+          x-field-uid: 1
+        range:
+          description: "This represents the number of SID in a SRGB range. "
+          type: integer
+          format: uint32
+          x-field-uid: 2
+    IsisLsp.Srlb:
+      description: |-
+        This contains the propeties of SRLB. The SR Local Block (SRLB) sub-TLV contains the range of labels the node has reserved  for Local SIDs. Local SIDs are used, e.g., for Adj-SIDs, and may also be allocated by components other than the IS-IS protocol Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-sr-local-block-sub-tlv.
+      type: object
+      properties:
+        starting_sid:
+          description: |-
+            The SID/Label sub-TLV contains the first value of the SRGB while the range contains the number of SRGB elements.
+          type: integer
+          format: uint32
+          x-field-uid: 1
+        range:
+          description: "This represents the number of SID in a SRGB range. "
+          type: integer
+          format: uint32
+          x-field-uid: 2
+    IsisLsp.Algorithm:
+      description: |-
+        Container for SR-Algorithms. Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-sr-algorithm-sub-tlv.
+      type: object
+      properties:
+        algorithm:
+          description: "The Isis may use various algorithms when calculating reachability\
+            \ to other nodes or to prefixes attached to these nodes. "
+          type: integer
+          format: uint32
+          x-field-uid: 1
+    IsisLsp.AdjacencySid:
+      description: |-
+        This container defines segment routing adjacency SIDs.
+      type: object
+      properties:
+        tlv_type:
+          description: |-
+            The corresponding adjacency SID type.
+          type: integer
+          format: uint32
+          x-field-uid: 1
+        sids:
+          description: |-
+            One or more SID/Indices are the SID/Label values associated with the IGP adjacency SID.
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 2
+        flags:
+          description: |-
+            Flags associated with Adjacency Segment-ID.
+          $ref: '#/components/schemas/IsisLsp.AdjSidFlags'
+          x-field-uid: 3
+        weight:
+          description: "The value represents the weight of the Adj-SID for the purpose\
+            \ of load balancing. "
+          type: integer
+          format: uint32
+          x-field-uid: 4
+    IsisLsp.PrefixSidFlags:
+      description: |-
+        Conatiner of 1-octet Flags associated with Prefix Segment-ID.
+      type: object
+      properties:
+        r_flag:
+          description: |-
+            Readvertisment flag. When set, the prefix to which this Prefix-SID is attached, has been propagated by
+            the router either from another level or from redistribution.
+          type: boolean
+          x-field-uid: 1
+        n_flag:
+          description: |-
+            Node flag. When set, the Prefix-SID refers to the router identified by the prefix. Typically, the
+            N-Flag is set on Prefix-SIDs attached to a router loopback address.
+          type: boolean
+          x-field-uid: 2
+        p_flag:
+          description: |-
+            Penultimate-Hop-Popping flag. When set, then the penultimate hop MUST NOT pop the Prefix-SID before
+            delivering the packet to the node that advertised the Prefix-SID.
+          type: boolean
+          x-field-uid: 3
+        e_flag:
+          description: |-
+            Explicit-Null flag. When set, any upstream neighbor of the Prefix-SID originator MUST replace the
+            Prefix-SID with a Prefix-SID having an Explicit-NULL value (0 for IPv4 and 2 for IPv6) before forwarding
+            the packet.
+          type: boolean
+          x-field-uid: 4
+        v_flag:
+          description: |-
+            Value flag. When set, the Prefix-SID carries avalue (instead of an index).
+          type: boolean
+          x-field-uid: 5
+        l_flag:
+          description: |-
+            Local flag. When set, the value/index carried by the Prefix-SID has local significance.
+          type: boolean
+          x-field-uid: 6
+    IsisLsp.AdjSidFlags:
+      description: |-
+        Conatiner of 1-octet Flags associated with Adjacency Segment-ID.
+      type: object
+      properties:
+        f_flag:
+          description: |-
+            The address family flag. If unset, then the Adj-SID refers
+            to an adjacency with outgoing IPv4 encapsulation.  If set then
+            the Adj-SID refers to an adjacency with outgoing IPv6
+            encapsulation.
+          type: boolean
+          x-field-uid: 1
+        b_flag:
+          description: |-
+            The backup flag. If set, the Adj-SID is eligible for protection.
+          type: boolean
+          x-field-uid: 2
+        v_flag:
+          description: |-
+            The value flag. If set, then the Adj-SID carries a value.
+          type: boolean
+          x-field-uid: 3
+        l_flag:
+          description: |-
+            The local flag.  If set, then the value/index carried by
+            the Adj-SID has local significance.
+          type: boolean
+          x-field-uid: 4
+        s_flag:
+          description: |-
+            The set flag. When set, the S-Flag indicates that the
+            Adj-SID refers to a set of adjacencies (and therefore MAY be
+            assigned to other adjacencies as well).
+          type: boolean
+          x-field-uid: 5
+        p_flag:
+          description: |-
+            The persistent flag. When set, the P-Flag indicates that
+            the Adj-SID is persistently allocated, i.e., the Adj-SID value
+            remains consistent across router restart and/or interface flap.
+          type: boolean
+          x-field-uid: 6
     LldpNeighbors.State.Request:
       description: |-
         The request to retrieve LLDP neighbor information for a given instance.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.19.0
+  version: 1.20.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -766,7 +766,7 @@ components:
             Priority code point
           type: integer
           format: uint32
-          maximum: 8
+          maximum: 7
           default: 0
           x-field-uid: 2
         id:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.20.0
+/* Open Traffic Generator API 1.22.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -1724,6 +1724,9 @@ message DeviceIsisRouter {
   // objects.
   // required = true
   optional string name = 9;
+
+  // Optional Segment Routing (SR).
+  IsisSegmentRouting segment_routing = 10;
 }
 
 // This container properties of an Multi-Instance-capable router (MI-RTR).
@@ -1811,6 +1814,9 @@ message IsisInterface {
   // objects.
   // required = true
   optional string name = 13;
+
+  // List of Adjacency Segment Identifier (Adj-SID) sub-TLVs.
+  repeated IsisInterfaceAdjacencySid adjacency_sids = 14;
 }
 
 // Configuration for the properties of Level 1 Hello.
@@ -2012,6 +2018,76 @@ message IsisInterfaceLinkProtection {
   optional bool reserved_80 = 8;
 }
 
+// Optional container for segment routing MPLS settings.
+// If the container exists then the adjacency SID (segment identifier)
+// sub TLV will be part of the packet.
+// Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-adjacency-segment-identifie.
+message IsisInterfaceAdjacencySid {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      sid_values = 1;
+      sid_indices = 2;
+    }
+  }
+  // Choice of whether Adjacency-SID carries and absolute value or a relative index to
+  // the SRGB/SRLB Ranges.
+  // Please refer to device.isis.segment_routing.router_capability.sr_capability.srgb_ranges
+  // for the Segment Routing Global Block (SRGB) Descriptor and
+  // device.isis.segment_routing.router_capability.srlb_ranges for the SR Local Block
+  // (SRLB).
+  // A user needs to configure at least one entry of SID value or SID index.
+  // If no entry is configured, then an implementation may advertise appropriate default
+  // SID Value/Index based on the choice. e.g. the first value
+  // from the SRGB or SRLB range.
+  // - sid_values: Adjacency-SID carries one or more values and then v_flag is set by
+  // the implementation.
+  // - sid_indices: Adjacency-SID carries one or more indices and then v_flag is unset
+  // by the implementation.
+  // default = Choice.Enum.sid_values
+  optional Choice.Enum choice = 1;
+
+  // The corresponding Adjacency SID as one or more absolute Values for the link.
+  repeated uint32 sid_values = 2;
+
+  // One or more adjacency Indices are relative to ranges defined for SRGB or SRLB.
+  repeated uint32 sid_indices = 3;
+
+  // The address family flag. If unset, then the Adj-SID refers
+  // to an adjacency with outgoing IPv4 encapsulation.  If set then
+  // the Adj-SID refers to an adjacency with outgoing IPv6
+  // encapsulation.
+  // default = True
+  optional bool f_flag = 4;
+
+  // The backup flag. If set, the Adj-SID is eligible for protection.
+  // default = False
+  optional bool b_flag = 5;
+
+  // The local flag.  If set, then the value/index carried by
+  // the Adj-SID has local significance. In this case, Adjacency_sid is from device.isis.segment_routing.router_capability.srlb_ranges.
+  // default = True
+  optional bool l_flag = 6;
+
+  // The set flag. When set, the S-Flag indicates that the
+  // Adj-SID refers to a set of adjacencies (and therefore MAY be
+  // assigned to other adjacencies as well).
+  // default = False
+  optional bool s_flag = 7;
+
+  // The persistent flag. When set, the P-Flag indicates that
+  // the Adj-SID is persistently allocated, i.e., the Adj-SID value
+  // remains consistent across router restart and/or interface flap.
+  // default = False
+  optional bool p_flag = 8;
+
+  // The value represents the weight of the Adj-SID for the purpose of load balancing.
+  // 
+  // default = 0
+  optional uint32 weight = 9;
+}
+
 // This contains ISIS router basic properties.
 message IsisBasic {
 
@@ -2190,6 +2266,9 @@ message IsisV4RouteRange {
   // Node Flag (Bit 2)
   // default = False
   optional bool n_flag = 9;
+
+  // A list of SID paramters for a group of IPv4 route addresses.
+  repeated IsisSRPrefixSid prefix_sids = 10;
 }
 
 // A container for IPv4 route addresses.
@@ -2253,6 +2332,85 @@ message MACRouteAddress {
   // present.  The value is incremented according to the mac prefix Length and Step.
   // default = 1
   optional uint32 step = 4;
+}
+
+// This contains the properties of IS-IS Prefix-SID and its attributes for  the extended
+// Ipv4 and Ipv6 reachability. Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-prefix-segment-identifier-p.
+message IsisSRPrefixSid {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      sid_values = 1;
+      sid_indices = 2;
+    }
+  }
+  // Choice of whether Prefix-SID carries and absolute value or a relative index to the
+  // SRGB/SRLB Ranges.
+  // Please refer to device.isis.segment_routing.router_capability.sr_capability.srgb_ranges
+  // for the Segment Routing Global Block (SRGB) Descriptor and
+  // device.isis.segment_routing.router_capability.srlb_ranges for the SR Local Block
+  // (SRLB).
+  // A user needs to configure at least one entry of SID value or SID index.
+  // If no entry is configured, then an implementation may advertise appropriate default
+  // SID Value/Index based on the choice. e.g. the first value
+  // from the SRGB or SRLB range.
+  // - sid_values: Prefix-SID carries one or more values and then v_flag is set by the
+  // implementation.
+  // - sid_indices: Prefix-SID carries one or more indices and then v_flag is unset by
+  // the implementation.
+  // default = Choice.Enum.sid_indices
+  optional Choice.Enum choice = 1;
+
+  // SID/Label as one or more absolute values that are associated with the IGP Prefix
+  // segment attached to the specific IPv4 or IPv6 prefix.
+  repeated uint32 sid_values = 2;
+
+  // One or more SID/Label Indices that are associated with the IGP Prefix segment attached
+  // to the specific IPv4 or IPv6 prefix.
+  repeated uint32 sid_indices = 3;
+
+  // R-Flag: Re-advertisement Flag.
+  // If set, then the prefix to which this Prefix-SID is attached has been propagated
+  // by the router
+  // from either another level (i.e., from Level-1 to Level-2 or the opposite) or redistribution
+  // (e.g., from another protocol).
+  // default = False
+  optional bool r_flag = 4;
+
+  // N-Flag: Node-SID flag.
+  // If set, then the Prefix-SID refers to the router identified by the prefix.
+  // Typically, the N-Flag is set on Prefix-SIDs that are attached to a router loopback
+  // address.
+  // The N-Flag is set when the Prefix-SID is a Node-SID as described in [RFC8402].
+  // default = False
+  optional bool n_flag = 5;
+
+  // P-Flag: No-PHP (No Penultimate Hop-Popping) Flag.
+  // If set, then the penultimate hop MUST NOT pop the Prefix-SID before delivering the
+  // packet to the node that advertised the Prefix-SID.
+  // default = False
+  optional bool p_flag = 6;
+
+  // E-Flag: Explicit-Null Flag.
+  // If set, any upstream neighbor of the Prefix-SID originator MUST replace the Prefix-SID
+  // with a Prefix-SID
+  // that has an Explicit NULL value (0 for IPv4 and 2 for IPv6) before forwarding the
+  // packet.
+  // default = False
+  optional bool e_flag = 7;
+
+  // The local flag. If set, then the value/index carried by
+  // the Prefix-SID has local significance and the Prefix SID is from Please refer to
+  // device.isis.segment_routing.router_capability.srlb_ranges.
+  // default = False
+  optional bool l_flag = 8;
+
+  // The Isis may use various algorithms when calculating reachability to other nodes
+  // or to prefixes attached to these nodes.
+  // Refernce: https://datatracker.ietf.org/doc/html/rfc8667#SRALGOSUBTLV
+  // default = 0
+  optional uint32 algorithm = 9;
 }
 
 // Emulated ISIS IPv6 routes.
@@ -2321,6 +2479,203 @@ message IsisV6RouteRange {
   // Node Flag (Bit 2)
   // default = False
   optional bool n_flag = 9;
+
+  // A list of SID parameters for a group of IPv6 route addresses.
+  repeated IsisSRPrefixSid prefix_sids = 10;
+}
+
+// Segment Routing (SR) allows for a flexible definition of end-to-end paths within
+// IGP topologies by encoding paths as sequences of topological sub-paths,
+// called segments. These segments are advertised by the link-state routing protocols
+// (IS-IS and OSPF).
+// Prefix segments represent an ECMP-aware shortest path to a prefix (or a node), as
+// per the state of the IGP topology.
+// Adjacency segments represent a hop over a specific adjacency between two nodes in
+// the IGP.
+// A prefix segment is typically a multi-hop path while an adjacency segment, in most
+// of the cases, is a one-hop path.
+// These segments act as topological sub-paths that can be combined together to form
+// the required path.
+// Reference: https://datatracker.ietf.org/doc/html/rfc8667.:w
+// An implementation may advertise Router Capability with default values if a user does
+// not even set the properties
+// of Router Capability and Segment Routing Capability.
+message IsisSegmentRouting {
+
+  // Optional IS-IS TLV named CAPABILITY, formed of multiple sub-TLVs, which allows a
+  // router to announce its
+  // capabilities within an IS-IS level or the entire routing domain.
+  IsisRouterCapability router_capability = 1;
+}
+
+// Container for the configuration of IS-IS Router CAPABILITY TLV.
+// https://datatracker.ietf.org/doc/html/rfc7981#section-2.
+// An implementation should set default values appropriately if any mandatory item is
+// not configured by a user.
+message IsisRouterCapability {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      ipv4_te_router_id = 1;
+      interface_ip = 2;
+      custom_router_cap_id = 3;
+    }
+  }
+  // The Router Capability ID SHOULD be identical to the value advertised in the Traffic
+  // Engineering Router ID TLV [RFC5305].
+  // If no Traffic Engineering Router ID is assigned, the Router ID SHOULD be identical
+  // to an IP Interface Address [RFC1195]
+  // advertised by the originating IS.
+  // If the originating node does not support IPv4, then the reserved value 0.0.0.0 MUST
+  // be used in the Router ID field,
+  // and the IPv6 TE Router ID sub-TLV [RFC5316] MUST be present in the TLV.
+  // - ipv4_te_router_id: IPv4 Traffic Engineering(TE) router id (defined in isis.basic.ipv4_te_router_id)
+  // to be used as Router Capability ID.
+  // - interface_ip: When this is chosen the first IPv4 address of the first eth interface
+  // associated with this isis router instance should be assigned as the Router Capability
+  // ID.
+  // - custom_router_cap_id: This option should be chosen when Router Capability ID needs
+  // to be configured different from above two options.
+  // default = Choice.Enum.ipv4_te_router_id
+  optional Choice.Enum choice = 1;
+
+  // Router Capability ID in IPv4 address format.
+  // default = 0.0.0.0
+  optional string custom_router_cap_id = 2;
+
+  message SBit {
+    enum Enum {
+      unspecified = 0;
+      flood = 1;
+      not_flood = 2;
+    }
+  }
+  // S bit (0x01): If the S bit is set(1), the IS-IS Router CAPABILITY TLV
+  // MUST be flooded across the entire routing domain.  If the S bit is
+  // not set(0), the TLV MUST NOT be leaked between levels.  This bit MUST
+  // NOT be altered during the TLV leaking.
+  // default = SBit.Enum.not_flood
+  optional SBit.Enum s_bit = 3;
+
+  message DBit {
+    enum Enum {
+      unspecified = 0;
+      down = 1;
+      not_down = 2;
+    }
+  }
+  // D bit (0x02): When the IS-IS Router CAPABILITY TLV is leaked from
+  // Level 2 (L2) to Level 1 (L1), the D bit MUST be set.  Otherwise, this
+  // bit MUST be clear.  IS-IS Router CAPABILITY TLVs with the D bit set
+  // MUST NOT be leaked from Level 1 to Level 2.  This is to prevent TLV looping.
+  // default = DBit.Enum.not_down
+  optional DBit.Enum d_bit = 4;
+
+  // SR-Capabilities.
+  IsisSRCapability sr_capability = 5;
+
+  // This contains one or more Segment Routing Algorithm that a router may use various
+  // algorithms when calculating
+  // reachability to other nodes or to prefixes attached to these nodes.
+  // When the originating router does not advertise the SR-Algorithm sub-TLV, it implies
+  // that algorithm 0 is the only algorithm supported by the routers.
+  // When the originating router does advertise the SR-Algorithm sub-TLV, then algorithm
+  // 0 MUST be present while non-zero algorithms MAY be present.
+  repeated IsisSRAlgorithm algorithms = 6;
+
+  // This contains the list of SR Local Block (SRLB)
+  repeated IsisSRSrlb srlb_ranges = 7;
+}
+
+// Container for the configuration of IS-IS SR-CAPABILITY TLV that Segment Routing requires
+// 
+// each router to advertise its SR data plane capability and the range of MPLS label
+// values
+// it uses for Segment Routing in the case where global SIDs are allocated (i.e., global
+// indexes).
+// Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-sr-capabilities-sub-tlv.
+// An implementation should set default values appropriately if any mandatory item is
+// not configured by a user.
+message IsisSRCapability {
+
+  // 1 octet of flags.
+  IsisSRCapabilityFlags flags = 1;
+
+  // This contains the list of SRGB.
+  // If no SRGB range is configured, implementation should send one SRGB range with default
+  // values.
+  repeated IsisSRSrgb srgb_ranges = 2;
+}
+
+// Container for the configuration of IS-IS SR-CAPABILITY flags.
+// The Router Capability TLV specifies flags that control its advertisement.
+// The SR-Capabilities sub-TLV MUST be propagated throughout the level and MUST NOT
+// be advertised across level boundaries.
+// Therefore, Router Capability TLV distribution flags are set accordingly, i.e.,
+// the S-Flag in the Router Capability TLV [RFC7981] MUST be unset.
+// Reference: https://datatracker.ietf.org/doc/html/rfc8667#section-3.1-5.1.1.6.1.
+message IsisSRCapabilityFlags {
+
+  // I-Flag for the MPLS IPv4 Flag. If set, then the router is capable of processing SR-MPLS-encapsulated
+  // IPv4 packets on all interfaces.
+  // default = True
+  optional bool ipv4_mpls = 1;
+
+  // V-Flag for the MPLS IPv6 Flag. If set, then the router is capable of processing SR-MPLS-encapsulated
+  // IPv6 packets on all interfaces.
+  // default = True
+  optional bool ipv6_mpls = 2;
+}
+
+// This contains the propeties of Segment Routing Global Block (SRGB) Descriptor. Reference:
+// https://datatracker.ietf.org/doc/html/rfc8667#section-3.1-7.1.1
+message IsisSRSrgb {
+
+  // The SID/Label sub-TLV contains the first value of the SRGB while the range contains
+  // the number of SRGB elements.
+  // default = 16000
+  optional uint32 starting_sid = 1;
+
+  // This represents the number of SID in a SRGB range.
+  // default = 8000
+  optional uint32 range = 2;
+}
+
+// The SR Local Block (SRLB) sub-TLV contains the range of labels the node has reserved
+// for Local SIDs.
+// Local SIDs are used for Adjacency SIDs or locally significant Prefix SIDs and may
+// also be allocated by components other than the IS-IS protocol.
+// As an example, an application or a controller may instruct the router to allocate
+// a specific Local SID. Therefore,
+// in order for such applications or controllers to know what Local SIDs are available
+// in the router,
+// it is required that the router advertises its SRLB.
+// Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-sr-local-block-sub-tlv.
+message IsisSRSrlb {
+
+  // The SID/Label sub-TLV contains the first value of the SRLB while the range contains
+  // the number of SRLB elements.
+  // default = 16000
+  optional uint32 starting_sid = 1;
+
+  // This represents the number of SIDs in a SRLB range.
+  // default = 8000
+  optional uint32 range = 2;
+}
+
+// Container for SR-Algorithms. The Isis may use various algorithms when calculating
+// reachability to other nodes or to prefixes attached to these
+// nodes. Examples of these algorithms are metric-based SPF, various sorts of Constrained
+// SPF, etc.
+// - 0: SPF algorithm based on link metric.
+// - 1: Strict SPF algorithm based on link metric.
+// Reference: https://datatracker.ietf.org/doc/html/rfc8665#name-igp-algorithm-types-registr.
+message IsisSRAlgorithm {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 algorithm = 1;
 }
 
 // Configuration for one or more IPv4 or IPv6 BGP peers.
@@ -12081,6 +12436,16 @@ message FlowMetricsRequest {
       bytes_rx = 5;
       frames_tx_rate = 6;
       frames_rx_rate = 7;
+      tx_l1_rate_bps = 8;
+      rx_l1_rate_bps = 9;
+      tx_rate_bytes = 10;
+      rx_rate_bytes = 11;
+      tx_rate_bps = 12;
+      rx_rate_bps = 13;
+      tx_rate_kbps = 14;
+      rx_rate_kbps = 15;
+      tx_rate_mbps = 16;
+      rx_rate_mbps = 17;
     }
   }
   // The list of metric names that the returned result set will contain. If the list is
@@ -12112,6 +12477,16 @@ message FlowTaggedMetricsFilter {
       bytes_rx = 4;
       frames_tx_rate = 5;
       frames_rx_rate = 6;
+      tx_l1_rate_bps = 7;
+      rx_l1_rate_bps = 8;
+      tx_rate_bytes = 9;
+      rx_rate_bytes = 10;
+      tx_rate_bps = 11;
+      rx_rate_bps = 12;
+      tx_rate_kbps = 13;
+      rx_rate_kbps = 14;
+      tx_rate_mbps = 15;
+      rx_rate_mbps = 16;
     }
   }
   // The list of metric names that the returned result set will contain. If the list is
@@ -12192,6 +12567,36 @@ message FlowMetric {
   // flow.
   // The container is keyed by list of tag-value pairs.
   repeated FlowTaggedMetric tagged_metrics = 15;
+
+  // The Layer 1 transmission rate in bits per second.
+  optional float tx_l1_rate_bps = 16;
+
+  // The Layer 1 receive rate in bits per second.
+  optional float rx_l1_rate_bps = 17;
+
+  // The transmission rate in bytes per second.
+  optional float tx_rate_bytes = 18;
+
+  // The receive rate in bytes per second.
+  optional float rx_rate_bytes = 19;
+
+  // The transmission rate in bits per second.
+  optional float tx_rate_bps = 20;
+
+  // The receive rate in bits per second.
+  optional float rx_rate_bps = 21;
+
+  // The transmission rate in Kilobits per second.
+  optional float tx_rate_kbps = 22;
+
+  // The receive rate in Kilobits per second.
+  optional float rx_rate_kbps = 23;
+
+  // The transmission rate in Megabits per second.
+  optional float tx_rate_mbps = 24;
+
+  // The receive rate in Megabits per second.
+  optional float rx_rate_mbps = 25;
 }
 
 // Metrics for each set of values applicable for configured
@@ -12228,6 +12633,36 @@ message FlowTaggedMetric {
 
   // Description missing in models
   MetricLatency latency = 10;
+
+  // The Layer 1 transmission rate in bits per second.
+  optional float tx_l1_rate_bps = 11;
+
+  // The Layer 1 receive rate in bits per second.
+  optional float rx_l1_rate_bps = 12;
+
+  // The transmission rate in bytes per second.
+  optional float tx_rate_bytes = 13;
+
+  // The receive rate in bytes per second.
+  optional float rx_rate_bytes = 14;
+
+  // The transmission rate in bits per second.
+  optional float tx_rate_bps = 15;
+
+  // The receive rate in bits per second.
+  optional float rx_rate_bps = 16;
+
+  // The transmission rate in Kilobits per second.
+  optional float tx_rate_kbps = 17;
+
+  // The receive rate in Kilobits per second.
+  optional float rx_rate_kbps = 18;
+
+  // The transmission rate in Megabits per second.
+  optional float tx_rate_mbps = 19;
+
+  // The receive rate in Megabits per second.
+  optional float rx_rate_mbps = 20;
 }
 
 // Description missing in models
@@ -14440,6 +14875,10 @@ message IsisLspTlvs {
 
   // Array of IPv6 Reachability TLVs (type 236) present in this LSP.
   repeated IsisLspIpv6ReachabilityTlv ipv6_reachability_tlvs = 7;
+
+  // IS-IS Router Capabilities: TLV 242.
+  // This container defines Router Capabilities.
+  repeated IsisLspCapability router_capabilities = 8;
 }
 
 // It contains Hostname for the TLV 137.
@@ -14488,7 +14927,7 @@ message IsisLspIsReachabilityTlv {
 message IsisLspExtendedIsReachabilityTlv {
 
   // This container describes IS neighbors.
-  repeated IsisLspneighbor neighbors = 1;
+  repeated IsisLspExtendedNeighbor neighbors = 1;
 }
 
 // This contains IS neighbors.
@@ -14496,6 +14935,16 @@ message IsisLspneighbor {
 
   // The System ID for this emulated ISIS router, e.g. 640100010000.
   optional string system_id = 1;
+}
+
+// This contains IS neighbors.
+message IsisLspExtendedNeighbor {
+
+  // The System ID for this emulated ISIS router, e.g. 640100010000.
+  optional string system_id = 1;
+
+  // List of segment routing adjacency SIDs.
+  repeated IsisLspAdjacencySid adjacency_sids = 2;
 }
 
 // This container defines list of IPv4 internal reachability information in one IPv4
@@ -14592,8 +15041,13 @@ message IsisLspExtendedV4Prefix {
   // (L1).
   optional RedistributionType.Enum redistribution_type = 4;
 
-  // Description missing in models
+  // Extended Prefix Attribute flags container sub-TLV is type 4.
   IsisLspPrefixAttributes prefix_attributes = 5;
+
+  // Prefix Segment-ID list. IGP-Prefix Segment is an IGP segment attached to an IGP prefix.
+  // An IGP-Prefix Segment is global
+  // (unless explicitly advertised otherwise) within the SR/IGP domain.
+  repeated IsisLspPrefixSid prefix_sids = 6;
 }
 
 // It defines list of IPv6 extended reachability information in one IPv6 Reachability
@@ -14644,22 +15098,231 @@ message IsisLspV6Prefix {
   // 1 LSPs.
   optional OriginType.Enum origin_type = 5;
 
-  // Description missing in models
+  // Extended Prefix Attribute flags container sub-TLV is type 4.
   IsisLspPrefixAttributes prefix_attributes = 6;
+
+  // Prefix Segment-ID list. IGP-Prefix Segment is an IGP segment attached to an IGP prefix.
+  // An IGP-Prefix Segment is global
+  // (unless explicitly advertised otherwise) within the SR/IGP domain.
+  repeated IsisLspPrefixSid prefix_sids = 7;
 }
 
-// This contains the properties of ISIS Prefix attributes for  the extended IPv4 and
-// IPv6 reachability. https://www.rfc-editor.org/rfc/rfc7794.html
+// One bit value of ISIS Prefix attributes for the extended IPv4 and IPv6 reachability.
+// https://www.rfc-editor.org/rfc/rfc7794.html.
 message IsisLspPrefixAttributes {
 
-  // External Prefix Flag (Bit 0)
+  // External prefix flag (Bit 0). Set if the prefix has been
+  // redistributed from another protocol. This includes
+  // the case where multiple virtual routers are
+  // supported and the source of the redistributed prefix
+  // is another IS-IS instance.
   optional bool x_flag = 1;
 
-  // Re-advertisement Flag (Bit 1)
+  // Readvertisement flag (Bit 1). Set when the prefix has been
+  // leaked from one level to another (upwards or
+  // downwards).
   optional bool r_flag = 2;
 
-  // Node Flag (Bit 2)
+  // Node Flag (Bit 2).
+  // Set when the prefix identifies the
+  // advertising router, i.e., the prefix is a host
+  // prefix advertising  a globally reachable address
+  // typically associated with a loopback address.
   optional bool n_flag = 3;
+}
+
+// This contains the properties of IS-IS Prefix-SID and its attributes for  the extended
+// Ipv4 and Ipv6 reachability. Refernce: https://datatracker.ietf.org/doc/html/rfc8667#name-prefix-segment-identifier-p.
+message IsisLspPrefixSid {
+
+  // One or more SIDs/Indices are the SID/Label values associated  with the IGP Prefix
+  // segment attached to the specific IPv4 or IPv6 prefix.
+  repeated uint32 sids = 1;
+
+  // Flags associated with Prefix Segment-ID.
+  IsisLspPrefixSidFlags flags = 2;
+
+  // The Isis may use various algorithms when calculating
+  // reachability to other nodes or to prefixes attached to these
+  // nodes.
+  optional uint32 algorithm = 3;
+}
+
+// Container of IS-IS Router CAPABILITY TLV.
+message IsisLspCapability {
+
+  // Router CapabilityID in IPv4 address format.
+  optional string router_cap_id = 1;
+
+  message SBit {
+    enum Enum {
+      unspecified = 0;
+      flood = 1;
+      not_flood = 2;
+    }
+  }
+  // S bit (0x01): If the S bit is set(1), the IS-IS Router CAPABILITY TLV
+  // MUST be flooded across the entire routing domain.  If the S bit is
+  // not set(0), the TLV MUST NOT be leaked between levels.  This bit MUST
+  // NOT be altered during the TLV leaking.
+  optional SBit.Enum s_bit = 2;
+
+  message DBit {
+    enum Enum {
+      unspecified = 0;
+      down = 1;
+      not_down = 2;
+    }
+  }
+  // D bit (0x02): When the IS-IS Router CAPABILITY TLV is leaked from
+  // Level 2 (L2) to Level 1 (L1), the D bit MUST be set.  Otherwise, this
+  // bit MUST be clear.  IS-IS Router CAPABILITY TLVs with the D bit set
+  // MUST NOT be leaked from Level 1 to Level 2.  This is to prevent TLV looping.
+  optional DBit.Enum d_bit = 3;
+
+  // SR-Capabilities.
+  IsisLspSRCapability sr_capability = 4;
+
+  // This contains one or more SR-Algorithm.
+  repeated IsisLspAlgorithm algorithms = 5;
+
+  // This contains the list of SR Local Block (SRLB)
+  repeated IsisLspSrlb srlb_ranges = 6;
+}
+
+// Container of IS-IS SR-CAPABILITY Sub-Tlv.
+message IsisLspSRCapability {
+
+  // 1 octet of flags.
+  IsisLspCapasFlags flags = 1;
+
+  // This contains the list of SRGB.
+  repeated IsisLspSrgb srgb_ranges = 2;
+}
+
+// Container for the configuration of IS-IS SR-CAPABILITY flags.
+message IsisLspCapasFlags {
+
+  // I-Flag for the MPLS IPv4 Flag. If set, then the router is capable of processing SR-MPLS-encapsulated
+  // IPv4 packets on all interfaces.
+  optional bool ipv4_mpls = 1;
+
+  // V-Flag for the MPLS IPv6 Flag. If set, then the router is capable of processing SR-MPLS-encapsulated
+  // IPv6 packets on all interfaces.
+  optional bool ipv6_mpls = 2;
+}
+
+// This contains the propeties of SRGB range. Reference: https://datatracker.ietf.org/doc/html/rfc8667#section-3.1-7.1.1
+message IsisLspSrgb {
+
+  // The SID/Label sub-TLV contains the first value of the SRGB while the range contains
+  // the number of SRGB elements.
+  optional uint32 starting_sid = 1;
+
+  // This represents the number of SID in a SRGB range.
+  optional uint32 range = 2;
+}
+
+// This contains the propeties of SRLB. The SR Local Block (SRLB) sub-TLV contains the
+// range of labels the node has reserved  for Local SIDs. Local SIDs are used, e.g.,
+// for Adj-SIDs, and may also be allocated by components other than the IS-IS protocol
+// Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-sr-local-block-sub-tlv.
+message IsisLspSrlb {
+
+  // The SID/Label sub-TLV contains the first value of the SRGB while the range contains
+  // the number of SRGB elements.
+  optional uint32 starting_sid = 1;
+
+  // This represents the number of SID in a SRGB range.
+  optional uint32 range = 2;
+}
+
+// Container for SR-Algorithms. Reference: https://datatracker.ietf.org/doc/html/rfc8667#name-sr-algorithm-sub-tlv.
+message IsisLspAlgorithm {
+
+  // The Isis may use various algorithms when calculating reachability to other nodes
+  // or to prefixes attached to these nodes.
+  optional uint32 algorithm = 1;
+}
+
+// This container defines segment routing adjacency SIDs.
+message IsisLspAdjacencySid {
+
+  // The corresponding adjacency SID type.
+  optional uint32 tlv_type = 1;
+
+  // One or more SID/Indices are the SID/Label values associated with the IGP adjacency
+  // SID.
+  repeated uint32 sids = 2;
+
+  // Flags associated with Adjacency Segment-ID.
+  IsisLspAdjSidFlags flags = 3;
+
+  // The value represents the weight of the Adj-SID for the purpose of load balancing.
+  // 
+  optional uint32 weight = 4;
+}
+
+// Conatiner of 1-octet Flags associated with Prefix Segment-ID.
+message IsisLspPrefixSidFlags {
+
+  // Readvertisment flag. When set, the prefix to which this Prefix-SID is attached, has
+  // been propagated by
+  // the router either from another level or from redistribution.
+  optional bool r_flag = 1;
+
+  // Node flag. When set, the Prefix-SID refers to the router identified by the prefix.
+  // Typically, the
+  // N-Flag is set on Prefix-SIDs attached to a router loopback address.
+  optional bool n_flag = 2;
+
+  // Penultimate-Hop-Popping flag. When set, then the penultimate hop MUST NOT pop the
+  // Prefix-SID before
+  // delivering the packet to the node that advertised the Prefix-SID.
+  optional bool p_flag = 3;
+
+  // Explicit-Null flag. When set, any upstream neighbor of the Prefix-SID originator
+  // MUST replace the
+  // Prefix-SID with a Prefix-SID having an Explicit-NULL value (0 for IPv4 and 2 for
+  // IPv6) before forwarding
+  // the packet.
+  optional bool e_flag = 4;
+
+  // Value flag. When set, the Prefix-SID carries avalue (instead of an index).
+  optional bool v_flag = 5;
+
+  // Local flag. When set, the value/index carried by the Prefix-SID has local significance.
+  optional bool l_flag = 6;
+}
+
+// Conatiner of 1-octet Flags associated with Adjacency Segment-ID.
+message IsisLspAdjSidFlags {
+
+  // The address family flag. If unset, then the Adj-SID refers
+  // to an adjacency with outgoing IPv4 encapsulation.  If set then
+  // the Adj-SID refers to an adjacency with outgoing IPv6
+  // encapsulation.
+  optional bool f_flag = 1;
+
+  // The backup flag. If set, the Adj-SID is eligible for protection.
+  optional bool b_flag = 2;
+
+  // The value flag. If set, then the Adj-SID carries a value.
+  optional bool v_flag = 3;
+
+  // The local flag.  If set, then the value/index carried by
+  // the Adj-SID has local significance.
+  optional bool l_flag = 4;
+
+  // The set flag. When set, the S-Flag indicates that the
+  // Adj-SID refers to a set of adjacencies (and therefore MAY be
+  // assigned to other adjacencies as well).
+  optional bool s_flag = 5;
+
+  // The persistent flag. When set, the P-Flag indicates that
+  // the Adj-SID is persistently allocated, i.e., the Adj-SID value
+  // remains consistent across router restart and/or interface flap.
+  optional bool p_flag = 6;
 }
 
 // The request to retrieve LLDP neighbor information for a given instance.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.19.0
+/* Open Traffic Generator API 1.20.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 

--- a/device/vlan.yaml
+++ b/device/vlan.yaml
@@ -27,7 +27,7 @@ components:
             Priority code point
           type: integer
           format: uint32
-          maximum: 8
+          maximum: 7
           default: 0
           x-field-uid: 2
         id:

--- a/device/vlan.yaml
+++ b/device/vlan.yaml
@@ -27,7 +27,7 @@ components:
             Priority code point
           type: integer
           format: uint32
-          maximum: 3
+          maximum: 8
           default: 0
           x-field-uid: 2
         id:


### PR DESCRIPTION
Issue: [Athena-G](https://jira.it.keysight.com/browse/ATHENAG)[ATHENAG-2836](https://jira.it.keysight.com/browse/ATHENAG-2836)
Increased max value of vlan priority for device/ethernet/vlan from 3 to 7 to allow all 3 bits to be set.