### PR TITLE
Adding fields to flow stats

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -16028,12 +16028,12 @@ components:
             Layer1 Rx frame rate in bits per second.
           type: number
           x-field-uid: 17
-        tx_rate_bytes_per_second:
+        tx_rate_bytes:
           description: |-
             Layer1 Tx frame rate in bytes per second.
           type: number
           x-field-uid: 18
-        rx_rate_bytes_per_second:
+        rx_rate_bytes:
           description: |-
             Layer1 Tx frame rate in bytes per second.
           type: number

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -16018,6 +16018,56 @@ components:
           items:
             $ref: '#/components/schemas/Flow.TaggedMetric'
           x-field-uid: 15
+        tx_l1_rate_bps:
+          description: |-
+            Layer1 Tx frame rate in bits per second.
+          type: number
+          x-field-uid: 16
+        rx_l1_rate_bps:
+          description: |-
+            Layer1 Rx frame rate in bits per second.
+          type: number
+          x-field-uid: 17
+        tx_rate_bytes_per_second:
+          description: |-
+            Layer1 Tx frame rate in bytes per second.
+          type: number
+          x-field-uid: 18
+        rx_rate_bytes_per_second:
+          description: |-
+            Layer1 Tx frame rate in bytes per second.
+          type: number
+          x-field-uid: 19
+        tx_rate_bps:
+          description: |-
+            Layer1 Tx frame rate in bits per second.
+          type: number
+          x-field-uid: 20
+        rx_rate_bps:
+          description: |-
+            Layer1 Tx frame rate in bits per second.
+          type: number
+          x-field-uid: 21
+        tx_rate_kbps:
+          description: |-
+            Layer1 Tx frame rate in kilobits per second.
+          type: number
+          x-field-uid: 22
+        rx_rate_kbps:
+          description: |-
+            Layer1 Tx frame rate in kilobits per second.
+          type: number
+          x-field-uid: 23
+        tx_rate_mbps:
+          description: |-
+            Layer1 Tx frame rate in megabits per second.
+          type: number
+          x-field-uid: 24
+        rx_rate_mbps:
+          description: |-
+            Layer1 Tx frame rate in megabits per second.
+          type: number
+          x-field-uid: 25
     Flow.TaggedMetric:
       description: |-
         Metrics for each set of values applicable for configured

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -15843,6 +15843,26 @@ components:
                 x-field-uid: 6
               frames_rx_rate:
                 x-field-uid: 7
+              tx_l1_rate_bps:
+                x-field-uid: 8
+              rx_l1_rate_bps:
+                x-field-uid: 9
+              tx_rate_bytes:
+                x-field-uid: 10
+              rx_rate_bytes:
+                x-field-uid: 11
+              tx_rate_bps:
+                x-field-uid: 12
+              rx_rate_bps:
+                x-field-uid: 13
+              tx_rate_kbps:
+                x-field-uid: 14
+              rx_rate_kbps:
+                x-field-uid: 15
+              tx_rate_mbps:
+                x-field-uid: 16
+              rx_rate_mbps:
+                x-field-uid: 17
             enum:
             - transmit
             - frames_tx
@@ -15851,6 +15871,16 @@ components:
             - bytes_rx
             - frames_tx_rate
             - frames_rx_rate
+            - tx_l1_rate_bps
+            - rx_l1_rate_bps
+            - tx_rate_bytes
+            - rx_rate_bytes
+            - tx_rate_bps
+            - rx_rate_bps
+            - tx_rate_kbps
+            - rx_rate_kbps
+            - tx_rate_mbps
+            - rx_rate_mbps
           x-field-uid: 3
         tagged_metrics:
           $ref: '#/components/schemas/Flow.TaggedMetrics.Filter'
@@ -15891,6 +15921,26 @@ components:
                 x-field-uid: 5
               frames_rx_rate:
                 x-field-uid: 6
+              tx_l1_rate_bps:
+                x-field-uid: 7
+              rx_l1_rate_bps:
+                x-field-uid: 8
+              tx_rate_bytes:
+                x-field-uid: 9
+              rx_rate_bytes:
+                x-field-uid: 10
+              tx_rate_bps:
+                x-field-uid: 11
+              rx_rate_bps:
+                x-field-uid: 12
+              tx_rate_kbps:
+                x-field-uid: 13
+              rx_rate_kbps:
+                x-field-uid: 14
+              tx_rate_mbps:
+                x-field-uid: 15
+              rx_rate_mbps:
+                x-field-uid: 16
             enum:
             - frames_tx
             - frames_rx
@@ -15898,6 +15948,16 @@ components:
             - bytes_rx
             - frames_tx_rate
             - frames_rx_rate
+            - tx_l1_rate_bps
+            - rx_l1_rate_bps
+            - tx_rate_bytes
+            - rx_rate_bytes
+            - tx_rate_bps
+            - rx_rate_bps
+            - tx_rate_kbps
+            - rx_rate_kbps
+            - tx_rate_mbps
+            - rx_rate_mbps
           x-field-uid: 3
         filters:
           description: |-
@@ -16127,6 +16187,56 @@ components:
         latency:
           $ref: '#/components/schemas/Metric.Latency'
           x-field-uid: 10
+        tx_l1_rate_bps:
+          description: |-
+            Layer1 Tx frame rate in bits per second.
+          type: number
+          x-field-uid: 11
+        rx_l1_rate_bps:
+          description: |-
+            Layer1 Rx frame rate in bits per second.
+          type: number
+          x-field-uid: 12
+        tx_rate_bytes:
+          description: |-
+            Tx frame rate in bytes per second.
+          type: number
+          x-field-uid: 13
+        rx_rate_bytes:
+          description: |-
+            Rx frame rate in bytes per second.
+          type: number
+          x-field-uid: 14
+        tx_rate_bps:
+          description: |-
+            Tx frame rate in bits per second.
+          type: number
+          x-field-uid: 15
+        rx_rate_bps:
+          description: |-
+            Rx frame rate in bits per second.
+          type: number
+          x-field-uid: 16
+        tx_rate_kbps:
+          description: |-
+            Tx frame rate in kilobits per second.
+          type: number
+          x-field-uid: 17
+        rx_rate_kbps:
+          description: |-
+            Rx frame rate in kilobits per second.
+          type: number
+          x-field-uid: 18
+        tx_rate_mbps:
+          description: |-
+            Tx frame rate in megabits per second.
+          type: number
+          x-field-uid: 19
+        rx_rate_mbps:
+          description: |-
+            Rx frame rate in megabits per second.
+          type: number
+          x-field-uid: 20
     Flow.MetricTag:
       type: object
       properties:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -16080,52 +16080,52 @@ components:
           x-field-uid: 15
         tx_l1_rate_bps:
           description: |-
-            Layer1 Tx frame rate in bits per second.
+            The Layer 1 transmission rate in bits per second.
           type: number
           x-field-uid: 16
         rx_l1_rate_bps:
           description: |-
-            Layer1 Rx frame rate in bits per second.
+            The Layer 1 receive rate in bits per second.
           type: number
           x-field-uid: 17
         tx_rate_bytes:
           description: |-
-            Tx frame rate in bytes per second.
+            The transmission rate in bytes per second.
           type: number
           x-field-uid: 18
         rx_rate_bytes:
           description: |-
-            Rx frame rate in bytes per second.
+            The receive rate in bytes per second.
           type: number
           x-field-uid: 19
         tx_rate_bps:
           description: |-
-            Tx frame rate in bits per second.
+            The transmission rate in bits per second.
           type: number
           x-field-uid: 20
         rx_rate_bps:
           description: |-
-            Rx frame rate in bits per second.
+            The receive rate in bits per second.
           type: number
           x-field-uid: 21
         tx_rate_kbps:
           description: |-
-            Tx frame rate in kilobits per second.
+            The transmission rate in Kilobits per second.
           type: number
           x-field-uid: 22
         rx_rate_kbps:
           description: |-
-            Rx frame rate in kilobits per second.
+            The receive rate in Kilobits per second.
           type: number
           x-field-uid: 23
         tx_rate_mbps:
           description: |-
-            Tx frame rate in megabits per second.
+            The transmission rate in Megabits per second.
           type: number
           x-field-uid: 24
         rx_rate_mbps:
           description: |-
-            Rx frame rate in megabits per second.
+            The receive rate in Megabits per second.
           type: number
           x-field-uid: 25
     Flow.TaggedMetric:
@@ -16189,52 +16189,52 @@ components:
           x-field-uid: 10
         tx_l1_rate_bps:
           description: |-
-            Layer1 Tx frame rate in bits per second.
+            The Layer 1 transmission rate in bits per second.
           type: number
           x-field-uid: 11
         rx_l1_rate_bps:
           description: |-
-            Layer1 Rx frame rate in bits per second.
+            The Layer 1 receive rate in bits per second.
           type: number
           x-field-uid: 12
         tx_rate_bytes:
           description: |-
-            Tx frame rate in bytes per second.
+            The transmission rate in bytes per second.
           type: number
           x-field-uid: 13
         rx_rate_bytes:
           description: |-
-            Rx frame rate in bytes per second.
+            The receive rate in bytes per second.
           type: number
           x-field-uid: 14
         tx_rate_bps:
           description: |-
-            Tx frame rate in bits per second.
+            The transmission rate in bits per second.
           type: number
           x-field-uid: 15
         rx_rate_bps:
           description: |-
-            Rx frame rate in bits per second.
+            The receive rate in bits per second.
           type: number
           x-field-uid: 16
         tx_rate_kbps:
           description: |-
-            Tx frame rate in kilobits per second.
+            The transmission rate in Kilobits per second.
           type: number
           x-field-uid: 17
         rx_rate_kbps:
           description: |-
-            Rx frame rate in kilobits per second.
+            The receive rate in Kilobits per second.
           type: number
           x-field-uid: 18
         tx_rate_mbps:
           description: |-
-            Tx frame rate in megabits per second.
+            The transmission rate in Megabits per second.
           type: number
           x-field-uid: 19
         rx_rate_mbps:
           description: |-
-            Rx frame rate in megabits per second.
+            The receive rate in Megabits per second.
           type: number
           x-field-uid: 20
     Flow.MetricTag:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -16030,42 +16030,42 @@ components:
           x-field-uid: 17
         tx_rate_bytes:
           description: |-
-            Layer1 Tx frame rate in bytes per second.
+            Tx frame rate in bytes per second.
           type: number
           x-field-uid: 18
         rx_rate_bytes:
           description: |-
-            Layer1 Tx frame rate in bytes per second.
+            Rx frame rate in bytes per second.
           type: number
           x-field-uid: 19
         tx_rate_bps:
           description: |-
-            Layer1 Tx frame rate in bits per second.
+            Tx frame rate in bits per second.
           type: number
           x-field-uid: 20
         rx_rate_bps:
           description: |-
-            Layer1 Tx frame rate in bits per second.
+            Rx frame rate in bits per second.
           type: number
           x-field-uid: 21
         tx_rate_kbps:
           description: |-
-            Layer1 Tx frame rate in kilobits per second.
+            Tx frame rate in kilobits per second.
           type: number
           x-field-uid: 22
         rx_rate_kbps:
           description: |-
-            Layer1 Tx frame rate in kilobits per second.
+            Rx frame rate in kilobits per second.
           type: number
           x-field-uid: 23
         tx_rate_mbps:
           description: |-
-            Layer1 Tx frame rate in megabits per second.
+            Tx frame rate in megabits per second.
           type: number
           x-field-uid: 24
         rx_rate_mbps:
           description: |-
-            Layer1 Tx frame rate in megabits per second.
+            Rx frame rate in megabits per second.
           type: number
           x-field-uid: 25
     Flow.TaggedMetric:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12213,34 +12213,34 @@ message FlowMetric {
   // The container is keyed by list of tag-value pairs.
   repeated FlowTaggedMetric tagged_metrics = 15;
 
-  // Layer1 Tx frame rate in bits per second.
+  // The Layer 1 transmission rate in bits per second.
   optional float tx_l1_rate_bps = 16;
 
-  // Layer1 Rx frame rate in bits per second.
+  // The Layer 1 receive rate in bits per second.
   optional float rx_l1_rate_bps = 17;
 
-  // Tx frame rate in bytes per second.
+  // The transmission rate in bytes per second.
   optional float tx_rate_bytes = 18;
 
-  // Rx frame rate in bytes per second.
+  // The receive rate in bytes per second.
   optional float rx_rate_bytes = 19;
 
-  // Tx frame rate in bits per second.
+  // The transmission rate in bits per second.
   optional float tx_rate_bps = 20;
 
-  // Rx frame rate in bits per second.
+  // The receive rate in bits per second.
   optional float rx_rate_bps = 21;
 
-  // Tx frame rate in kilobits per second.
+  // The transmission rate in Kilobits per second.
   optional float tx_rate_kbps = 22;
 
-  // Rx frame rate in kilobits per second.
+  // The receive rate in Kilobits per second.
   optional float rx_rate_kbps = 23;
 
-  // Tx frame rate in megabits per second.
+  // The transmission rate in Megabits per second.
   optional float tx_rate_mbps = 24;
 
-  // Rx frame rate in megabits per second.
+  // The receive rate in Megabits per second.
   optional float rx_rate_mbps = 25;
 }
 
@@ -12279,34 +12279,34 @@ message FlowTaggedMetric {
   // Description missing in models
   MetricLatency latency = 10;
 
-  // Layer1 Tx frame rate in bits per second.
+  // The Layer 1 transmission rate in bits per second.
   optional float tx_l1_rate_bps = 11;
 
-  // Layer1 Rx frame rate in bits per second.
+  // The Layer 1 receive rate in bits per second.
   optional float rx_l1_rate_bps = 12;
 
-  // Tx frame rate in bytes per second.
+  // The transmission rate in bytes per second.
   optional float tx_rate_bytes = 13;
 
-  // Rx frame rate in bytes per second.
+  // The receive rate in bytes per second.
   optional float rx_rate_bytes = 14;
 
-  // Tx frame rate in bits per second.
+  // The transmission rate in bits per second.
   optional float tx_rate_bps = 15;
 
-  // Rx frame rate in bits per second.
+  // The receive rate in bits per second.
   optional float rx_rate_bps = 16;
 
-  // Tx frame rate in kilobits per second.
+  // The transmission rate in Kilobits per second.
   optional float tx_rate_kbps = 17;
 
-  // Rx frame rate in kilobits per second.
+  // The receive rate in Kilobits per second.
   optional float rx_rate_kbps = 18;
 
-  // Tx frame rate in megabits per second.
+  // The transmission rate in Megabits per second.
   optional float tx_rate_mbps = 19;
 
-  // Rx frame rate in megabits per second.
+  // The receive rate in Megabits per second.
   optional float rx_rate_mbps = 20;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12199,28 +12199,28 @@ message FlowMetric {
   // Layer1 Rx frame rate in bits per second.
   optional float rx_l1_rate_bps = 17;
 
-  // Layer1 Tx frame rate in bytes per second.
+  // Tx frame rate in bytes per second.
   optional float tx_rate_bytes = 18;
 
-  // Layer1 Tx frame rate in bytes per second.
+  // Rx frame rate in bytes per second.
   optional float rx_rate_bytes = 19;
 
-  // Layer1 Tx frame rate in bits per second.
+  // Tx frame rate in bits per second.
   optional float tx_rate_bps = 20;
 
-  // Layer1 Tx frame rate in bits per second.
+  // Rx frame rate in bits per second.
   optional float rx_rate_bps = 21;
 
-  // Layer1 Tx frame rate in kilobits per second.
+  // Tx frame rate in kilobits per second.
   optional float tx_rate_kbps = 22;
 
-  // Layer1 Tx frame rate in kilobits per second.
+  // Rx frame rate in kilobits per second.
   optional float rx_rate_kbps = 23;
 
-  // Layer1 Tx frame rate in megabits per second.
+  // Tx frame rate in megabits per second.
   optional float tx_rate_mbps = 24;
 
-  // Layer1 Tx frame rate in megabits per second.
+  // Rx frame rate in megabits per second.
   optional float rx_rate_mbps = 25;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12081,6 +12081,16 @@ message FlowMetricsRequest {
       bytes_rx = 5;
       frames_tx_rate = 6;
       frames_rx_rate = 7;
+      tx_l1_rate_bps = 8;
+      rx_l1_rate_bps = 9;
+      tx_rate_bytes = 10;
+      rx_rate_bytes = 11;
+      tx_rate_bps = 12;
+      rx_rate_bps = 13;
+      tx_rate_kbps = 14;
+      rx_rate_kbps = 15;
+      tx_rate_mbps = 16;
+      rx_rate_mbps = 17;
     }
   }
   // The list of metric names that the returned result set will contain. If the list is
@@ -12112,6 +12122,16 @@ message FlowTaggedMetricsFilter {
       bytes_rx = 4;
       frames_tx_rate = 5;
       frames_rx_rate = 6;
+      tx_l1_rate_bps = 7;
+      rx_l1_rate_bps = 8;
+      tx_rate_bytes = 9;
+      rx_rate_bytes = 10;
+      tx_rate_bps = 11;
+      rx_rate_bps = 12;
+      tx_rate_kbps = 13;
+      rx_rate_kbps = 14;
+      tx_rate_mbps = 15;
+      rx_rate_mbps = 16;
     }
   }
   // The list of metric names that the returned result set will contain. If the list is
@@ -12258,6 +12278,36 @@ message FlowTaggedMetric {
 
   // Description missing in models
   MetricLatency latency = 10;
+
+  // Layer1 Tx frame rate in bits per second.
+  optional float tx_l1_rate_bps = 11;
+
+  // Layer1 Rx frame rate in bits per second.
+  optional float rx_l1_rate_bps = 12;
+
+  // Tx frame rate in bytes per second.
+  optional float tx_rate_bytes = 13;
+
+  // Rx frame rate in bytes per second.
+  optional float rx_rate_bytes = 14;
+
+  // Tx frame rate in bits per second.
+  optional float tx_rate_bps = 15;
+
+  // Rx frame rate in bits per second.
+  optional float rx_rate_bps = 16;
+
+  // Tx frame rate in kilobits per second.
+  optional float tx_rate_kbps = 17;
+
+  // Rx frame rate in kilobits per second.
+  optional float rx_rate_kbps = 18;
+
+  // Tx frame rate in megabits per second.
+  optional float tx_rate_mbps = 19;
+
+  // Rx frame rate in megabits per second.
+  optional float rx_rate_mbps = 20;
 }
 
 // Description missing in models

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12200,10 +12200,10 @@ message FlowMetric {
   optional float rx_l1_rate_bps = 17;
 
   // Layer1 Tx frame rate in bytes per second.
-  optional float tx_rate_bytes_per_second = 18;
+  optional float tx_rate_bytes = 18;
 
   // Layer1 Tx frame rate in bytes per second.
-  optional float rx_rate_bytes_per_second = 19;
+  optional float rx_rate_bytes = 19;
 
   // Layer1 Tx frame rate in bits per second.
   optional float tx_rate_bps = 20;

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12192,6 +12192,36 @@ message FlowMetric {
   // flow.
   // The container is keyed by list of tag-value pairs.
   repeated FlowTaggedMetric tagged_metrics = 15;
+
+  // Layer1 Tx frame rate in bits per second.
+  optional float tx_l1_rate_bps = 16;
+
+  // Layer1 Rx frame rate in bits per second.
+  optional float rx_l1_rate_bps = 17;
+
+  // Layer1 Tx frame rate in bytes per second.
+  optional float tx_rate_bytes_per_second = 18;
+
+  // Layer1 Tx frame rate in bytes per second.
+  optional float rx_rate_bytes_per_second = 19;
+
+  // Layer1 Tx frame rate in bits per second.
+  optional float tx_rate_bps = 20;
+
+  // Layer1 Tx frame rate in bits per second.
+  optional float rx_rate_bps = 21;
+
+  // Layer1 Tx frame rate in kilobits per second.
+  optional float tx_rate_kbps = 22;
+
+  // Layer1 Tx frame rate in kilobits per second.
+  optional float rx_rate_kbps = 23;
+
+  // Layer1 Tx frame rate in megabits per second.
+  optional float tx_rate_mbps = 24;
+
+  // Layer1 Tx frame rate in megabits per second.
+  optional float rx_rate_mbps = 25;
 }
 
 // Metrics for each set of values applicable for configured

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -200,12 +200,12 @@ components:
             Layer1 Rx frame rate in bits per second.
           type: number
           x-field-uid: 17
-        tx_rate_bytes_per_second:
+        tx_rate_bytes:
           description: >-
             Layer1 Tx frame rate in bytes per second.
           type: number
           x-field-uid: 18
-        rx_rate_bytes_per_second:
+        rx_rate_bytes:
           description: >-
             Layer1 Tx frame rate in bytes per second.
           type: number

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -37,6 +37,26 @@ components:
                 x-field-uid: 6
               frames_rx_rate:
                 x-field-uid: 7
+              tx_l1_rate_bps:
+                x-field-uid: 8
+              rx_l1_rate_bps:
+                x-field-uid: 9
+              tx_rate_bytes:
+                x-field-uid: 10
+              rx_rate_bytes:
+                x-field-uid: 11
+              tx_rate_bps:
+                x-field-uid: 12
+              rx_rate_bps:
+                x-field-uid: 13
+              tx_rate_kbps:
+                x-field-uid: 14
+              rx_rate_kbps:
+                x-field-uid: 15
+              tx_rate_mbps:
+                x-field-uid: 16
+              rx_rate_mbps:
+                x-field-uid: 17
           x-field-uid: 3
         tagged_metrics:
           $ref: '#/components/schemas/Flow.TaggedMetrics.Filter'
@@ -75,6 +95,26 @@ components:
                 x-field-uid: 5
               frames_rx_rate:
                 x-field-uid: 6
+              tx_l1_rate_bps:
+                x-field-uid: 7
+              rx_l1_rate_bps:
+                x-field-uid: 8
+              tx_rate_bytes:
+                x-field-uid: 9
+              rx_rate_bytes:
+                x-field-uid: 10
+              tx_rate_bps:
+                x-field-uid: 11
+              rx_rate_bps:
+                x-field-uid: 12
+              tx_rate_kbps:
+                x-field-uid: 13
+              rx_rate_kbps:
+                x-field-uid: 14
+              tx_rate_mbps:
+                x-field-uid: 15
+              rx_rate_mbps:
+                x-field-uid: 16
           x-field-uid: 3
         filters:
           description: List of filters to selectively fetch tagged metrics with certain tag and corresponding value.
@@ -299,6 +339,26 @@ components:
         latency:
           $ref: '#/components/schemas/Metric.Latency'
           x-field-uid: 10
+        tx_l1_rate_bps:
+          x-field-uid: 11
+        rx_l1_rate_bps:
+          x-field-uid: 12
+        tx_rate_bytes:
+          x-field-uid: 13
+        rx_rate_bytes:
+          x-field-uid: 14
+        tx_rate_bps:
+          x-field-uid: 15
+        rx_rate_bps:
+          x-field-uid: 16
+        tx_rate_kbps:
+          x-field-uid: 17
+        rx_rate_kbps:
+          x-field-uid: 18
+        tx_rate_mbps:
+          x-field-uid: 19
+        rx_rate_mbps:
+          x-field-uid: 20
     Flow.MetricTag:
       type: object
       properties:

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -232,52 +232,52 @@ components:
           x-field-uid: 15
         tx_l1_rate_bps:
           description: >-
-            Layer1 Tx frame rate in bits per second.
+            The Layer 1 transmission rate in bits per second.
           type: number
           x-field-uid: 16
         rx_l1_rate_bps:
           description: >-
-            Layer1 Rx frame rate in bits per second.
+            The Layer 1 receive rate in bits per second.
           type: number
           x-field-uid: 17
         tx_rate_bytes:
           description: >-
-            Tx frame rate in bytes per second.
+            The transmission rate in bytes per second.
           type: number
           x-field-uid: 18
         rx_rate_bytes:
           description: >-
-            Rx frame rate in bytes per second.
+            The receive rate in bytes per second.
           type: number
           x-field-uid: 19
         tx_rate_bps:
           description: >-
-            Tx frame rate in bits per second.
+            The transmission rate in bits per second.
           type: number
           x-field-uid: 20
         rx_rate_bps:
           description: >-
-            Rx frame rate in bits per second.
+            The receive rate in bits per second.
           type: number
           x-field-uid: 21
         tx_rate_kbps:
           description: >-
-            Tx frame rate in kilobits per second.
+            The transmission rate in Kilobits per second.
           type: number
           x-field-uid: 22
         rx_rate_kbps:
           description: >-
-            Rx frame rate in kilobits per second.
+            The receive rate in Kilobits per second.
           type: number
           x-field-uid: 23
         tx_rate_mbps:
           description: >-
-            Tx frame rate in megabits per second.
+            The transmission rate in Megabits per second.
           type: number
           x-field-uid: 24
         rx_rate_mbps:
           description: >-
-            Rx frame rate in megabits per second.
+            The receive rate in Megabits per second.
           type: number
           x-field-uid: 25
     Flow.TaggedMetric:
@@ -341,52 +341,52 @@ components:
           x-field-uid: 10
         tx_l1_rate_bps:
           description: >-
-            Layer1 Tx frame rate in bits per second.
+            The Layer 1 transmission rate in bits per second.
           type: number
           x-field-uid: 11
         rx_l1_rate_bps:
           description: >-
-            Layer1 Rx frame rate in bits per second.
+            The Layer 1 receive rate in bits per second.
           type: number
           x-field-uid: 12
         tx_rate_bytes:
           description: >-
-            Tx frame rate in bytes per second.
+            The transmission rate in bytes per second.
           type: number
           x-field-uid: 13
         rx_rate_bytes:
           description: >-
-            Rx frame rate in bytes per second.
+            The receive rate in bytes per second.
           type: number
           x-field-uid: 14
         tx_rate_bps:
           description: >-
-            Tx frame rate in bits per second.
+            The transmission rate in bits per second.
           type: number
           x-field-uid: 15
         rx_rate_bps:
           description: >-
-            Rx frame rate in bits per second.
+            The receive rate in bits per second.
           type: number
           x-field-uid: 16
         tx_rate_kbps:
           description: >-
-            Tx frame rate in kilobits per second.
+            The transmission rate in Kilobits per second.
           type: number
           x-field-uid: 17
         rx_rate_kbps:
           description: >-
-            Rx frame rate in kilobits per second.
+            The receive rate in Kilobits per second.
           type: number
           x-field-uid: 18
         tx_rate_mbps:
           description: >-
-            Tx frame rate in megabits per second.
+            The transmission rate in Megabits per second.
           type: number
           x-field-uid: 19
         rx_rate_mbps:
           description: >-
-            Rx frame rate in megabits per second.
+            The receive rate in Megabits per second.
           type: number
           x-field-uid: 20
     Flow.MetricTag:

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -340,24 +340,54 @@ components:
           $ref: '#/components/schemas/Metric.Latency'
           x-field-uid: 10
         tx_l1_rate_bps:
+          description: >-
+            Layer1 Tx frame rate in bits per second.
+          type: number
           x-field-uid: 11
         rx_l1_rate_bps:
+          description: >-
+            Layer1 Rx frame rate in bits per second.
+          type: number
           x-field-uid: 12
         tx_rate_bytes:
+          description: >-
+            Tx frame rate in bytes per second.
+          type: number
           x-field-uid: 13
         rx_rate_bytes:
+          description: >-
+            Rx frame rate in bytes per second.
+          type: number
           x-field-uid: 14
         tx_rate_bps:
+          description: >-
+            Tx frame rate in bits per second.
+          type: number
           x-field-uid: 15
         rx_rate_bps:
+          description: >-
+            Rx frame rate in bits per second.
+          type: number
           x-field-uid: 16
         tx_rate_kbps:
+          description: >-
+            Tx frame rate in kilobits per second.
+          type: number
           x-field-uid: 17
         rx_rate_kbps:
+          description: >-
+            Rx frame rate in kilobits per second.
+          type: number
           x-field-uid: 18
         tx_rate_mbps:
+          description: >-
+            Tx frame rate in megabits per second.
+          type: number
           x-field-uid: 19
         rx_rate_mbps:
+          description: >-
+            Rx frame rate in megabits per second.
+          type: number
           x-field-uid: 20
     Flow.MetricTag:
       type: object

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -190,6 +190,56 @@ components:
           items:
             $ref: '#/components/schemas/Flow.TaggedMetric'
           x-field-uid: 15
+        tx_l1_rate_bps:
+          description: >-
+            Layer1 Tx frame rate in bits per second.
+          type: number
+          x-field-uid: 16
+        rx_l1_rate_bps:
+          description: >-
+            Layer1 Rx frame rate in bits per second.
+          type: number
+          x-field-uid: 17
+        tx_rate_bytes_per_second:
+          description: >-
+            Layer1 Tx frame rate in bytes per second.
+          type: number
+          x-field-uid: 18
+        rx_rate_bytes_per_second:
+          description: >-
+            Layer1 Tx frame rate in bytes per second.
+          type: number
+          x-field-uid: 19
+        tx_rate_bps:
+          description: >-
+            Layer1 Tx frame rate in bits per second.
+          type: number
+          x-field-uid: 20
+        rx_rate_bps:
+          description: >-
+            Layer1 Tx frame rate in bits per second.
+          type: number
+          x-field-uid: 21
+        tx_rate_kbps:
+          description: >-
+            Layer1 Tx frame rate in kilobits per second.
+          type: number
+          x-field-uid: 22
+        rx_rate_kbps:
+          description: >-
+            Layer1 Tx frame rate in kilobits per second.
+          type: number
+          x-field-uid: 23
+        tx_rate_mbps:
+          description: >-
+            Layer1 Tx frame rate in megabits per second.
+          type: number
+          x-field-uid: 24
+        rx_rate_mbps:
+          description: >-
+            Layer1 Tx frame rate in megabits per second.
+          type: number
+          x-field-uid: 25
     Flow.TaggedMetric:
       description: |-
         Metrics for each set of values applicable for configured

--- a/result/flow.yaml
+++ b/result/flow.yaml
@@ -202,42 +202,42 @@ components:
           x-field-uid: 17
         tx_rate_bytes:
           description: >-
-            Layer1 Tx frame rate in bytes per second.
+            Tx frame rate in bytes per second.
           type: number
           x-field-uid: 18
         rx_rate_bytes:
           description: >-
-            Layer1 Tx frame rate in bytes per second.
+            Rx frame rate in bytes per second.
           type: number
           x-field-uid: 19
         tx_rate_bps:
           description: >-
-            Layer1 Tx frame rate in bits per second.
+            Tx frame rate in bits per second.
           type: number
           x-field-uid: 20
         rx_rate_bps:
           description: >-
-            Layer1 Tx frame rate in bits per second.
+            Rx frame rate in bits per second.
           type: number
           x-field-uid: 21
         tx_rate_kbps:
           description: >-
-            Layer1 Tx frame rate in kilobits per second.
+            Tx frame rate in kilobits per second.
           type: number
           x-field-uid: 22
         rx_rate_kbps:
           description: >-
-            Layer1 Tx frame rate in kilobits per second.
+            Rx frame rate in kilobits per second.
           type: number
           x-field-uid: 23
         tx_rate_mbps:
           description: >-
-            Layer1 Tx frame rate in megabits per second.
+            Tx frame rate in megabits per second.
           type: number
           x-field-uid: 24
         rx_rate_mbps:
           description: >-
-            Layer1 Tx frame rate in megabits per second.
+            Rx frame rate in megabits per second.
           type: number
           x-field-uid: 25
     Flow.TaggedMetric:


### PR DESCRIPTION
**Redocly View:**
[ReDoc Interactive Demo (redocly.github.io)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-flow-stats/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_metrics)

**Newly added fields in flow metrics:**
1. tx_l1_rate_bps
2. rx_l1_rate_bps
3. tx_rate_bytes
4. rx_rate_byte
5. tx_rate_bps
6. rx_rate_bps
7. tx_rate_kbps
8. rx_rate_kbps
9. tx_rate_mbps
10. rx_rate_mbps

**Sample Code Snippet:**

```py
# new config
config = api.config()

// skipping other config snippets
# configure flow properties
flw, = config.flows.flow(name='flw')

// skipping other flow config snippets

# push configuration
api.set_config(config)

# start all protocols
control_state = api.control_state()
control_state.protocol.all.state = control_state.protocol.all.START
api.set_control_state(control_state)

# start transmitting configured flows
control_state = api.control_state()
control_state.traffic.choice = control_state.traffic.FLOW_TRANSMIT
control_state.traffic.flow_transmit.state = control_state.traffic.flow_transmit.START  # noqa
api.set_control_state(control_state)

# create a query for flow metrics
req = api.metrics_request()
req.flow.flow_names = [flw.name]

res = api.get_metrics(req)
# Response will contains the newly added fields if the application supported those fields.
```