### PR TITLE
MACsec/ MKA model reworked (on dev_macsec branch) based on review comments from PR #408 (on macsec branch)

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11258,7 +11258,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 8
+          maxLength: 16
           minimum: 1
           default: '0x0000000000000006'
           x-field-uid: 2
@@ -11289,7 +11289,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 8
+          maxLength: 16
           minimum: 1
           default: '0x0000000000010000'
           x-field-uid: 3
@@ -11331,7 +11331,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 8
+          maxLength: 16
           minimum: 1
           default: '0x0000000000000001'
           x-field-uid: 3
@@ -11490,7 +11490,7 @@ components:
             Actor priority.
           type: string
           format: hex
-          minLength: 2
+          minLength: 1
           maxLength: 2
           default: '70'
           x-field-uid: 3
@@ -11532,7 +11532,7 @@ components:
           format: hex
           minLength: 1
           maxLength: 4
-          default: '0x888E'
+          default: 888E
           x-field-uid: 7
         mka_version:
           description: |-
@@ -11642,11 +11642,11 @@ components:
       properties:
         cak_value:
           description: |-
-            Connectivity association key(CAK) value.
+            Connectivity association key(CAK) value. It can be 128 bits or 256 bits long depending on the chosen MKA key derivation function.
           type: string
           format: hex
-          minLength: 16
-          maxLength: 32
+          minLength: 1
+          maxLength: 64
           default: F123456789ABCDEF0123456789ABCDEF
           x-field-uid: 1
         cak_name:
@@ -11655,7 +11655,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 32
+          maxLength: 64
           default: F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF
           x-field-uid: 2
         start_time:
@@ -11802,7 +11802,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 4
+          maxLength: 8
           default: C0000000
           x-field-uid: 5
         rekey_threshold_xpn:
@@ -11811,7 +11811,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 8
+          maxLength: 16
           default: C000000000000000
           x-field-uid: 6
     Mka.Tx:
@@ -11991,11 +11991,11 @@ components:
       properties:
         sak:
           description: |-
-            Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending on the citpher suite chosen.
+            Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending on the chosen cipher suite.
           type: string
           format: hex
-          minLength: 16
-          maxLength: 32
+          minLength: 1
+          maxLength: 64
           default: F123456789ABCDEF0123456789ABCDEF
           x-field-uid: 1
         ssci:
@@ -12003,8 +12003,8 @@ components:
             4 bytes short SCI(SSCI) used in case of XPN cipher suites.
           type: string
           format: hex
-          minLength: 4
-          maxLength: 4
+          minLength: 1
+          maxLength: 8
           default: '00000001'
           x-field-uid: 2
         salt:
@@ -12012,8 +12012,8 @@ components:
             12 bytes salt used in case of XPN cipher suites.
           type: string
           format: hex
-          minLength: 12
-          maxLength: 12
+          minLength: 1
+          maxLength: 24
           default: '000000000000000000000001'
           x-field-uid: 3
     Macsec.StaticKey.Tx:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11029,6 +11029,7 @@ components:
       type: object
       required:
       - name
+      - key_generation_protocol
       properties:
         name:
           x-field-uid: 1
@@ -11104,6 +11105,8 @@ components:
       description: |-
         A container of encapsulation properties for a secure entity(SecY).
       type: object
+      required:
+      - crypto_engine
       properties:
         tx:
           description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -17003,6 +17003,10 @@ components:
               x-field-uid: 14
             convergence:
               x-field-uid: 15
+            macsec:
+              x-field-uid: 16
+            mka:
+              x-field-uid: 17
           enum:
           - port
           - flow
@@ -17019,6 +17023,8 @@ components:
           - dhcpv6_server
           - ospfv2
           - convergence
+          - macsec
+          - mka
         port:
           $ref: '#/components/schemas/Port.Metrics.Request'
           x-field-uid: 2
@@ -17064,6 +17070,12 @@ components:
         convergence:
           $ref: '#/components/schemas/Convergence.Request'
           x-field-uid: 16
+        macsec:
+          $ref: '#/components/schemas/Macsec.Metrics.Request'
+          x-field-uid: 17
+        mka:
+          $ref: '#/components/schemas/Mka.Metrics.Request'
+          x-field-uid: 18
     Metrics.Response:
       description: |-
         Response containing chosen traffic generator metrics.
@@ -17102,8 +17114,12 @@ components:
               x-field-uid: 13
             ospfv2_metrics:
               x-field-uid: 14
-            convergence_metrics:
+            macsec_metrics:
               x-field-uid: 15
+            mka_metrics:
+              x-field-uid: 16
+            convergence_metrics:
+              x-field-uid: 17
           enum:
           - flow_metrics
           - port_metrics
@@ -17119,6 +17135,8 @@ components:
           - dhcpv6_client
           - dhcpv6_server
           - ospfv2_metrics
+          - macsec_metrics
+          - mka_metrics
           - convergence_metrics
         port_metrics:
           type: array
@@ -17195,6 +17213,16 @@ components:
           items:
             $ref: '#/components/schemas/Convergence.Metric'
           x-field-uid: 16
+        macsec_metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.Metric'
+          x-field-uid: 17
+        mka_metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Mka.Metric'
+          x-field-uid: 18
     Port.Metrics.Request:
       description: |-
         The port result request to the traffic generator
@@ -20271,6 +20299,353 @@ components:
           type: number
           format: double
           x-field-uid: 4
+    Macsec.Metrics.Request:
+      description: |-
+        The request to retrieve MACsec per secure entity(secY) metrics/statistics.
+      type: object
+      properties:
+        secure_entity_names:
+          description: |
+            The names of secure entities(secYs) to return results for. An empty list will return results for all secYs.
+
+            x-constraint:
+            - /components/schemas/Macsec/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Macsec/properties/name
+          x-field-uid: 1
+        column_names:
+          description: |-
+            The list of column names that the returned result set will contain. If the list is empty then all columns will be returned except for any result_groups. The name of the secure entity(secY) cannot be excluded.
+          type: array
+          items:
+            type: string
+            x-enum:
+              session_state:
+                x-field-uid: 1
+              session_flap_count:
+                x-field-uid: 2
+              out_pkts_protected:
+                x-field-uid: 3
+              out_pkts_encrypted:
+                x-field-uid: 4
+              in_pkts_ok:
+                x-field-uid: 5
+              in_pkts_bad:
+                x-field-uid: 6
+              in_pkts_bad_tag:
+                x-field-uid: 7
+              in_pkts_late:
+                x-field-uid: 8
+              in_pkts_no_sci:
+                x-field-uid: 9
+              in_pkts_not_using_sa:
+                x-field-uid: 10
+              in_pkts_not_valid:
+                x-field-uid: 11
+              in_pkts_unknown_sci:
+                x-field-uid: 12
+              in_pkts_unused_sa:
+                x-field-uid: 13
+              in_pkts_invalid:
+                x-field-uid: 14
+              in_pkts_untagged:
+                x-field-uid: 15
+              out_octets_protected:
+                x-field-uid: 16
+              out_octets_encrypted:
+                x-field-uid: 17
+              in_octets_validated:
+                x-field-uid: 18
+              in_octets_decrypted:
+                x-field-uid: 19
+            enum:
+            - session_state
+            - session_flap_count
+            - out_pkts_protected
+            - out_pkts_encrypted
+            - in_pkts_ok
+            - in_pkts_bad
+            - in_pkts_bad_tag
+            - in_pkts_late
+            - in_pkts_no_sci
+            - in_pkts_not_using_sa
+            - in_pkts_not_valid
+            - in_pkts_unknown_sci
+            - in_pkts_unused_sa
+            - in_pkts_invalid
+            - in_pkts_untagged
+            - out_octets_protected
+            - out_octets_encrypted
+            - in_octets_validated
+            - in_octets_decrypted
+          x-field-uid: 2
+    Macsec.Metric:
+      description: |-
+        MACsec per secure entity(secY) statistics information.
+      type: object
+      properties:
+        name:
+          description: |-
+            The name of a configured MACsec secure entity(secY).
+          type: string
+          x-field-uid: 1
+        session_state:
+          description: |-
+            Session state as up or down. Up refers to an Established state and Down refers to any other state.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          enum:
+          - up
+          - down
+        session_flap_count:
+          description: |-
+            Number of times the session went from Up to Down state.
+          type: integer
+          format: uint64
+          x-field-uid: 3
+        out_pkts_protected:
+          description: |-
+            OutPktsProtected, the number of protected packets transmitted.
+          type: integer
+          format: uint64
+          x-field-uid: 4
+        out_pkts_encrypted:
+          description: |-
+            OutPktsEncrypted, the number of encrypted packets transmitted.
+          type: integer
+          format: uint64
+          x-field-uid: 5
+        in_pkts_ok:
+          description: |-
+            InPktsOk, the number of valid packets received.
+          type: integer
+          format: uint64
+          x-field-uid: 6
+        bad_pkts_rx:
+          description: |-
+            The number of bad packets received.
+          type: integer
+          format: uint64
+          x-field-uid: 7
+        in_pkts_bad_tag:
+          description: |-
+            InPktsBadTag, the number of packets discarded due to bad tag/ICV.
+          type: integer
+          format: uint64
+          x-field-uid: 8
+        in_pkts_late:
+          description: |-
+            InPktsLate, the number of packets discarded out of window.
+          type: integer
+          format: uint64
+          x-field-uid: 9
+        in_pkts_no_sci:
+          description: |-
+            InPktsNoSCI,the number of packets discarded due to unknown SCI.
+          type: integer
+          format: uint64
+          x-field-uid: 10
+        in_pkts_not_using_sa:
+          description: |-
+            InPktsNotUsingSA, the number of packets discarded due to unused SA.
+          type: integer
+          format: uint64
+          x-field-uid: 11
+        in_pkts_not_valid:
+          description: |-
+            InPktsNotValid, the number of packets discarded due to invalid ICV.
+          type: integer
+          format: uint64
+          x-field-uid: 12
+        in_pkts_unknown_sci:
+          description: |-
+            InPktsUnknownSCI, the number of packets received with unknown SCI.
+          type: integer
+          format: uint64
+          x-field-uid: 13
+        in_pkts_unused_sa:
+          description: |-
+            InPktsUnusedSA, the number of packets received with unused SA.
+          type: integer
+          format: uint64
+          x-field-uid: 14
+        in_pkts_invalid:
+          description: |-
+            InPktsInvalid, the number of packets received with invalid ICV.
+          type: integer
+          format: uint64
+          x-field-uid: 15
+        in_pkts_untagged:
+          description: |-
+            InPktsUntagged, the number of non-MACsec packets received.
+          type: integer
+          format: uint64
+          x-field-uid: 16
+        out_octets_protected:
+          description: |-
+            OutOctetsProtected, the number of bytes transmitted as protected.
+          type: integer
+          format: uint64
+          x-field-uid: 17
+        out_octets_encrypted:
+          description: |-
+            OutOctetsEncrypted, the number of bytes transmitted as encrypted.
+          type: integer
+          format: uint64
+          x-field-uid: 18
+        in_octets_validated:
+          description: |-
+            InOctetsValidated, the number of received bytes validated.
+          type: integer
+          format: uint64
+          x-field-uid: 19
+        in_octets_decrypted:
+          description: |-
+            InOctetsDecrypted, the number of received bytes decrypted.
+          type: integer
+          format: uint64
+          x-field-uid: 20
+    Mka.Metrics.Request:
+      description: |-
+        The request to retrieve MKA per peer metrics/statistics.
+      type: object
+      properties:
+        peer_names:
+          description: |
+            The names of peers to return results for. An empty list will return results for all peers.
+
+            x-constraint:
+            - /components/schemas/Mka/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Mka/properties/name
+          x-field-uid: 1
+        column_names:
+          description: |-
+            The list of column names that the returned result set will contain. If the list is empty then all columns will be returned except for any result_groups. The name of the peer cannot be excluded.
+          type: array
+          items:
+            type: string
+            x-enum:
+              session_state:
+                x-field-uid: 1
+              session_flap_count:
+                x-field-uid: 2
+              mkpdu_tx:
+                x-field-uid: 3
+              mkpdu_rx:
+                x-field-uid: 4
+              live_peer_count:
+                x-field-uid: 5
+              potential_peer_count:
+                x-field-uid: 6
+              latest_key_tx_peer_count:
+                x-field-uid: 7
+              latest_key_rx_peer_count:
+                x-field-uid: 8
+              malformed_mkpdu:
+                x-field-uid: 9
+              icv_mismatch:
+                x-field-uid: 10
+            enum:
+            - session_state
+            - session_flap_count
+            - mkpdu_tx
+            - mkpdu_rx
+            - live_peer_count
+            - potential_peer_count
+            - latest_key_tx_peer_count
+            - latest_key_rx_peer_count
+            - malformed_mkpdu
+            - icv_mismatch
+          x-field-uid: 2
+    Mka.Metric:
+      description: |-
+        MKA per peer statistics information.
+      type: object
+      properties:
+        name:
+          description: |-
+            The name of a configured MKA peer.
+          type: string
+          x-field-uid: 1
+        session_state:
+          description: |-
+            Session state as up or down. Up refers to an Established state and Down refers to any other state.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          enum:
+          - up
+          - down
+        session_flap_count:
+          description: |-
+            Number of times the session went from Up to Down state.
+          type: integer
+          format: uint64
+          x-field-uid: 3
+        mkpdu_tx:
+          description: |-
+            Number of MKA protocol data unit(MKPDU) frames Tx.
+          type: integer
+          format: uint64
+          x-field-uid: 4
+        mkpdu_rx:
+          description: |-
+            Number of MKA protocol data unit(MKPDU) frames Rx.
+          type: integer
+          format: uint64
+          x-field-uid: 5
+        live_peer_count:
+          description: |-
+            Number of MKA live peers.
+          type: integer
+          format: uint64
+          x-field-uid: 6
+        potential_peer_count:
+          description: |-
+            Number of MKA potential peers.
+          type: integer
+          format: uint64
+          x-field-uid: 7
+        latest_key_tx_peer_count:
+          description: |-
+            Number of MKA latest key Tx peers.
+          type: integer
+          format: uint64
+          x-field-uid: 8
+        latest_key_rx_peer_count:
+          description: |-
+            Number of MKA latest key Rx peers.
+          type: integer
+          format: uint64
+          x-field-uid: 9
+        malformed_mkpdu:
+          description: |-
+            Number of malformed MKA Protocol Data Unit(MKPDU) frames Rx.
+          type: integer
+          format: uint64
+          x-field-uid: 10
+        icv_mismatch:
+          description: |-
+            Number of MKA Protocol Data Unit(MKPDU) frames with ICV mismatch Rx.
+          type: integer
+          format: uint64
+          x-field-uid: 11
     States.Request:
       description: |-
         Request to traffic generator for states of choice

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11457,9 +11457,7 @@ components:
         tx:
           description: |-
             Tx Properties.
-          type: array
-          items:
-            $ref: '#/components/schemas/Mka.Tx'
+          $ref: '#/components/schemas/Mka.Tx'
           x-field-uid: 4
     Mka.Basic:
       description: |-
@@ -11826,7 +11824,9 @@ components:
         secure_channels:
           description: |-
             Tx secure channels.
-          $ref: '#/components/schemas/Mka.TxSc'
+          type: array
+          items:
+            $ref: '#/components/schemas/Mka.TxSc'
           x-field-uid: 1
     Mka.TxSc:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11567,7 +11567,7 @@ components:
           x-field-uid: 11
         delay_protect:
           description: |-
-            Delay Protect or not. When delay protect is enabled, it guards against delaying the delivery of MACsec encrypted frames by an attacker to the receipient.
+            Delay Protect or not. When delay protect is enabled, it guards against delaying the delivery of MACsec encrypted frames by an attacker to the recipient.
           type: boolean
           default: true
           x-field-uid: 12
@@ -11665,15 +11665,93 @@ components:
         start_offset_time:
           description: |-
             Key start offset time in HH:MM. This is relative to key chain start time.
-          type: string
-          default: 00:00
+          $ref: '#/components/schemas/Mka.Basic.OffsetTime'
           x-field-uid: 3
         end_offset_time:
           description: |-
             Key end offset time in HH:MM. This is relative to key chain start time.
-          type: string
-          default: 00:00
+          $ref: '#/components/schemas/Mka.Basic.OffsetTime'
           x-field-uid: 4
+    Mka.Basic.OffsetTime:
+      description: |-
+        Offset time.
+      type: object
+      properties:
+        mm:
+          description: |-
+            Minutes in mm.
+          type: integer
+          minimum: 0
+          default: 0
+          x-field-uid: 2
+    Mka.Basic.Time:
+      description: |-
+        Absolute time in a timezone.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Timezone choice. Currently only Coordinated Universal Time(UTC) is supported.
+          type: string
+          default: utc
+          x-field-uid: 1
+          x-enum:
+            utc:
+              x-field-uid: 1
+          enum:
+          - utc
+        utc:
+          description: |-
+            Coordinated Universal Time(UTC) time.
+          $ref: '#/components/schemas/Mka.Basic.TimeUtc'
+          x-field-uid: 2
+    Mka.Basic.TimeUtc:
+      description: |-
+        Coordinated Universal Time(UTC).
+      type: object
+      properties:
+        day:
+          description: |-
+            Day of the month in DD format.
+          type: integer
+          minimum: 1
+          maximum: 31
+          x-field-uid: 1
+        month:
+          description: |-
+            Month of the year in MM format.
+          type: integer
+          minimum: 1
+          maximum: 12
+          x-field-uid: 2
+        year:
+          description: |-
+            Year from the start of common era(CE) in YYYY format.
+          type: integer
+          minimum: 0
+          maximum: 9999
+          x-field-uid: 3
+        hour:
+          description: |-
+            Hour of the day in hh format.
+          type: integer
+          minimum: 0
+          maximum: 23
+          x-field-uid: 4
+        minute:
+          description: |-
+            Minute of the hour in mm format.
+          type: integer
+          minimum: 0
+          maximum: 59
+          x-field-uid: 5
+        second:
+          description: |-
+            Second of the minute in ss format.
+          type: integer
+          minimum: 0
+          maximum: 59
+          x-field-uid: 6
     Mka.Basic.RekeyMode:
       description: |-
         Rekey mode.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11691,8 +11691,6 @@ components:
           default: 0
           x-field-uid: 2
     Mka.Basic.Time:
-      description: |-
-        Absolute time in a timezone.
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11826,9 +11826,7 @@ components:
         secure_channels:
           description: |-
             Tx secure channels.
-          type: array
-          items:
-            $ref: '#/components/schemas/Mka.TxSc'
+          $ref: '#/components/schemas/Mka.TxSc'
           x-field-uid: 1
     Mka.TxSc:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11574,7 +11574,7 @@ components:
           $ref: '#/components/schemas/Mka.Basic.RekeyMode'
         psk_chain_start_time:
           description: |-
-            Pre-shared key(PSK) chain start time (in UTC - DD-MM-YYYY HH:MM:SS). The key start time will be relative to this value.
+            Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. The key start time will be relative to this value.
           type: string
           minLength: 19
           maxLength: 19
@@ -11660,13 +11660,13 @@ components:
           x-field-uid: 2
         start_time:
           description: |-
-            Key start time in HH:MM. This is relative to test start time.
+            Key start time in HH:MM. This is relative to key chain start time.
           type: string
           default: 00:00
           x-field-uid: 3
         end_time:
           description: |-
-            Key end time in HH:MM. This is relative to test start time.
+            Key end time in HH:MM. This is relative to key chain start time.
           type: string
           default: 00:00
           x-field-uid: 4

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2464,6 +2464,11 @@ components:
             Configuration for OSPFv2 router.
           $ref: '#/components/schemas/Device.Ospfv2Router'
           x-field-uid: 10
+        macsec:
+          description: |-
+            Configuration of MACsec device.
+          $ref: '#/components/schemas/Device.Macsec'
+          x-field-uid: 11
       required:
       - name
     Protocol.Options:
@@ -10981,6 +10986,1065 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
+    Device.Macsec:
+      description: |-
+        A container of properties for a MACsec capable device.
+      type: object
+      required:
+      - ethernet_interfaces
+      properties:
+        ethernet_interfaces:
+          description: |-
+            Ethernet Interfaces
+          type: array
+          items:
+            $ref: '#/components/schemas/Device.Macsec.EthernetInterface'
+          x-field-uid: 1
+    Device.Macsec.EthernetInterface:
+      description: |-
+        Configuration for single MACsec interface.
+      type: object
+      required:
+      - eth_name
+      - secy
+      properties:
+        eth_name:
+          description: |
+            The unique name of the Ethernet interface on which MACsec is enabled.
+
+            x-constraint:
+            - /components/schemas/Device.Ethernet/properties/name
+          type: string
+          x-constraint:
+          - /components/schemas/Device.Ethernet/properties/name
+          x-field-uid: 1
+        secy:
+          description: |-
+            This contains the properties of Secure Entity (SecY).
+          $ref: '#/components/schemas/Macsec'
+          x-field-uid: 2
+    Macsec:
+      description: |-
+        Configuration of a Secure Entity (SecY).
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          x-field-uid: 1
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-unique: global
+        key_generation_protocol:
+          description: |-
+            This contains the properties of key generation protocol of Secure Entity (SecY).
+          $ref: '#/components/schemas/Macsec.KeyGenerationProtocol'
+          x-field-uid: 2
+        data_plane:
+          description: |-
+            This contains the properties of data plane of Secure Entity (SecY).
+          $ref: '#/components/schemas/Macsec.DataPlane'
+          x-field-uid: 3
+    Macsec.KeyGenerationProtocol:
+      description: |-
+        Container of Key generation protocol configuration.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Key generation protocol choices. Choose "mka" for dynamic key distribution using MACsec key agreement(MKA) protocol. Choose "static_key" for static configuration of secure association key(SAK).
+          type: string
+          default: mka
+          x-field-uid: 1
+          x-enum:
+            mka:
+              x-field-uid: 1
+            static_key:
+              x-field-uid: 2
+          enum:
+          - mka
+          - static_key
+        kay:
+          description: |-
+            This contains the properties of Key Agreement Entity (KaY) in MKA supplicant.
+          x-field-uid: 2
+          $ref: '#/components/schemas/Mka'
+        static_key:
+          description: |-
+            Static key properties properties of SecY. Static key is used in absence MKA.
+          $ref: '#/components/schemas/Macsec.StaticKey'
+          x-field-uid: 3
+    Macsec.DataPlane:
+      description: |-
+        A container of data plane properties for a secure entity(SecY).
+      type: object
+      properties:
+        tx:
+          description: |-
+            Tx properties of SecY.
+          $ref: '#/components/schemas/Macsec.DataPlane.Tx'
+          x-field-uid: 1
+        rx:
+          description: |-
+            Rx properties of SecY.
+          $ref: '#/components/schemas/Macsec.DataPlane.Rx'
+          x-field-uid: 2
+        crypto_engine:
+          description: |-
+            Crypto engine properties of SecY.
+          $ref: '#/components/schemas/Macsec.CryptoEngine'
+          x-field-uid: 3
+    Macsec.DataPlane.Tx:
+      description: |-
+        A container of Tx properties of SecY.
+      type: object
+      properties:
+        end_station:
+          description: |-
+            End station on not.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        include_sci:
+          description: |-
+            Include SCI on not.
+          type: boolean
+          default: false
+          x-field-uid: 2
+    Macsec.DataPlane.Rx:
+      description: |-
+        A container for Rx settings of SecY.
+      type: object
+      properties:
+        replay_protection:
+          description: "Enable replay protection on not. "
+          type: boolean
+          default: false
+          x-field-uid: 1
+        replay_window:
+          description: "Replay window size. "
+          type: integer
+          format: uint32
+          minimum: 1
+          default: 1
+          x-field-uid: 2
+    Macsec.CryptoEngine:
+      description: |-
+        A container of crypto engine properties of a SecY.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Engine type based on encryption and/ or decryption capability. Supported types: 1) encrypt_only - engine can only encrypt transmitted packets but such engine cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent. 2) encrypt_decrypt - engine can both encrypt transmitted packets and decrypt packets on arrival. Such engine can have hardware acceleration for faster encryption/ ddecryption. As both encryption and decryption are possible, stateful (e.g. TCP) traffic can also be sent/ received.
+          type: string
+          default: encrypt_only
+          x-field-uid: 1
+          x-enum:
+            encrypt_only:
+              x-field-uid: 1
+            encrypt_decrypt:
+              x-field-uid: 2
+          enum:
+          - encrypt_only
+          - encrypt_decrypt
+        encrypt_only:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly'
+          x-field-uid: 2
+        encrypt_decrypt:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt'
+          x-field-uid: 3
+    Macsec.CryptoEngine.EncryptOnly:
+      description: |-
+        The container for encrypt only engine configuration.
+      type: object
+      properties:
+        secure_channel:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc'
+          x-field-uid: 1
+        traffic_options:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TrafficOptions'
+          x-field-uid: 2
+    Macsec.CryptoEngine.EncryptDecrypt:
+      description: |-
+        The container for encrypt and decrypt engine configuration.
+      type: object
+      properties:
+        secure_channel:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc'
+          x-field-uid: 1
+        hardware_acceleration:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
+          x-field-uid: 2
+    Macsec.CryptoEngine.EncryptOnly.TxSc:
+      description: |-
+        The container for Tx secure channel configuration.
+      type: object
+      properties:
+        tx_pn:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc.TxPn'
+          x-field-uid: 1
+    Macsec.CryptoEngine.EncryptOnly.TxSc.TxPn:
+      description: |-
+        Tx packet number(PN) configuration.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Types of Tx packet number(PN) series. Supported choices: 1) fixed PN - MACsec packets will be sent out with the configured fixed PN or lower half of configured fixed XPN. 2) incrementing PN - MACsec packets will be sent out by single device with an incrementing PN or XPN.
+          type: string
+          default: fixed_pn
+          x-field-uid: 1
+          x-enum:
+            fixed_pn:
+              x-field-uid: 1
+            incrementing_pn:
+              x-field-uid: 2
+          enum:
+          - fixed_pn
+          - incrementing_pn
+        fixed:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.FixedPn'
+          x-field-uid: 2
+        incrementing:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.IncrementingPn'
+          x-field-uid: 3
+    Macsec.CryptoEngine.EncryptOnly.FixedPn:
+      description: |-
+        Fixed packet number(PN) configuration.
+      type: object
+      properties:
+        pn:
+          description: |-
+            Fixed Tx packet number(PN). 4 bytes PN with which all packets will be sent out.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 4294967295
+          default: 6
+          x-field-uid: 1
+        xpn:
+          description: |-
+            Fixed Tx extended packet number(XPN). 8 bytes XPN with which all packets will be sent out.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 8
+          minimum: 1
+          default: '0x0000000000000006'
+          x-field-uid: 2
+    Macsec.CryptoEngine.EncryptOnly.IncrementingPn:
+      description: |-
+        Incrementing packet number(PN) configuration.
+      type: object
+      properties:
+        count:
+          description: "Count of packet numbers in series. "
+          type: integer
+          format: uint32
+          minimum: 2
+          maximum: 1000000
+          default: 100
+          x-field-uid: 1
+        starting_pn:
+          description: |-
+            The starting packet number(PN).
+          type: integer
+          format: uint32
+          minimum: 1
+          default: 10000
+          x-field-uid: 2
+        starting_xpn:
+          description: |-
+            The starting extended packet number(XPN).
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 8
+          minimum: 1
+          default: '0x0000000000010000'
+          x-field-uid: 3
+    Macsec.CryptoEngine.EncryptOnly.TrafficOptions:
+      description: |-
+        Encrypt only traffic options.
+      type: object
+      properties:
+        send_gratuitous_arp:
+          description: |-
+            Send gratuitous ARP or not.
+          type: boolean
+          default: true
+          x-field-uid: 1
+    Macsec.CryptoEngine.EncryptDecrypt.TxSc:
+      description: |-
+        Secure channel configuration.
+      type: object
+      properties:
+        tx_pn:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc.TxPn'
+          x-field-uid: 1
+    Macsec.CryptoEngine.EncryptDecrypt.TxSc.TxPn:
+      description: |-
+        Starting packet number(PN) configuration.
+      type: object
+      properties:
+        starting_pn:
+          description: |-
+            Initial Tx packet number(PN).
+          type: integer
+          format: uint32
+          minimum: 1
+          default: 1
+          x-field-uid: 1
+        starting_xpn:
+          description: |-
+            The starting extended packet number(XPN).
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 8
+          minimum: 1
+          default: '0x0000000000000001'
+          x-field-uid: 3
+    Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration:
+      description: |-
+        Hardware acceleration configuration for offloading MACsec processing to hardware.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Hardware acceleration types.
+          type: string
+          default: none
+          x-field-uid: 1
+          x-enum:
+            none:
+              x-field-uid: 1
+            inline_crypto:
+              x-field-uid: 2
+          enum:
+          - none
+          - inline_crypto
+        inline_crypto:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto'
+          x-field-uid: 2
+    Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
+      description: |-
+        Inline cryto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
+      type: object
+      properties:
+        rx_sectag_offset:
+          description: |-
+            Offset of Rx secTAG from the first byte in packet.
+          type: integer
+          format: uint32
+          default: 12
+          x-field-uid: 1
+        type_of_ca:
+          description: |-
+            Type of connectivity association(CA).
+          type: string
+          x-field-uid: 2
+          x-enum:
+            pairwise_ca:
+              x-field-uid: 1
+            group_ca_single_dut:
+              x-field-uid: 2
+            group_ca_multipe_duts:
+              x-field-uid: 3
+          enum:
+          - pairwise_ca
+          - group_ca_single_dut
+          - group_ca_multipe_duts
+        max_ca_count:
+          description: |-
+            The maximum number of CAs configured on the port. The maximum count supported per port is 256 for Pair-wise CA, each CA having one MACsec device.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 256
+          default: 256
+          x-field-uid: 3
+        max_dut_tx_sc_per_ca:
+          description: |-
+            The maximum number of DUT transmit SCs that can be supported per CA. The count should be number of Tx SCs supported by the DUT per CA, multiplied by number of DUTs in the CA in case of group CA with multiple DUTs scenario.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 256
+          default: 1
+          x-field-uid: 4
+        max_device_per_ca:
+          description: |-
+            The maximum number of MACsec devices at test port that can be supported on each CA. This number is calculated automatically based on the values configured for Max CA Count and Max DUT Tx SC Per CA. Number of MACsec devices at test port should be configured accordingly.
+          type: integer
+          format: uint32
+          minimum: 1
+          default: 256
+          x-field-uid: 5
+        rx_sc_identifying_field:
+          description: |-
+            The field based on which secure channel(SC) will be identified by the receiving port. Supported fields are:- - 1) source MAC - identify SC based on source MAC field. 2) SCI system ID - identify SC bbased on SCI system ID field. 3) SCI port ID - identify based on SCI port ID field.
+          type: string
+          default: source_mac
+          x-field-uid: 6
+          x-enum:
+            source_mac:
+              x-field-uid: 1
+            sci_sytem_id:
+              x-field-uid: 2
+            sci_port_id:
+              x-field-uid: 3
+          enum:
+          - source_mac
+          - sci_sytem_id
+          - sci_port_id
+    Mka:
+      description: |-
+        Configuration of a Key Agreement Entity (KaY).
+      type: object
+      required:
+      - name
+      - basic
+      - txscs
+      properties:
+        name:
+          x-field-uid: 1
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-unique: global
+        basic:
+          description: |-
+            This contains the basic properties of KaY.
+          $ref: '#/components/schemas/Mka.Basic'
+          x-field-uid: 2
+        key_server:
+          description: |-
+            Key server attributes.
+          $ref: '#/components/schemas/Mka.KeyServer'
+          x-field-uid: 3
+        txscs:
+          description: |-
+            Properties for Tx secure channels.
+          type: array
+          items:
+            $ref: '#/components/schemas/Mka.TxSc'
+          x-field-uid: 4
+    Mka.Basic:
+      description: |-
+        A container of basic properties for a KaY.
+      type: object
+      required:
+      - key_source
+      properties:
+        key_derivation_function:
+          description: |-
+            Key Derivation Function.
+          type: string
+          default: aes_cmac_128
+          x-field-uid: 1
+          x-enum:
+            aes_cmac_128:
+              x-field-uid: 1
+            aes_cmac_256:
+              x-field-uid: 2
+          enum:
+          - aes_cmac_128
+          - aes_cmac_256
+        key_source:
+          description: |-
+            Key source.
+          x-field-uid: 2
+          $ref: '#/components/schemas/Mka.Basic.KeySource'
+        actor_priority:
+          description: |-
+            Actor priority.
+          type: string
+          format: hex
+          minLength: 2
+          maxLength: 2
+          default: '70'
+          x-field-uid: 3
+        macsec_desired:
+          description: |-
+            Determines whether MACsec is desired or not. It is advertised in periodic Hellos.
+          type: boolean
+          default: true
+          x-field-uid: 4
+        macsec_capability:
+          description: |-
+            MACSec Capability.
+          type: string
+          default: macsec_integrity_with_confidentiality_offset
+          x-field-uid: 5
+          x-enum:
+            macsec_not_implemented:
+              x-field-uid: 1
+            macsec_integrity_without_confidentiality:
+              x-field-uid: 2
+            macsec_integrity_with_no_confidentiality_offset:
+              x-field-uid: 3
+            macsec_integrity_with_confidentiality_offset:
+              x-field-uid: 4
+          enum:
+          - macsec_not_implemented
+          - macsec_integrity_without_confidentiality
+          - macsec_integrity_with_no_confidentiality_offset
+          - macsec_integrity_with_confidentiality_offset
+        supported_cipher_suites:
+          description: |-
+            Supported Cipher Suites.
+          x-field-uid: 6
+          $ref: '#/components/schemas/Mka.Basic.SupportedCipherSuites'
+        mka_version:
+          description: |-
+            MKA Version.
+          type: integer
+          format: uint32
+          default: 3
+          x-field-uid: 7
+        mka_hello_time:
+          description: |-
+            MKA Hello Time (msec).
+          type: integer
+          format: uint32
+          default: 2000
+          x-field-uid: 8
+        mka_life_time:
+          description: |-
+            MKA Life Time (sec).
+          type: integer
+          format: uint32
+          default: 6
+          x-field-uid: 9
+        send_icv_indicatior_in_mkpdu:
+          description: |-
+            Send ICV Indicator in MKPDU.
+          type: boolean
+          default: true
+          x-field-uid: 10
+        delay_protect:
+          description: |-
+            Delay Protect.
+          type: boolean
+          default: true
+          x-field-uid: 11
+        rekey_mode:
+          description: |-
+            Rekey Mode.
+          x-field-uid: 12
+          $ref: '#/components/schemas/Mka.Basic.RekeyMode'
+    Mka.Basic.SupportedCipherSuites:
+      description: |-
+        The container for supported cipher suites.
+      type: object
+      properties:
+        gcm_aes_128:
+          description: |-
+            GCM-AES-128.
+          type: boolean
+          default: true
+          x-field-uid: 1
+        gcm_aes_256:
+          description: |-
+            GCM-AES-256.
+          type: boolean
+          default: true
+          x-field-uid: 2
+        gcm_aes_xpn_128:
+          description: |-
+            GCM-AES-XPN-128.
+          type: boolean
+          default: true
+          x-field-uid: 3
+        gcm_aes_xpn_256:
+          description: |-
+            GCM-AES-XPN-256.
+          type: boolean
+          default: true
+          x-field-uid: 4
+    Mka.Basic.KeySource:
+      description: |-
+        The container for key source settings.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Key source. Choose one from PSK or MSK.
+          type: string
+          default: psk
+          x-field-uid: 1
+          x-enum:
+            psk:
+              x-field-uid: 1
+            msk:
+              x-field-uid: 2
+          enum:
+          - psk
+          - msk
+        psks:
+          description: |-
+            PSK chain.
+          type: array
+          items:
+            $ref: '#/components/schemas/Mka.Basic.KeySource.Psk'
+          x-field-uid: 2
+    Mka.Basic.KeySource.Psk:
+      description: |-
+        The container for Pre-shared key(PSK).
+      type: object
+      properties:
+        cak_value:
+          description: |-
+            Connectivity association key(CAK) value.
+          type: string
+          format: hex
+          minLength: 16
+          maxLength: 32
+          default: F123456789ABCDEF0123456789ABCDEF
+          x-field-uid: 1
+        cak_name:
+          description: |-
+            Connectivity association key(CAK) name.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 32
+          default: F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF
+          x-field-uid: 2
+        start_time:
+          description: |-
+            Key start time in HH:MM. This is relative to test start time.
+          type: string
+          default: 00:00
+          x-field-uid: 3
+        end_time:
+          description: |-
+            Key end time in HH:MM. This is relative to test start time.
+          type: string
+          default: 00:00
+          x-field-uid: 4
+    Mka.Basic.RekeyMode:
+      description: |-
+        Rekey mode.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Mode choices.
+          type: string
+          default: dont_rekey
+          x-field-uid: 1
+          x-enum:
+            dont_rekey:
+              x-field-uid: 1
+            timer_based:
+              x-field-uid: 2
+            pn_based:
+              x-field-uid: 3
+          enum:
+          - dont_rekey
+          - timer_based
+          - pn_based
+        timer_based:
+          description: |-
+            Container for timer based periodic rekey properties.
+          x-field-uid: 2
+          $ref: '#/components/schemas/Mka.Basic.RekeyMode.TimerBased'
+    Mka.Basic.RekeyMode.TimerBased:
+      description: |-
+        Timer based periodic rekey properties.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Periodic Rekey count.
+          type: string
+          default: continuous
+          x-field-uid: 1
+          x-enum:
+            continuous:
+              x-field-uid: 1
+            fixed_count:
+              x-field-uid: 2
+          enum:
+          - continuous
+          - fixed_count
+        fixed_count:
+          description: |-
+            Fixed rekey attempts.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 10
+          x-field-uid: 2
+        interval:
+          description: |-
+            Periodic rekey interval (sec).
+          type: integer
+          format: uint32
+          minimum: 30
+          maximum: 65535
+          default: 300
+          x-field-uid: 3
+    Mka.KeyServer:
+      description: |-
+        Key server attributes of a KaY.
+      properties:
+        confidentialty_offset:
+          description: |-
+            Confidentiality Offset.
+          type: string
+          default: no_confidentiality_offset
+          x-field-uid: 1
+          x-enum:
+            no_confidentiality:
+              x-field-uid: 1
+            no_confidentiality_offset:
+              x-field-uid: 2
+            confidentiality_offset_30_octets:
+              x-field-uid: 3
+            confidentiality_offset_50_octets:
+              x-field-uid: 4
+          enum:
+          - no_confidentiality
+          - no_confidentiality_offset
+          - confidentiality_offset_30_octets
+          - confidentiality_offset_50_octets
+        cipher_suite:
+          description: |-
+            The cipher suite. Choose one from GCM-AES-128 GCM-AES-256 GCM-AES-XPN-128 GCM-AES-XPN-256
+          type: string
+          default: gcm_aes_128
+          x-field-uid: 2
+          x-enum:
+            gcm_aes_128:
+              x-field-uid: 1
+            gcm_aes_256:
+              x-field-uid: 2
+            gcm_aes_xpn_128:
+              x-field-uid: 3
+            gcm_aes_xpn_256:
+              x-field-uid: 4
+          enum:
+          - gcm_aes_128
+          - gcm_aes_256
+          - gcm_aes_xpn_128
+          - gcm_aes_xpn_256
+        starting_key_number:
+          description: |-
+            Starting Key Number.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 1
+          x-field-uid: 3
+        starting_distributed_an:
+          description: |-
+            Starting Distributed AN.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 3
+          default: 0
+          x-field-uid: 4
+        rekey_threshold_pn:
+          description: |-
+            Determines the PN rekey threshold.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 4
+          default: C0000000
+          x-field-uid: 5
+        rekey_threshold_xpn:
+          description: |-
+            Determines the XPN rekey threshold.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 8
+          default: C000000000000000
+          x-field-uid: 6
+    Mka.TxSc:
+      description: |-
+        Tx secure channel(SC) properties.
+      type: object
+      required:
+      - name
+      - system_id
+      properties:
+        name:
+          description: |-
+            Tx SC name.
+          type: string
+          x-field-uid: 1
+        system_id:
+          description: "System ID. "
+          type: string
+          format: mac
+          x-field-uid: 2
+        port_id:
+          description: "Port ID. "
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 1
+          x-field-uid: 3
+        starting_message_number:
+          description: |-
+            Starting Message Number.
+          type: integer
+          format: uint64
+          minimum: 1
+          maximum: 4294967295
+          default: 1
+          x-field-uid: 4
+    Macsec.StaticKey:
+      description: |-
+        A container of static key properties for a secure entity(SecY). This configuration is applicable when no dynamic key management protocol i.e. MACsec key agreement(MKA) is configured. If MKA is configured, any static key configuration is not applicable.
+      type: object
+      properties:
+        cipher_suite:
+          description: |-
+            The cipher suite. Choose one from GCM-AES-128 GCM-AES-128 GCM-AES-256 GCM-AES-XPN-128 GCM-AES-XPN-256
+          type: string
+          default: gcm_aes_128
+          x-field-uid: 1
+          x-enum:
+            gcm_aes_128:
+              x-field-uid: 1
+            gcm_aes_256:
+              x-field-uid: 2
+            gcm_aes_xpn_128:
+              x-field-uid: 3
+            gcm_aes_xpn_256:
+              x-field-uid: 4
+          enum:
+          - gcm_aes_128
+          - gcm_aes_256
+          - gcm_aes_xpn_128
+          - gcm_aes_xpn_256
+        confidentiality:
+          description: "Encrypt or not. "
+          type: boolean
+          default: true
+          x-field-uid: 2
+        confidentiality_offset:
+          description: |-
+            Confidentiality offset.
+          type: string
+          default: zero
+          x-field-uid: 3
+          x-enum:
+            zero:
+              x-field-uid: 1
+            thirty:
+              x-field-uid: 2
+            fifty:
+              x-field-uid: 3
+          enum:
+          - zero
+          - thirty
+          - fifty
+        tx:
+          description: |-
+            Tx properties of SecY.
+          $ref: '#/components/schemas/Macsec.StaticKey.Tx'
+          x-field-uid: 4
+        rx:
+          description: |-
+            Rx properties of SecY.
+          $ref: '#/components/schemas/Macsec.StaticKey.Rx'
+          x-field-uid: 5
+    Macsec.StaticKey.RekeyMode:
+      description: |-
+        Rekey mode.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Rekey mode choices.
+          type: string
+          default: dont_rekey
+          x-field-uid: 1
+          x-enum:
+            dont_rekey:
+              x-field-uid: 1
+            timer_based:
+              x-field-uid: 2
+            pn_based:
+              x-field-uid: 3
+          enum:
+          - dont_rekey
+          - timer_based
+          - pn_based
+        timer_based:
+          description: |-
+            Container for timer based periodic rekey properties.
+          x-field-uid: 2
+          $ref: '#/components/schemas/Macsec.StaticKey.RekeyMode.TimerBased'
+    Macsec.StaticKey.RekeyMode.TimerBased:
+      description: |-
+        Timer based periodic rekey properties.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Periodic rekey attempt choices.
+          type: string
+          default: continuous
+          x-field-uid: 1
+          x-enum:
+            continuous:
+              x-field-uid: 1
+            fixed_count:
+              x-field-uid: 2
+          enum:
+          - continuous
+          - fixed_count
+        fixed_count:
+          description: |-
+            Fixed rekey attempts.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 10
+          x-field-uid: 2
+        interval:
+          description: |-
+            Periodic rekey interval (sec).
+          type: integer
+          format: uint32
+          minimum: 30
+          maximum: 65535
+          default: 300
+          x-field-uid: 3
+    Macsec.StaticKey.Sak:
+      description: |-
+        The container for SAK.
+      type: object
+      properties:
+        sak:
+          description: |-
+            Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending on the citpher suite chosen.
+          type: string
+          format: hex
+          minLength: 16
+          maxLength: 32
+          default: F123456789ABCDEF0123456789ABCDEF
+          x-field-uid: 1
+        ssci:
+          description: |-
+            4 bytes short SCI(SSCI) used in case of XPN cipher suites.
+          type: string
+          format: hex
+          minLength: 4
+          maxLength: 4
+          default: '00000001'
+          x-field-uid: 2
+        salt:
+          description: |-
+            12 bytes salt used in case of XPN cipher suites.
+          type: string
+          format: hex
+          minLength: 12
+          maxLength: 12
+          default: '000000000000000000000001'
+          x-field-uid: 3
+    Macsec.StaticKey.Tx:
+      description: |-
+        A container of static key Tx properties.
+      type: object
+      properties:
+        secure_channels:
+          description: |-
+            Tx secure channels.
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.StaticKey.TxSc'
+          x-field-uid: 1
+        rekey_mode:
+          $ref: '#/components/schemas/Macsec.StaticKey.RekeyMode'
+          x-field-uid: 2
+    Macsec.StaticKey.TxSc:
+      description: |-
+        Tx SC setting for static key.
+      type: object
+      properties:
+        system_id:
+          description: "System ID. "
+          type: string
+          format: mac
+          x-field-uid: 1
+        port_id:
+          description: "Port ID. "
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 1
+          x-field-uid: 2
+        saks:
+          description: |-
+            Tx SAK pool.
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.StaticKey.Sak'
+          x-field-uid: 3
+    Macsec.StaticKey.Rx:
+      description: |-
+        A container of static key Rx properties.
+      type: object
+      properties:
+        secure_channels:
+          description: |-
+            Rx secure channels.
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.StaticKey.RxSc'
+          x-field-uid: 1
+    Macsec.StaticKey.RxSc:
+      description: |-
+        Rx SC settings.
+      type: object
+      properties:
+        dut_sci_system_id:
+          description: "System ID in DUT SCI. "
+          type: string
+          format: mac
+          x-field-uid: 1
+        dut_sci_port_id:
+          description: "Port ID in DUT SCI. "
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 1
+          x-field-uid: 2
+        dut_msb_xpn:
+          description: |-
+            DUT MSB of XPN. The 32 most significant bits of the XPN that DUT will be using to construct the 64 bits XPN value when test starts.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 4294967295
+          default: 0
+          x-field-uid: 3
+        saks:
+          description: |-
+            Rx SAK pool.
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.StaticKey.Sak'
+          x-field-uid: 4
     Flow:
       description: |-
         A high level data plane traffic flow.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11021,9 +11021,9 @@ components:
         secure_entity:
           description: |-
             This contains the properties of Secure Entity (SecY).
-          $ref: '#/components/schemas/Macsec'
+          $ref: '#/components/schemas/SecureEntity'
           x-field-uid: 2
-    Macsec:
+    SecureEntity:
       description: |-
         Configuration of a Secure Entity (SecY).
       type: object
@@ -11040,14 +11040,14 @@ components:
         key_generation_protocol:
           description: |-
             This contains the properties of key generation protocol of Secure Entity (SecY).
-          $ref: '#/components/schemas/Macsec.KeyGenerationProtocol'
+          $ref: '#/components/schemas/SecureEntity.KeyGenerationProtocol'
           x-field-uid: 2
         data_plane:
           description: |-
             This contains the properties of data plane of Secure Entity (SecY).
-          $ref: '#/components/schemas/Macsec.DataPlane'
+          $ref: '#/components/schemas/SecureEntity.DataPlane'
           x-field-uid: 3
-    Macsec.KeyGenerationProtocol:
+    SecureEntity.KeyGenerationProtocol:
       description: |-
         Container of Key generation protocol configuration.
       type: object
@@ -11074,9 +11074,9 @@ components:
         static_key:
           description: |-
             Static key properties properties of SecY. Static key is used in absence MKA.
-          $ref: '#/components/schemas/Macsec.StaticKey'
+          $ref: '#/components/schemas/SecureEntity.StaticKey'
           x-field-uid: 3
-    Macsec.DataPlane:
+    SecureEntity.DataPlane:
       description: |-
         A container of data plane properties.
       type: object
@@ -11098,9 +11098,9 @@ components:
         encapsulation:
           description: |-
             A container of encapsulation properties for a secure entity(SecY).
-          $ref: '#/components/schemas/Macsec.DataPlane.Encapsulation'
+          $ref: '#/components/schemas/SecureEntity.DataPlane.Encapsulation'
           x-field-uid: 2
-    Macsec.DataPlane.Encapsulation:
+    SecureEntity.DataPlane.Encapsulation:
       description: |-
         A container of encapsulation properties for a secure entity(SecY).
       type: object
@@ -11108,19 +11108,19 @@ components:
         tx:
           description: |-
             Tx properties of SecY.
-          $ref: '#/components/schemas/Macsec.DataPlane.Tx'
+          $ref: '#/components/schemas/SecureEntity.DataPlane.Tx'
           x-field-uid: 1
         rx:
           description: |-
             Rx properties of SecY.
-          $ref: '#/components/schemas/Macsec.DataPlane.Rx'
+          $ref: '#/components/schemas/SecureEntity.DataPlane.Rx'
           x-field-uid: 2
         crypto_engine:
           description: |-
             Crypto engine properties of SecY.
-          $ref: '#/components/schemas/Macsec.CryptoEngine'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine'
           x-field-uid: 3
-    Macsec.DataPlane.Tx:
+    SecureEntity.DataPlane.Tx:
       description: |-
         A container of Tx properties of SecY.
       type: object
@@ -11137,7 +11137,7 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
-    Macsec.DataPlane.Rx:
+    SecureEntity.DataPlane.Rx:
       description: |-
         A container for Rx settings of SecY.
       type: object
@@ -11154,7 +11154,7 @@ components:
           minimum: 1
           default: 1
           x-field-uid: 2
-    Macsec.CryptoEngine:
+    SecureEntity.CryptoEngine:
       description: |-
         A container of crypto engine properties of a SecY.
       type: object
@@ -11174,12 +11174,12 @@ components:
           - encrypt_only
           - encrypt_decrypt
         encrypt_only:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly'
           x-field-uid: 2
         encrypt_decrypt:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt'
           x-field-uid: 3
-    Macsec.CryptoEngine.EncryptOnly:
+    SecureEntity.CryptoEngine.EncryptOnly:
       description: |-
         The container for encrypt only engine configuration.
       type: object
@@ -11187,12 +11187,12 @@ components:
         secure_channels:
           type: array
           items:
-            $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc'
+            $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.TxSc'
           x-field-uid: 1
         traffic_options:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TrafficOptions'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.TrafficOptions'
           x-field-uid: 2
-    Macsec.CryptoEngine.EncryptDecrypt:
+    SecureEntity.CryptoEngine.EncryptDecrypt:
       description: |-
         The container for encrypt and decrypt engine configuration.
       type: object
@@ -11200,20 +11200,20 @@ components:
         secure_channels:
           type: array
           items:
-            $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc'
+            $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.TxSc'
           x-field-uid: 1
         hardware_acceleration:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
           x-field-uid: 2
-    Macsec.CryptoEngine.EncryptOnly.TxSc:
+    SecureEntity.CryptoEngine.EncryptOnly.TxSc:
       description: |-
         The container for Tx secure channel configuration.
       type: object
       properties:
         tx_pn:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc.TxPn'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.TxSc.TxPn'
           x-field-uid: 1
-    Macsec.CryptoEngine.EncryptOnly.TxSc.TxPn:
+    SecureEntity.CryptoEngine.EncryptOnly.TxSc.TxPn:
       description: |-
         Tx packet number(PN) configuration.
       type: object
@@ -11233,12 +11233,12 @@ components:
           - fixed_pn
           - incrementing_pn
         fixed:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.FixedPn'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.FixedPn'
           x-field-uid: 2
         incrementing:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.IncrementingPn'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.IncrementingPn'
           x-field-uid: 3
-    Macsec.CryptoEngine.EncryptOnly.FixedPn:
+    SecureEntity.CryptoEngine.EncryptOnly.FixedPn:
       description: |-
         Fixed packet number(PN) configuration.
       type: object
@@ -11262,7 +11262,7 @@ components:
           minimum: 1
           default: '0x0000000000000006'
           x-field-uid: 2
-    Macsec.CryptoEngine.EncryptOnly.IncrementingPn:
+    SecureEntity.CryptoEngine.EncryptOnly.IncrementingPn:
       description: |-
         Incrementing packet number(PN) configuration.
       type: object
@@ -11293,7 +11293,7 @@ components:
           minimum: 1
           default: '0x0000000000010000'
           x-field-uid: 3
-    Macsec.CryptoEngine.EncryptOnly.TrafficOptions:
+    SecureEntity.CryptoEngine.EncryptOnly.TrafficOptions:
       description: |-
         Encrypt only traffic options.
       type: object
@@ -11304,15 +11304,15 @@ components:
           type: boolean
           default: true
           x-field-uid: 1
-    Macsec.CryptoEngine.EncryptDecrypt.TxSc:
+    SecureEntity.CryptoEngine.EncryptDecrypt.TxSc:
       description: |-
         Secure channel configuration.
       type: object
       properties:
         tx_pn:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc.TxPn'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.TxSc.TxPn'
           x-field-uid: 1
-    Macsec.CryptoEngine.EncryptDecrypt.TxSc.TxPn:
+    SecureEntity.CryptoEngine.EncryptDecrypt.TxSc.TxPn:
       description: |-
         Starting packet number(PN) configuration.
       type: object
@@ -11335,7 +11335,7 @@ components:
           minimum: 1
           default: '0x0000000000000001'
           x-field-uid: 3
-    Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration:
+    SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration:
       description: |-
         Hardware acceleration configuration for offloading MACsec processing to hardware.
       type: object
@@ -11355,9 +11355,9 @@ components:
           - none
           - inline_crypto
         inline_crypto:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto'
           x-field-uid: 2
-    Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
+    SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
       description: |-
         Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
       type: object
@@ -11678,6 +11678,7 @@ components:
           description: |-
             Hours in HH format.
           type: integer
+          format: uint32
           minimum: 0
           default: 0
           x-field-uid: 1
@@ -11685,6 +11686,7 @@ components:
           description: |-
             Minutes in MM format.
           type: integer
+          format: uint32
           minimum: 0
           default: 0
           x-field-uid: 2
@@ -11718,6 +11720,7 @@ components:
           description: |-
             Day of the month in DD format.
           type: integer
+          format: uint32
           minimum: 1
           maximum: 31
           x-field-uid: 1
@@ -11725,6 +11728,7 @@ components:
           description: |-
             Month of the year in MM format.
           type: integer
+          format: uint32
           minimum: 1
           maximum: 12
           x-field-uid: 2
@@ -11732,6 +11736,7 @@ components:
           description: |-
             Year from the start of common era(CE) in YYYY format.
           type: integer
+          format: uint32
           minimum: 0
           maximum: 9999
           x-field-uid: 3
@@ -11739,6 +11744,7 @@ components:
           description: |-
             Hour of the day in HH format.
           type: integer
+          format: uint32
           minimum: 0
           maximum: 23
           x-field-uid: 4
@@ -11746,6 +11752,7 @@ components:
           description: |-
             Minute of the hour in MM format.
           type: integer
+          format: uint32
           minimum: 0
           maximum: 59
           x-field-uid: 5
@@ -11753,6 +11760,7 @@ components:
           description: |-
             Second of the minute in SS format.
           type: integer
+          format: uint32
           minimum: 0
           maximum: 59
           x-field-uid: 6
@@ -11949,7 +11957,7 @@ components:
           maximum: 4294967295
           default: 1
           x-field-uid: 4
-    Macsec.StaticKey:
+    SecureEntity.StaticKey:
       description: |-
         A container of static key properties for a secure entity(SecY). This configuration is applicable when no dynamic key management protocol i.e. MACsec key agreement(MKA) is configured. If MKA is configured, any static key configuration is not applicable.
       type: object
@@ -11999,14 +12007,14 @@ components:
         tx:
           description: |-
             Tx properties of SecY.
-          $ref: '#/components/schemas/Macsec.StaticKey.Tx'
+          $ref: '#/components/schemas/SecureEntity.StaticKey.Tx'
           x-field-uid: 4
         rx:
           description: |-
             Rx properties of SecY.
-          $ref: '#/components/schemas/Macsec.StaticKey.Rx'
+          $ref: '#/components/schemas/SecureEntity.StaticKey.Rx'
           x-field-uid: 5
-    Macsec.StaticKey.RekeyMode:
+    SecureEntity.StaticKey.RekeyMode:
       description: |-
         Rekey mode.
       type: object
@@ -12032,8 +12040,8 @@ components:
           description: |-
             Container for timer based periodic rekey properties.
           x-field-uid: 2
-          $ref: '#/components/schemas/Macsec.StaticKey.RekeyMode.TimerBased'
-    Macsec.StaticKey.RekeyMode.TimerBased:
+          $ref: '#/components/schemas/SecureEntity.StaticKey.RekeyMode.TimerBased'
+    SecureEntity.StaticKey.RekeyMode.TimerBased:
       description: |-
         Timer based periodic rekey properties.
       type: object
@@ -12070,7 +12078,7 @@ components:
           maximum: 65535
           default: 300
           x-field-uid: 3
-    Macsec.StaticKey.Sak:
+    SecureEntity.StaticKey.Sak:
       description: |-
         The container for SAK.
       type: object
@@ -12102,7 +12110,7 @@ components:
           maxLength: 24
           default: '000000000000000000000001'
           x-field-uid: 3
-    Macsec.StaticKey.Tx:
+    SecureEntity.StaticKey.Tx:
       description: |-
         A container of static key Tx properties.
       type: object
@@ -12112,12 +12120,12 @@ components:
             Tx secure channels.
           type: array
           items:
-            $ref: '#/components/schemas/Macsec.StaticKey.TxSc'
+            $ref: '#/components/schemas/SecureEntity.StaticKey.TxSc'
           x-field-uid: 1
         rekey_mode:
-          $ref: '#/components/schemas/Macsec.StaticKey.RekeyMode'
+          $ref: '#/components/schemas/SecureEntity.StaticKey.RekeyMode'
           x-field-uid: 2
-    Macsec.StaticKey.TxSc:
+    SecureEntity.StaticKey.TxSc:
       description: |-
         Tx SC setting for static key.
       type: object
@@ -12140,9 +12148,9 @@ components:
             Tx SAK pool.
           type: array
           items:
-            $ref: '#/components/schemas/Macsec.StaticKey.Sak'
+            $ref: '#/components/schemas/SecureEntity.StaticKey.Sak'
           x-field-uid: 3
-    Macsec.StaticKey.Rx:
+    SecureEntity.StaticKey.Rx:
       description: |-
         A container of static key Rx properties.
       type: object
@@ -12152,9 +12160,9 @@ components:
             Rx secure channels.
           type: array
           items:
-            $ref: '#/components/schemas/Macsec.StaticKey.RxSc'
+            $ref: '#/components/schemas/SecureEntity.StaticKey.RxSc'
           x-field-uid: 1
-    Macsec.StaticKey.RxSc:
+    SecureEntity.StaticKey.RxSc:
       description: |-
         Rx SC settings.
       type: object
@@ -12186,7 +12194,7 @@ components:
             Rx SAK pool.
           type: array
           items:
-            $ref: '#/components/schemas/Macsec.StaticKey.Sak'
+            $ref: '#/components/schemas/SecureEntity.StaticKey.Sak'
           x-field-uid: 4
     Flow:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11456,7 +11456,7 @@ components:
           x-field-uid: 3
         tx:
           description: |-
-            Tx Properties.
+            The Tx Properties.
           $ref: '#/components/schemas/Mka.Tx'
           x-field-uid: 4
     Mka.Basic:
@@ -11823,7 +11823,7 @@ components:
       properties:
         secure_channels:
           description: |-
-            Tx secure channels.
+            The Tx secure channels.
           type: array
           items:
             $ref: '#/components/schemas/Mka.TxSc'

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11578,7 +11578,7 @@ components:
           x-field-uid: 13
         psk_chain_start_time:
           description: |-
-            Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. The key start time will be relative to this value.
+            Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this time is set, the key start time will be relative to this value. Otherwise if this value is not set, key start time will be relative to test start time.
           $ref: '#/components/schemas/Mka.Basic.Time'
           x-field-uid: 14
     Mka.Basic.SupportedCipherSuites:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11658,18 +11658,37 @@ components:
           default: F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF
           x-field-uid: 2
         start_offset_time:
-          description: |-
-            Key start offset time in HH:MM. This is relative to key chain start time.
-          $ref: '#/components/schemas/Mka.Basic.OffsetTime'
+          description: ""
+          $ref: '#/components/schemas/Mka.Basic.StartOffsetTime'
           x-field-uid: 3
         end_offset_time:
-          description: |-
-            Key end offset time in HH:MM. This is relative to key chain start time.
-          $ref: '#/components/schemas/Mka.Basic.OffsetTime'
+          description: ""
+          $ref: '#/components/schemas/Mka.Basic.EndOffsetTime'
           x-field-uid: 4
-    Mka.Basic.OffsetTime:
+    Mka.Basic.StartOffsetTime:
       description: |-
-        Offset time.
+        Key start offset time in HH:MM. This is relative to key chain start time.
+      type: object
+      properties:
+        hh:
+          description: |-
+            Hours in HH format.
+          type: integer
+          format: uint32
+          minimum: 0
+          default: 0
+          x-field-uid: 1
+        mm:
+          description: |-
+            Minutes in MM format.
+          type: integer
+          format: uint32
+          minimum: 0
+          default: 0
+          x-field-uid: 2
+    Mka.Basic.EndOffsetTime:
+      description: |-
+        Key end offset time in HH:MM. This is relative to key chain start time. A value of "00:00" makes the key valid for lifetime.
       type: object
       properties:
         hh:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11164,24 +11164,18 @@ components:
       properties:
         choice:
           description: |-
-            Engine type based on encryption and/ or decryption capability. Supported types: 1) encrypt_only - engine can only encrypt transmitted packets but such engine cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent. 2) encrypt_decrypt - engine can both encrypt transmitted packets and decrypt packets on arrival. Such engine can have hardware acceleration for faster encryption/ ddecryption. As both encryption and decryption are possible, stateful (e.g. TCP) traffic can also be sent/ received.
+            Engine type based on encryption and/ or decryption capability. Supported types: encrypt_only - engine can only encrypt transmitted packets but such engine cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent.
           type: string
           default: encrypt_only
           x-field-uid: 1
           x-enum:
             encrypt_only:
               x-field-uid: 1
-            encrypt_decrypt:
-              x-field-uid: 2
           enum:
           - encrypt_only
-          - encrypt_decrypt
         encrypt_only:
           $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly'
           x-field-uid: 2
-        encrypt_decrypt:
-          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt'
-          x-field-uid: 3
     SecureEntity.CryptoEngine.EncryptOnly:
       description: |-
         The container for encrypt only engine configuration.
@@ -11194,19 +11188,6 @@ components:
           x-field-uid: 1
         traffic_options:
           $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.TrafficOptions'
-          x-field-uid: 2
-    SecureEntity.CryptoEngine.EncryptDecrypt:
-      description: |-
-        The container for encrypt and decrypt engine configuration.
-      type: object
-      properties:
-        secure_channels:
-          type: array
-          items:
-            $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.TxSc'
-          x-field-uid: 1
-        hardware_acceleration:
-          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
           x-field-uid: 2
     SecureEntity.CryptoEngine.EncryptOnly.TxSc:
       description: |-
@@ -11307,130 +11288,6 @@ components:
           type: boolean
           default: true
           x-field-uid: 1
-    SecureEntity.CryptoEngine.EncryptDecrypt.TxSc:
-      description: |-
-        Secure channel configuration.
-      type: object
-      properties:
-        tx_pn:
-          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.TxSc.TxPn'
-          x-field-uid: 1
-    SecureEntity.CryptoEngine.EncryptDecrypt.TxSc.TxPn:
-      description: |-
-        Starting packet number(PN) configuration.
-      type: object
-      properties:
-        starting_pn:
-          description: |-
-            Initial Tx packet number(PN).
-          type: integer
-          format: uint32
-          minimum: 1
-          default: 1
-          x-field-uid: 1
-        starting_xpn:
-          description: |-
-            The starting extended packet number(XPN).
-          type: string
-          format: hex
-          minLength: 1
-          maxLength: 16
-          minimum: 1
-          default: '0x0000000000000001'
-          x-field-uid: 3
-    SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration:
-      description: |-
-        Hardware acceleration configuration for offloading MACsec processing to hardware.
-      type: object
-      properties:
-        choice:
-          description: |-
-            Hardware acceleration types.
-          type: string
-          default: none
-          x-field-uid: 1
-          x-enum:
-            none:
-              x-field-uid: 1
-            inline_crypto:
-              x-field-uid: 2
-          enum:
-          - none
-          - inline_crypto
-        inline_crypto:
-          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto'
-          x-field-uid: 2
-    SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
-      description: |-
-        Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
-      type: object
-      properties:
-        rx_sectag_offset:
-          description: |-
-            Offset of Rx secTAG from the first byte in packet.
-          type: integer
-          format: uint32
-          default: 12
-          x-field-uid: 1
-        type_of_ca:
-          description: |-
-            Type of connectivity association(CA).
-          type: string
-          x-field-uid: 2
-          x-enum:
-            pairwise_ca:
-              x-field-uid: 1
-            group_ca_single_dut:
-              x-field-uid: 2
-            group_ca_multipe_duts:
-              x-field-uid: 3
-          enum:
-          - pairwise_ca
-          - group_ca_single_dut
-          - group_ca_multipe_duts
-        max_ca_count:
-          description: |-
-            The maximum number of CAs configured on the port. The maximum count supported per port is 256 for Pair-wise CA, each CA having one MACsec device.
-          type: integer
-          format: uint32
-          minimum: 1
-          maximum: 256
-          default: 256
-          x-field-uid: 3
-        max_dut_tx_sc_per_ca:
-          description: |-
-            The maximum number of DUT transmit SCs that can be supported per CA. The count should be number of Tx SCs supported by the DUT per CA, multiplied by number of DUTs in the CA in case of group CA with multiple DUTs scenario.
-          type: integer
-          format: uint32
-          minimum: 1
-          maximum: 256
-          default: 1
-          x-field-uid: 4
-        max_device_per_ca:
-          description: |-
-            The maximum number of MACsec devices at test port that can be supported on each CA. This number is calculated automatically based on the values configured for Max CA Count and Max DUT Tx SC Per CA. Number of MACsec devices at test port should be configured accordingly.
-          type: integer
-          format: uint32
-          minimum: 1
-          default: 256
-          x-field-uid: 5
-        rx_sc_identifying_field:
-          description: |-
-            The field based on which secure channel(SC) will be identified by the receiving port. Supported fields are:- - 1) source MAC - identify SC based on source MAC field. 2) SCI system ID - identify SC bbased on SCI system ID field. 3) SCI port ID - identify based on SCI port ID field.
-          type: string
-          default: source_mac
-          x-field-uid: 6
-          x-enum:
-            source_mac:
-              x-field-uid: 1
-            sci_sytem_id:
-              x-field-uid: 2
-            sci_port_id:
-              x-field-uid: 3
-          enum:
-          - source_mac
-          - sci_sytem_id
-          - sci_port_id
     Mka:
       description: |-
         Configuration of a MKA Key Agreement Entity (KaY). Reference https://1.ieee802.org/security/802-1x/.
@@ -11687,6 +11544,7 @@ components:
           type: integer
           format: uint32
           minimum: 0
+          maximum: 59
           default: 0
           x-field-uid: 2
     Mka.Basic.EndOffsetTime:
@@ -11708,6 +11566,7 @@ components:
           type: integer
           format: uint32
           minimum: 0
+          maximum: 59
           default: 0
           x-field-uid: 2
     Mka.Basic.PskChainStartTime:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11164,7 +11164,7 @@ components:
       properties:
         choice:
           description: |-
-            Engine type based on encryption and/ or decryption capability. Supported types: encrypt_only - engine can only encrypt transmitted packets but such engine cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent.
+            Engine type based on encryption and/ or decryption capability. Supported types: encrypt_only - engine can only encrypt transmitted packets but it cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent.
           type: string
           default: encrypt_only
           x-field-uid: 1

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11676,14 +11676,14 @@ components:
       properties:
         hh:
           description: |-
-            Hours in hh.
+            Hours in HH format.
           type: integer
           minimum: 0
           default: 0
           x-field-uid: 1
         mm:
           description: |-
-            Minutes in mm.
+            Minutes in MM format.
           type: integer
           minimum: 0
           default: 0
@@ -11737,21 +11737,21 @@ components:
           x-field-uid: 3
         hour:
           description: |-
-            Hour of the day in hh format.
+            Hour of the day in HH format.
           type: integer
           minimum: 0
           maximum: 23
           x-field-uid: 4
         minute:
           description: |-
-            Minute of the hour in mm format.
+            Minute of the hour in MM format.
           type: integer
           minimum: 0
           maximum: 59
           x-field-uid: 5
         second:
           description: |-
-            Second of the minute in ss format.
+            Second of the minute in SS format.
           type: integer
           minimum: 0
           maximum: 59

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11577,9 +11577,7 @@ components:
           $ref: '#/components/schemas/Mka.Basic.RekeyMode'
           x-field-uid: 13
         psk_chain_start_time:
-          description: |-
-            Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this time is set, the key start time will be relative to this value. Otherwise if this value is not set, key start time will be relative to test start time.
-          $ref: '#/components/schemas/Mka.Basic.Time'
+          $ref: '#/components/schemas/Mka.Basic.PskChainStartTime'
           x-field-uid: 14
     Mka.Basic.SupportedCipherSuites:
       description: |-
@@ -11690,7 +11688,9 @@ components:
           minimum: 0
           default: 0
           x-field-uid: 2
-    Mka.Basic.Time:
+    Mka.Basic.PskChainStartTime:
+      description: |-
+        Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this time is set, the key start time will be relative to this value. Otherwise if this value is not set, key start time will be relative to test start time.
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11456,7 +11456,7 @@ components:
           x-field-uid: 3
         tx:
           description: |-
-            The Tx Properties.
+            Tx Properties.
           $ref: '#/components/schemas/Mka.Tx'
           x-field-uid: 4
     Mka.Basic:
@@ -11823,7 +11823,7 @@ components:
       properties:
         secure_channels:
           description: |-
-            The Tx secure channels.
+            Tx secure channels.
           type: array
           items:
             $ref: '#/components/schemas/Mka.TxSc'

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -11006,7 +11006,7 @@ components:
       type: object
       required:
       - eth_name
-      - secy
+      - secure_entity
       properties:
         eth_name:
           description: |
@@ -11018,7 +11018,7 @@ components:
           x-constraint:
           - /components/schemas/Device.Ethernet/properties/name
           x-field-uid: 1
-        secy:
+        secure_entity:
           description: |-
             This contains the properties of Secure Entity (SecY).
           $ref: '#/components/schemas/Macsec'
@@ -11066,7 +11066,7 @@ components:
           enum:
           - mka
           - static_key
-        kay:
+        mka:
           description: |-
             This contains the properties of Key Agreement Entity (KaY) in MKA supplicant.
           x-field-uid: 2
@@ -11078,7 +11078,31 @@ components:
           x-field-uid: 3
     Macsec.DataPlane:
       description: |-
-        A container of data plane properties for a secure entity(SecY).
+        A container of data plane properties.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Choose "encapsulation" so that data packets are sent with MACsec encapsulation. Choose "no_encapsulation" so that data packets are sent without MACsec encapsulation.
+          type: string
+          default: encapsulation
+          x-field-uid: 1
+          x-enum:
+            encapsulation:
+              x-field-uid: 1
+            no_encapsulation:
+              x-field-uid: 2
+          enum:
+          - encapsulation
+          - no_encapsulation
+        encapsulation:
+          description: |-
+            A container of encapsulation properties for a secure entity(SecY).
+          $ref: '#/components/schemas/Macsec.DataPlane.Encapsulation'
+          x-field-uid: 2
+    Macsec.DataPlane.Encapsulation:
+      description: |-
+        A container of encapsulation properties for a secure entity(SecY).
       type: object
       properties:
         tx:
@@ -11160,8 +11184,10 @@ components:
         The container for encrypt only engine configuration.
       type: object
       properties:
-        secure_channel:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc'
+        secure_channels:
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc'
           x-field-uid: 1
         traffic_options:
           $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TrafficOptions'
@@ -11171,8 +11197,10 @@ components:
         The container for encrypt and decrypt engine configuration.
       type: object
       properties:
-        secure_channel:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc'
+        secure_channels:
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc'
           x-field-uid: 1
         hardware_acceleration:
           $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
@@ -11407,7 +11435,7 @@ components:
       required:
       - name
       - basic
-      - txscs
+      - tx
       properties:
         name:
           x-field-uid: 1
@@ -11426,12 +11454,12 @@ components:
             Key server attributes.
           $ref: '#/components/schemas/Mka.KeyServer'
           x-field-uid: 3
-        txscs:
+        tx:
           description: |-
-            Properties for Tx secure channels.
+            Tx Properties.
           type: array
           items:
-            $ref: '#/components/schemas/Mka.TxSc'
+            $ref: '#/components/schemas/Mka.Tx'
           x-field-uid: 4
     Mka.Basic:
       description: |-
@@ -11499,44 +11527,61 @@ components:
             Supported Cipher Suites.
           x-field-uid: 6
           $ref: '#/components/schemas/Mka.Basic.SupportedCipherSuites'
+        eapol_ethernet_type:
+          description: |-
+            EAPOL Ethernet type.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 4
+          default: '0x888E'
+          x-field-uid: 7
         mka_version:
           description: |-
             MKA Version.
           type: integer
           format: uint32
           default: 3
-          x-field-uid: 7
+          x-field-uid: 8
         mka_hello_time:
           description: |-
             MKA Hello Time (msec).
           type: integer
           format: uint32
           default: 2000
-          x-field-uid: 8
+          x-field-uid: 9
         mka_life_time:
           description: |-
             MKA Life Time (sec).
           type: integer
           format: uint32
           default: 6
-          x-field-uid: 9
+          x-field-uid: 10
         send_icv_indicatior_in_mkpdu:
           description: |-
             Send ICV Indicator in MKPDU.
           type: boolean
           default: true
-          x-field-uid: 10
+          x-field-uid: 11
         delay_protect:
           description: |-
             Delay Protect.
           type: boolean
           default: true
-          x-field-uid: 11
+          x-field-uid: 12
         rekey_mode:
           description: |-
             Rekey Mode.
-          x-field-uid: 12
+          x-field-uid: 13
           $ref: '#/components/schemas/Mka.Basic.RekeyMode'
+        psk_chain_start_time:
+          description: |-
+            Pre-shared key(PSK) chain start time (in UTC - DD-MM-YYYY HH:MM:SS). The key start time will be relative to this value.
+          type: string
+          minLength: 19
+          maxLength: 19
+          default: 00-00-0000 00:00:00
+          x-field-uid: 14
     Mka.Basic.SupportedCipherSuites:
       description: |-
         The container for supported cipher suites.
@@ -11771,6 +11816,20 @@ components:
           maxLength: 8
           default: C000000000000000
           x-field-uid: 6
+    Mka.Tx:
+      description: |-
+        A container of Tx properties.
+      type: object
+      required:
+      - secure_channels
+      properties:
+        secure_channels:
+          description: |-
+            Tx secure channels.
+          type: array
+          items:
+            $ref: '#/components/schemas/Mka.TxSc'
+          x-field-uid: 1
     Mka.TxSc:
       description: |-
         Tx secure channel(SC) properties.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -10988,7 +10988,7 @@ components:
           x-field-uid: 2
     Device.Macsec:
       description: |-
-        A container of properties for a MACsec capable device.
+        A container of properties for a MACsec capable device. Reference https://1.ieee802.org/security/802-1ae/.
       type: object
       required:
       - ethernet_interfaces
@@ -11359,7 +11359,7 @@ components:
           x-field-uid: 2
     Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
       description: |-
-        Inline cryto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
+        Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
       type: object
       properties:
         rx_sectag_offset:
@@ -11430,7 +11430,7 @@ components:
           - sci_port_id
     Mka:
       description: |-
-        Configuration of a Key Agreement Entity (KaY).
+        Configuration of a MKA Key Agreement Entity (KaY). Reference https://1.ieee802.org/security/802-1x/.
       type: object
       required:
       - name
@@ -11546,6 +11546,8 @@ components:
             MKA Hello Time (msec).
           type: integer
           format: uint32
+          minimum: 500
+          maximum: 10000
           default: 2000
           x-field-uid: 9
         mka_life_time:
@@ -11553,6 +11555,8 @@ components:
             MKA Life Time (sec).
           type: integer
           format: uint32
+          minimum: 1
+          maximum: 255
           default: 6
           x-field-uid: 10
         send_icv_indicatior_in_mkpdu:
@@ -11563,7 +11567,7 @@ components:
           x-field-uid: 11
         delay_protect:
           description: |-
-            Delay Protect.
+            Delay Protect or not. When delay protect is enabled, it guards against delaying the delivery of MACsec encrypted frames by an attacker to the receipient.
           type: boolean
           default: true
           x-field-uid: 12
@@ -11658,15 +11662,15 @@ components:
           maxLength: 64
           default: F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF
           x-field-uid: 2
-        start_time:
+        start_offset_time:
           description: |-
-            Key start time in HH:MM. This is relative to key chain start time.
+            Key start offset time in HH:MM. This is relative to key chain start time.
           type: string
           default: 00:00
           x-field-uid: 3
-        end_time:
+        end_offset_time:
           description: |-
-            Key end time in HH:MM. This is relative to key chain start time.
+            Key end offset time in HH:MM. This is relative to key chain start time.
           type: string
           default: 00:00
           x-field-uid: 4
@@ -17114,11 +17118,11 @@ components:
               x-field-uid: 13
             ospfv2_metrics:
               x-field-uid: 14
-            macsec_metrics:
-              x-field-uid: 15
-            mka_metrics:
-              x-field-uid: 16
             convergence_metrics:
+              x-field-uid: 15
+            macsec_metrics:
+              x-field-uid: 16
+            mka_metrics:
               x-field-uid: 17
           enum:
           - flow_metrics
@@ -17135,9 +17139,9 @@ components:
           - dhcpv6_client
           - dhcpv6_server
           - ospfv2_metrics
+          - convergence_metrics
           - macsec_metrics
           - mka_metrics
-          - convergence_metrics
         port_metrics:
           type: array
           items:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8221,11 +8221,11 @@ message DeviceMacsecEthernetInterface {
 
   // This contains the properties of Secure Entity (SecY).
   // required = true
-  Macsec secure_entity = 2;
+  SecureEntity secure_entity = 2;
 }
 
 // Configuration of a Secure Entity (SecY).
-message Macsec {
+message SecureEntity {
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
   // objects.
@@ -8233,14 +8233,14 @@ message Macsec {
   optional string name = 1;
 
   // This contains the properties of key generation protocol of Secure Entity (SecY).
-  MacsecKeyGenerationProtocol key_generation_protocol = 2;
+  SecureEntityKeyGenerationProtocol key_generation_protocol = 2;
 
   // This contains the properties of data plane of Secure Entity (SecY).
-  MacsecDataPlane data_plane = 3;
+  SecureEntityDataPlane data_plane = 3;
 }
 
 // Container of Key generation protocol configuration.
-message MacsecKeyGenerationProtocol {
+message SecureEntityKeyGenerationProtocol {
 
   message Choice {
     enum Enum {
@@ -8259,11 +8259,11 @@ message MacsecKeyGenerationProtocol {
   Mka mka = 2;
 
   // Static key properties properties of SecY. Static key is used in absence MKA.
-  MacsecStaticKey static_key = 3;
+  SecureEntityStaticKey static_key = 3;
 }
 
 // A container of data plane properties.
-message MacsecDataPlane {
+message SecureEntityDataPlane {
 
   message Choice {
     enum Enum {
@@ -8278,24 +8278,24 @@ message MacsecDataPlane {
   optional Choice.Enum choice = 1;
 
   // A container of encapsulation properties for a secure entity(SecY).
-  MacsecDataPlaneEncapsulation encapsulation = 2;
+  SecureEntityDataPlaneEncapsulation encapsulation = 2;
 }
 
 // A container of encapsulation properties for a secure entity(SecY).
-message MacsecDataPlaneEncapsulation {
+message SecureEntityDataPlaneEncapsulation {
 
   // Tx properties of SecY.
-  MacsecDataPlaneTx tx = 1;
+  SecureEntityDataPlaneTx tx = 1;
 
   // Rx properties of SecY.
-  MacsecDataPlaneRx rx = 2;
+  SecureEntityDataPlaneRx rx = 2;
 
   // Crypto engine properties of SecY.
-  MacsecCryptoEngine crypto_engine = 3;
+  SecureEntityCryptoEngine crypto_engine = 3;
 }
 
 // A container of Tx properties of SecY.
-message MacsecDataPlaneTx {
+message SecureEntityDataPlaneTx {
 
   // End station on not.
   // default = False
@@ -8307,7 +8307,7 @@ message MacsecDataPlaneTx {
 }
 
 // A container for Rx settings of SecY.
-message MacsecDataPlaneRx {
+message SecureEntityDataPlaneRx {
 
   // Enable replay protection on not.
   // default = False
@@ -8319,7 +8319,7 @@ message MacsecDataPlaneRx {
 }
 
 // A container of crypto engine properties of a SecY.
-message MacsecCryptoEngine {
+message SecureEntityCryptoEngine {
 
   message Choice {
     enum Enum {
@@ -8340,41 +8340,41 @@ message MacsecCryptoEngine {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  MacsecCryptoEngineEncryptOnly encrypt_only = 2;
+  SecureEntityCryptoEngineEncryptOnly encrypt_only = 2;
 
   // Description missing in models
-  MacsecCryptoEngineEncryptDecrypt encrypt_decrypt = 3;
+  SecureEntityCryptoEngineEncryptDecrypt encrypt_decrypt = 3;
 }
 
 // The container for encrypt only engine configuration.
-message MacsecCryptoEngineEncryptOnly {
+message SecureEntityCryptoEngineEncryptOnly {
 
   // Description missing in models
-  repeated MacsecCryptoEngineEncryptOnlyTxSc secure_channels = 1;
+  repeated SecureEntityCryptoEngineEncryptOnlyTxSc secure_channels = 1;
 
   // Description missing in models
-  MacsecCryptoEngineEncryptOnlyTrafficOptions traffic_options = 2;
+  SecureEntityCryptoEngineEncryptOnlyTrafficOptions traffic_options = 2;
 }
 
 // The container for encrypt and decrypt engine configuration.
-message MacsecCryptoEngineEncryptDecrypt {
+message SecureEntityCryptoEngineEncryptDecrypt {
 
   // Description missing in models
-  repeated MacsecCryptoEngineEncryptDecryptTxSc secure_channels = 1;
+  repeated SecureEntityCryptoEngineEncryptDecryptTxSc secure_channels = 1;
 
   // Description missing in models
-  MacsecCryptoEngineEncryptDecryptHardwareAcceleration hardware_acceleration = 2;
+  SecureEntityCryptoEngineEncryptDecryptHardwareAcceleration hardware_acceleration = 2;
 }
 
 // The container for Tx secure channel configuration.
-message MacsecCryptoEngineEncryptOnlyTxSc {
+message SecureEntityCryptoEngineEncryptOnlyTxSc {
 
   // Description missing in models
-  MacsecCryptoEngineEncryptOnlyTxScTxPn tx_pn = 1;
+  SecureEntityCryptoEngineEncryptOnlyTxScTxPn tx_pn = 1;
 }
 
 // Tx packet number(PN) configuration.
-message MacsecCryptoEngineEncryptOnlyTxScTxPn {
+message SecureEntityCryptoEngineEncryptOnlyTxScTxPn {
 
   message Choice {
     enum Enum {
@@ -8391,14 +8391,14 @@ message MacsecCryptoEngineEncryptOnlyTxScTxPn {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  MacsecCryptoEngineEncryptOnlyFixedPn fixed = 2;
+  SecureEntityCryptoEngineEncryptOnlyFixedPn fixed = 2;
 
   // Description missing in models
-  MacsecCryptoEngineEncryptOnlyIncrementingPn incrementing = 3;
+  SecureEntityCryptoEngineEncryptOnlyIncrementingPn incrementing = 3;
 }
 
 // Fixed packet number(PN) configuration.
-message MacsecCryptoEngineEncryptOnlyFixedPn {
+message SecureEntityCryptoEngineEncryptOnlyFixedPn {
 
   // Fixed Tx packet number(PN). 4 bytes PN with which all packets will be sent out.
   // default = 6
@@ -8411,7 +8411,7 @@ message MacsecCryptoEngineEncryptOnlyFixedPn {
 }
 
 // Incrementing packet number(PN) configuration.
-message MacsecCryptoEngineEncryptOnlyIncrementingPn {
+message SecureEntityCryptoEngineEncryptOnlyIncrementingPn {
 
   // Count of packet numbers in series.
   // default = 100
@@ -8427,7 +8427,7 @@ message MacsecCryptoEngineEncryptOnlyIncrementingPn {
 }
 
 // Encrypt only traffic options.
-message MacsecCryptoEngineEncryptOnlyTrafficOptions {
+message SecureEntityCryptoEngineEncryptOnlyTrafficOptions {
 
   // Send gratuitous ARP or not.
   // default = True
@@ -8435,14 +8435,14 @@ message MacsecCryptoEngineEncryptOnlyTrafficOptions {
 }
 
 // Secure channel configuration.
-message MacsecCryptoEngineEncryptDecryptTxSc {
+message SecureEntityCryptoEngineEncryptDecryptTxSc {
 
   // Description missing in models
-  MacsecCryptoEngineEncryptDecryptTxScTxPn tx_pn = 1;
+  SecureEntityCryptoEngineEncryptDecryptTxScTxPn tx_pn = 1;
 }
 
 // Starting packet number(PN) configuration.
-message MacsecCryptoEngineEncryptDecryptTxScTxPn {
+message SecureEntityCryptoEngineEncryptDecryptTxScTxPn {
 
   // Initial Tx packet number(PN).
   // default = 1
@@ -8454,7 +8454,7 @@ message MacsecCryptoEngineEncryptDecryptTxScTxPn {
 }
 
 // Hardware acceleration configuration for offloading MACsec processing to hardware.
-message MacsecCryptoEngineEncryptDecryptHardwareAcceleration {
+message SecureEntityCryptoEngineEncryptDecryptHardwareAcceleration {
 
   message Choice {
     enum Enum {
@@ -8468,13 +8468,13 @@ message MacsecCryptoEngineEncryptDecryptHardwareAcceleration {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  MacsecCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto inline_crypto = 2;
+  SecureEntityCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto inline_crypto = 2;
 }
 
 // Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware.
 // Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated
 // in MACsec header on transmit.
-message MacsecCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto {
+message SecureEntityCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto {
 
   // Offset of Rx secTAG from the first byte in packet.
   // default = 12
@@ -8682,11 +8682,11 @@ message MkaBasicOffsetTime {
 
   // Hours in HH format.
   // default = 0
-  optional int32 hh = 1;
+  optional uint32 hh = 1;
 
   // Minutes in MM format.
   // default = 0
-  optional int32 mm = 2;
+  optional uint32 mm = 2;
 }
 
 // Absolute time in a timezone.
@@ -8710,22 +8710,22 @@ message MkaBasicTime {
 message MkaBasicTimeUtc {
 
   // Day of the month in DD format.
-  optional int32 day = 1;
+  optional uint32 day = 1;
 
   // Month of the year in MM format.
-  optional int32 month = 2;
+  optional uint32 month = 2;
 
   // Year from the start of common era(CE) in YYYY format.
-  optional int32 year = 3;
+  optional uint32 year = 3;
 
   // Hour of the day in HH format.
-  optional int32 hour = 4;
+  optional uint32 hour = 4;
 
   // Minute of the hour in MM format.
-  optional int32 minute = 5;
+  optional uint32 minute = 5;
 
   // Second of the minute in SS format.
-  optional int32 second = 6;
+  optional uint32 second = 6;
 }
 
 // Rekey mode.
@@ -8846,7 +8846,7 @@ message MkaTxSc {
 // A container of static key properties for a secure entity(SecY). This configuration
 // is applicable when no dynamic key management protocol i.e. MACsec key agreement(MKA)
 // is configured. If MKA is configured, any static key configuration is not applicable.
-message MacsecStaticKey {
+message SecureEntityStaticKey {
 
   message CipherSuite {
     enum Enum {
@@ -8879,14 +8879,14 @@ message MacsecStaticKey {
   optional ConfidentialityOffset.Enum confidentiality_offset = 3;
 
   // Tx properties of SecY.
-  MacsecStaticKeyTx tx = 4;
+  SecureEntityStaticKeyTx tx = 4;
 
   // Rx properties of SecY.
-  MacsecStaticKeyRx rx = 5;
+  SecureEntityStaticKeyRx rx = 5;
 }
 
 // Rekey mode.
-message MacsecStaticKeyRekeyMode {
+message SecureEntityStaticKeyRekeyMode {
 
   message Choice {
     enum Enum {
@@ -8901,11 +8901,11 @@ message MacsecStaticKeyRekeyMode {
   optional Choice.Enum choice = 1;
 
   // Container for timer based periodic rekey properties.
-  MacsecStaticKeyRekeyModeTimerBased timer_based = 2;
+  SecureEntityStaticKeyRekeyModeTimerBased timer_based = 2;
 }
 
 // Timer based periodic rekey properties.
-message MacsecStaticKeyRekeyModeTimerBased {
+message SecureEntityStaticKeyRekeyModeTimerBased {
 
   message Choice {
     enum Enum {
@@ -8928,7 +8928,7 @@ message MacsecStaticKeyRekeyModeTimerBased {
 }
 
 // The container for SAK.
-message MacsecStaticKeySak {
+message SecureEntityStaticKeySak {
 
   // Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending
   // on the chosen cipher suite.
@@ -8945,17 +8945,17 @@ message MacsecStaticKeySak {
 }
 
 // A container of static key Tx properties.
-message MacsecStaticKeyTx {
+message SecureEntityStaticKeyTx {
 
   // Tx secure channels.
-  repeated MacsecStaticKeyTxSc secure_channels = 1;
+  repeated SecureEntityStaticKeyTxSc secure_channels = 1;
 
   // Description missing in models
-  MacsecStaticKeyRekeyMode rekey_mode = 2;
+  SecureEntityStaticKeyRekeyMode rekey_mode = 2;
 }
 
 // Tx SC setting for static key.
-message MacsecStaticKeyTxSc {
+message SecureEntityStaticKeyTxSc {
 
   // System ID.
   optional string system_id = 1;
@@ -8965,18 +8965,18 @@ message MacsecStaticKeyTxSc {
   optional uint32 port_id = 2;
 
   // Tx SAK pool.
-  repeated MacsecStaticKeySak saks = 3;
+  repeated SecureEntityStaticKeySak saks = 3;
 }
 
 // A container of static key Rx properties.
-message MacsecStaticKeyRx {
+message SecureEntityStaticKeyRx {
 
   // Rx secure channels.
-  repeated MacsecStaticKeyRxSc secure_channels = 1;
+  repeated SecureEntityStaticKeyRxSc secure_channels = 1;
 }
 
 // Rx SC settings.
-message MacsecStaticKeyRxSc {
+message SecureEntityStaticKeyRxSc {
 
   // System ID in DUT SCI.
   optional string dut_sci_system_id = 1;
@@ -8991,7 +8991,7 @@ message MacsecStaticKeyRxSc {
   optional uint32 dut_msb_xpn = 3;
 
   // Rx SAK pool.
-  repeated MacsecStaticKeySak saks = 4;
+  repeated SecureEntityStaticKeySak saks = 4;
 }
 
 // A high level data plane traffic flow.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8221,7 +8221,7 @@ message DeviceMacsecEthernetInterface {
 
   // This contains the properties of Secure Entity (SecY).
   // required = true
-  Macsec secy = 2;
+  Macsec secure_entity = 2;
 }
 
 // Configuration of a Secure Entity (SecY).
@@ -8256,14 +8256,33 @@ message MacsecKeyGenerationProtocol {
   optional Choice.Enum choice = 1;
 
   // This contains the properties of Key Agreement Entity (KaY) in MKA supplicant.
-  Mka kay = 2;
+  Mka mka = 2;
 
   // Static key properties properties of SecY. Static key is used in absence MKA.
   MacsecStaticKey static_key = 3;
 }
 
-// A container of data plane properties for a secure entity(SecY).
+// A container of data plane properties.
 message MacsecDataPlane {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      encapsulation = 1;
+      no_encapsulation = 2;
+    }
+  }
+  // Choose encapsulation so that data packets are sent with MACsec encapsulation. Choose
+  // no_encapsulation so that data packets are sent without MACsec encapsulation.
+  // default = Choice.Enum.encapsulation
+  optional Choice.Enum choice = 1;
+
+  // A container of encapsulation properties for a secure entity(SecY).
+  MacsecDataPlaneEncapsulation encapsulation = 2;
+}
+
+// A container of encapsulation properties for a secure entity(SecY).
+message MacsecDataPlaneEncapsulation {
 
   // Tx properties of SecY.
   MacsecDataPlaneTx tx = 1;
@@ -8331,7 +8350,7 @@ message MacsecCryptoEngine {
 message MacsecCryptoEngineEncryptOnly {
 
   // Description missing in models
-  MacsecCryptoEngineEncryptOnlyTxSc secure_channel = 1;
+  repeated MacsecCryptoEngineEncryptOnlyTxSc secure_channels = 1;
 
   // Description missing in models
   MacsecCryptoEngineEncryptOnlyTrafficOptions traffic_options = 2;
@@ -8341,7 +8360,7 @@ message MacsecCryptoEngineEncryptOnly {
 message MacsecCryptoEngineEncryptDecrypt {
 
   // Description missing in models
-  MacsecCryptoEngineEncryptDecryptTxSc secure_channel = 1;
+  repeated MacsecCryptoEngineEncryptDecryptTxSc secure_channels = 1;
 
   // Description missing in models
   MacsecCryptoEngineEncryptDecryptHardwareAcceleration hardware_acceleration = 2;
@@ -8521,8 +8540,8 @@ message Mka {
   // Key server attributes.
   MkaKeyServer key_server = 3;
 
-  // Properties for Tx secure channels.
-  repeated MkaTxSc txscs = 4;
+  // Tx Properties.
+  repeated MkaTx tx = 4;
 }
 
 // A container of basic properties for a KaY.
@@ -8567,28 +8586,37 @@ message MkaBasic {
   // Supported Cipher Suites.
   MkaBasicSupportedCipherSuites supported_cipher_suites = 6;
 
+  // EAPOL Ethernet type.
+  // default = 0x888E
+  optional string eapol_ethernet_type = 7;
+
   // MKA Version.
   // default = 3
-  optional uint32 mka_version = 7;
+  optional uint32 mka_version = 8;
 
   // MKA Hello Time (msec).
   // default = 2000
-  optional uint32 mka_hello_time = 8;
+  optional uint32 mka_hello_time = 9;
 
   // MKA Life Time (sec).
   // default = 6
-  optional uint32 mka_life_time = 9;
+  optional uint32 mka_life_time = 10;
 
   // Send ICV Indicator in MKPDU.
   // default = True
-  optional bool send_icv_indicatior_in_mkpdu = 10;
+  optional bool send_icv_indicatior_in_mkpdu = 11;
 
   // Delay Protect.
   // default = True
-  optional bool delay_protect = 11;
+  optional bool delay_protect = 12;
 
   // Rekey Mode.
-  MkaBasicRekeyMode rekey_mode = 12;
+  MkaBasicRekeyMode rekey_mode = 13;
+
+  // Pre-shared key(PSK) chain start time (in UTC - DD-MM-YYYY HH:MM:SS). The key start
+  // time will be relative to this value.
+  // default = 00-00-0000 00:00:00
+  optional string psk_chain_start_time = 14;
 }
 
 // The container for supported cipher suites.
@@ -8735,6 +8763,13 @@ message MkaKeyServer {
   // Determines the XPN rekey threshold.
   // default = C000000000000000
   optional string rekey_threshold_xpn = 6;
+}
+
+// A container of Tx properties.
+message MkaTx {
+
+  // Tx secure channels.
+  repeated MkaTxSc secure_channels = 1;
 }
 
 // Tx secure channel(SC) properties.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8330,9 +8330,9 @@ message SecureEntityCryptoEngine {
     }
   }
   // Engine type based on encryption and/ or decryption capability. Supported types: encrypt_only
-  // - engine can only encrypt transmitted packets but such engine cannot decrypt packets
-  // upon arrival. As the packets cannot be decrypted on arrival, such packets cannot
-  // be delivered to the receiving device. Hence only stateless traffic can be sent.
+  // - engine can only encrypt transmitted packets but it cannot decrypt packets upon
+  // arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered
+  // to the receiving device. Hence only stateless traffic can be sent.
   // default = Choice.Enum.encrypt_only
   optional Choice.Enum choice = 1;
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8588,7 +8588,7 @@ message MkaBasic {
   MkaBasicSupportedCipherSuites supported_cipher_suites = 6;
 
   // EAPOL Ethernet type.
-  // default = 0x888E
+  // default = 888E
   optional string eapol_ethernet_type = 7;
 
   // MKA Version.
@@ -8661,7 +8661,8 @@ message MkaBasicKeySource {
 // The container for Pre-shared key(PSK).
 message MkaBasicKeySourcePsk {
 
-  // Connectivity association key(CAK) value.
+  // Connectivity association key(CAK) value. It can be 128 bits or 256 bits long depending
+  // on the chosen MKA key derivation function.
   // default = F123456789ABCDEF0123456789ABCDEF
   optional string cak_value = 1;
 
@@ -8881,7 +8882,7 @@ message MacsecStaticKeyRekeyModeTimerBased {
 message MacsecStaticKeySak {
 
   // Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending
-  // on the citpher suite chosen.
+  // on the chosen cipher suite.
   // default = F123456789ABCDEF0123456789ABCDEF
   optional string sak = 1;
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8201,7 +8201,7 @@ message Ospfv2V4RRExtdPrefixFlags {
   optional bool n_flag = 2;
 }
 
-// A container of properties for a MACsec capable device.
+// A container of properties for a MACsec capable device. Reference https://1.ieee802.org/security/802-1ae/.
 message DeviceMacsec {
 
   // Ethernet Interfaces
@@ -8471,7 +8471,7 @@ message MacsecCryptoEngineEncryptDecryptHardwareAcceleration {
   MacsecCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto inline_crypto = 2;
 }
 
-// Inline cryto engine configuration. Encryption/ decryption are offloaded to hardware.
+// Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware.
 // Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated
 // in MACsec header on transmit.
 message MacsecCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto {
@@ -8525,7 +8525,7 @@ message MacsecCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto {
   optional RxScIdentifyingField.Enum rx_sc_identifying_field = 6;
 }
 
-// Configuration of a Key Agreement Entity (KaY).
+// Configuration of a MKA Key Agreement Entity (KaY). Reference https://1.ieee802.org/security/802-1x/.
 message Mka {
 
   // Globally unique name of an object. It also serves as the primary key for arrays of
@@ -8607,7 +8607,8 @@ message MkaBasic {
   // default = True
   optional bool send_icv_indicatior_in_mkpdu = 11;
 
-  // Delay Protect.
+  // Delay Protect or not. When delay protect is enabled, it guards against delaying the
+  // delivery of MACsec encrypted frames by an attacker to the receipient.
   // default = True
   optional bool delay_protect = 12;
 
@@ -8670,13 +8671,13 @@ message MkaBasicKeySourcePsk {
   // default = F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF
   optional string cak_name = 2;
 
-  // Key start time in HH:MM. This is relative to key chain start time.
+  // Key start offset time in HH:MM. This is relative to key chain start time.
   // default = 00:00
-  optional string start_time = 3;
+  optional string start_offset_time = 3;
 
-  // Key end time in HH:MM. This is relative to key chain start time.
+  // Key end offset time in HH:MM. This is relative to key chain start time.
   // default = 00:00
-  optional string end_time = 4;
+  optional string end_offset_time = 4;
 }
 
 // Rekey mode.
@@ -12999,9 +13000,9 @@ message MetricsResponse {
       dhcpv6_client = 12;
       dhcpv6_server = 13;
       ospfv2_metrics = 14;
-      macsec_metrics = 15;
-      mka_metrics = 16;
-      convergence_metrics = 17;
+      convergence_metrics = 15;
+      macsec_metrics = 16;
+      mka_metrics = 17;
     }
   }
   // Description missing in models

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8540,7 +8540,7 @@ message Mka {
   // Key server attributes.
   MkaKeyServer key_server = 3;
 
-  // The Tx Properties.
+  // Tx Properties.
   // required = true
   MkaTx tx = 4;
 }
@@ -8769,7 +8769,7 @@ message MkaKeyServer {
 // A container of Tx properties.
 message MkaTx {
 
-  // The Tx secure channels.
+  // Tx secure channels.
   repeated MkaTxSc secure_channels = 1;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12919,6 +12919,8 @@ message MetricsRequest {
       dhcpv6_server = 13;
       ospfv2 = 14;
       convergence = 15;
+      macsec = 16;
+      mka = 17;
     }
   }
   // Description missing in models
@@ -12969,6 +12971,12 @@ message MetricsRequest {
 
   // Description missing in models
   ConvergenceRequest convergence = 16;
+
+  // Description missing in models
+  MacsecMetricsRequest macsec = 17;
+
+  // Description missing in models
+  MkaMetricsRequest mka = 18;
 }
 
 // Response containing chosen traffic generator metrics.
@@ -12991,7 +12999,9 @@ message MetricsResponse {
       dhcpv6_client = 12;
       dhcpv6_server = 13;
       ospfv2_metrics = 14;
-      convergence_metrics = 15;
+      macsec_metrics = 15;
+      mka_metrics = 16;
+      convergence_metrics = 17;
     }
   }
   // Description missing in models
@@ -13042,6 +13052,12 @@ message MetricsResponse {
 
   // Description missing in models
   repeated ConvergenceMetric convergence_metrics = 16;
+
+  // Description missing in models
+  repeated MacsecMetric macsec_metrics = 17;
+
+  // Description missing in models
+  repeated MkaMetric mka_metrics = 18;
 }
 
 // The port result request to the traffic generator
@@ -14801,6 +14817,196 @@ message ConvergenceEvent {
 
   // The timestamp(nanoseconds) of the end event that triggers convergence.
   optional double end_timestamp_ns = 4;
+}
+
+// The request to retrieve MACsec per secure entity(secY) metrics/statistics.
+message MacsecMetricsRequest {
+
+  // The names of secure entities(secYs) to return results for. An empty list will return
+  // results for all secYs.
+  // 
+  // x-constraint:
+  // - /components/schemas/Macsec/properties/name
+  // 
+  repeated string secure_entity_names = 1;
+
+  message ColumnNames {
+    enum Enum {
+      unspecified = 0;
+      session_state = 1;
+      session_flap_count = 2;
+      out_pkts_protected = 3;
+      out_pkts_encrypted = 4;
+      in_pkts_ok = 5;
+      in_pkts_bad = 6;
+      in_pkts_bad_tag = 7;
+      in_pkts_late = 8;
+      in_pkts_no_sci = 9;
+      in_pkts_not_using_sa = 10;
+      in_pkts_not_valid = 11;
+      in_pkts_unknown_sci = 12;
+      in_pkts_unused_sa = 13;
+      in_pkts_invalid = 14;
+      in_pkts_untagged = 15;
+      out_octets_protected = 16;
+      out_octets_encrypted = 17;
+      in_octets_validated = 18;
+      in_octets_decrypted = 19;
+    }
+  }
+  // The list of column names that the returned result set will contain. If the list is
+  // empty then all columns will be returned except for any result_groups. The name of
+  // the secure entity(secY) cannot be excluded.
+  repeated ColumnNames.Enum column_names = 2;
+}
+
+// MACsec per secure entity(secY) statistics information.
+message MacsecMetric {
+
+  // The name of a configured MACsec secure entity(secY).
+  optional string name = 1;
+
+  message SessionState {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // Session state as up or down. Up refers to an Established state and Down refers to
+  // any other state.
+  optional SessionState.Enum session_state = 2;
+
+  // Number of times the session went from Up to Down state.
+  optional uint64 session_flap_count = 3;
+
+  // OutPktsProtected, the number of protected packets transmitted.
+  optional uint64 out_pkts_protected = 4;
+
+  // OutPktsEncrypted, the number of encrypted packets transmitted.
+  optional uint64 out_pkts_encrypted = 5;
+
+  // InPktsOk, the number of valid packets received.
+  optional uint64 in_pkts_ok = 6;
+
+  // The number of bad packets received.
+  optional uint64 bad_pkts_rx = 7;
+
+  // InPktsBadTag, the number of packets discarded due to bad tag/ICV.
+  optional uint64 in_pkts_bad_tag = 8;
+
+  // InPktsLate, the number of packets discarded out of window.
+  optional uint64 in_pkts_late = 9;
+
+  // InPktsNoSCI,the number of packets discarded due to unknown SCI.
+  optional uint64 in_pkts_no_sci = 10;
+
+  // InPktsNotUsingSA, the number of packets discarded due to unused SA.
+  optional uint64 in_pkts_not_using_sa = 11;
+
+  // InPktsNotValid, the number of packets discarded due to invalid ICV.
+  optional uint64 in_pkts_not_valid = 12;
+
+  // InPktsUnknownSCI, the number of packets received with unknown SCI.
+  optional uint64 in_pkts_unknown_sci = 13;
+
+  // InPktsUnusedSA, the number of packets received with unused SA.
+  optional uint64 in_pkts_unused_sa = 14;
+
+  // InPktsInvalid, the number of packets received with invalid ICV.
+  optional uint64 in_pkts_invalid = 15;
+
+  // InPktsUntagged, the number of non-MACsec packets received.
+  optional uint64 in_pkts_untagged = 16;
+
+  // OutOctetsProtected, the number of bytes transmitted as protected.
+  optional uint64 out_octets_protected = 17;
+
+  // OutOctetsEncrypted, the number of bytes transmitted as encrypted.
+  optional uint64 out_octets_encrypted = 18;
+
+  // InOctetsValidated, the number of received bytes validated.
+  optional uint64 in_octets_validated = 19;
+
+  // InOctetsDecrypted, the number of received bytes decrypted.
+  optional uint64 in_octets_decrypted = 20;
+}
+
+// The request to retrieve MKA per peer metrics/statistics.
+message MkaMetricsRequest {
+
+  // The names of peers to return results for. An empty list will return results for all
+  // peers.
+  // 
+  // x-constraint:
+  // - /components/schemas/Mka/properties/name
+  // 
+  repeated string peer_names = 1;
+
+  message ColumnNames {
+    enum Enum {
+      unspecified = 0;
+      session_state = 1;
+      session_flap_count = 2;
+      mkpdu_tx = 3;
+      mkpdu_rx = 4;
+      live_peer_count = 5;
+      potential_peer_count = 6;
+      latest_key_tx_peer_count = 7;
+      latest_key_rx_peer_count = 8;
+      malformed_mkpdu = 9;
+      icv_mismatch = 10;
+    }
+  }
+  // The list of column names that the returned result set will contain. If the list is
+  // empty then all columns will be returned except for any result_groups. The name of
+  // the peer cannot be excluded.
+  repeated ColumnNames.Enum column_names = 2;
+}
+
+// MKA per peer statistics information.
+message MkaMetric {
+
+  // The name of a configured MKA peer.
+  optional string name = 1;
+
+  message SessionState {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // Session state as up or down. Up refers to an Established state and Down refers to
+  // any other state.
+  optional SessionState.Enum session_state = 2;
+
+  // Number of times the session went from Up to Down state.
+  optional uint64 session_flap_count = 3;
+
+  // Number of MKA protocol data unit(MKPDU) frames Tx.
+  optional uint64 mkpdu_tx = 4;
+
+  // Number of MKA protocol data unit(MKPDU) frames Rx.
+  optional uint64 mkpdu_rx = 5;
+
+  // Number of MKA live peers.
+  optional uint64 live_peer_count = 6;
+
+  // Number of MKA potential peers.
+  optional uint64 potential_peer_count = 7;
+
+  // Number of MKA latest key Tx peers.
+  optional uint64 latest_key_tx_peer_count = 8;
+
+  // Number of MKA latest key Rx peers.
+  optional uint64 latest_key_rx_peer_count = 9;
+
+  // Number of malformed MKA Protocol Data Unit(MKPDU) frames Rx.
+  optional uint64 malformed_mkpdu = 10;
+
+  // Number of MKA Protocol Data Unit(MKPDU) frames with ICV mismatch Rx.
+  optional uint64 icv_mismatch = 11;
 }
 
 // Request to traffic generator for states of choice

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8614,8 +8614,8 @@ message MkaBasic {
   // Rekey Mode.
   MkaBasicRekeyMode rekey_mode = 13;
 
-  // Pre-shared key(PSK) chain start time (in UTC - DD-MM-YYYY HH:MM:SS). The key start
-  // time will be relative to this value.
+  // Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. The
+  // key start time will be relative to this value.
   // default = 00-00-0000 00:00:00
   optional string psk_chain_start_time = 14;
 }
@@ -8670,11 +8670,11 @@ message MkaBasicKeySourcePsk {
   // default = F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF
   optional string cak_name = 2;
 
-  // Key start time in HH:MM. This is relative to test start time.
+  // Key start time in HH:MM. This is relative to key chain start time.
   // default = 00:00
   optional string start_time = 3;
 
-  // Key end time in HH:MM. This is relative to test start time.
+  // Key end time in HH:MM. This is relative to key chain start time.
   // default = 00:00
   optional string end_time = 4;
 }

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8541,7 +8541,8 @@ message Mka {
   MkaKeyServer key_server = 3;
 
   // Tx Properties.
-  repeated MkaTx tx = 4;
+  // required = true
+  MkaTx tx = 4;
 }
 
 // A container of basic properties for a KaY.
@@ -8769,8 +8770,7 @@ message MkaKeyServer {
 message MkaTx {
 
   // Tx secure channels.
-  // required = true
-  MkaTxSc secure_channels = 1;
+  repeated MkaTxSc secure_channels = 1;
 }
 
 // Tx secure channel(SC) properties.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8540,7 +8540,7 @@ message Mka {
   // Key server attributes.
   MkaKeyServer key_server = 3;
 
-  // Tx Properties.
+  // The Tx Properties.
   // required = true
   MkaTx tx = 4;
 }
@@ -8769,7 +8769,7 @@ message MkaKeyServer {
 // A container of Tx properties.
 message MkaTx {
 
-  // Tx secure channels.
+  // The Tx secure channels.
   repeated MkaTxSc secure_channels = 1;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8769,7 +8769,8 @@ message MkaKeyServer {
 message MkaTx {
 
   // Tx secure channels.
-  repeated MkaTxSc secure_channels = 1;
+  // required = true
+  MkaTxSc secure_channels = 1;
 }
 
 // Tx secure channel(SC) properties.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8615,10 +8615,8 @@ message MkaBasic {
   // Rekey Mode.
   MkaBasicRekeyMode rekey_mode = 13;
 
-  // Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this
-  // time is set, the key start time will be relative to this value. Otherwise if this
-  // value is not set, key start time will be relative to test start time.
-  MkaBasicTime psk_chain_start_time = 14;
+  // Description missing in models
+  MkaBasicPskChainStartTime psk_chain_start_time = 14;
 }
 
 // The container for supported cipher suites.
@@ -8690,8 +8688,10 @@ message MkaBasicOffsetTime {
   optional uint32 mm = 2;
 }
 
-// Description missing in models
-message MkaBasicTime {
+// Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this
+// time is set, the key start time will be relative to this value. Otherwise if this
+// value is not set, key start time will be relative to test start time.
+message MkaBasicPskChainStartTime {
 
   message Choice {
     enum Enum {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8608,7 +8608,7 @@ message MkaBasic {
   optional bool send_icv_indicatior_in_mkpdu = 11;
 
   // Delay Protect or not. When delay protect is enabled, it guards against delaying the
-  // delivery of MACsec encrypted frames by an attacker to the receipient.
+  // delivery of MACsec encrypted frames by an attacker to the recipient.
   // default = True
   optional bool delay_protect = 12;
 
@@ -8672,12 +8672,57 @@ message MkaBasicKeySourcePsk {
   optional string cak_name = 2;
 
   // Key start offset time in HH:MM. This is relative to key chain start time.
-  // default = 00:00
-  optional string start_offset_time = 3;
+  MkaBasicOffsetTime start_offset_time = 3;
 
   // Key end offset time in HH:MM. This is relative to key chain start time.
-  // default = 00:00
-  optional string end_offset_time = 4;
+  MkaBasicOffsetTime end_offset_time = 4;
+}
+
+// Offset time.
+message MkaBasicOffsetTime {
+
+  // Minutes in mm.
+  // default = 0
+  optional int32 mm = 2;
+}
+
+// Absolute time in a timezone.
+message MkaBasicTime {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      utc = 1;
+    }
+  }
+  // Timezone choice. Currently only Coordinated Universal Time(UTC) is supported.
+  // default = Choice.Enum.utc
+  optional Choice.Enum choice = 1;
+
+  // Coordinated Universal Time(UTC) time.
+  MkaBasicTimeUtc utc = 2;
+}
+
+// Coordinated Universal Time(UTC).
+message MkaBasicTimeUtc {
+
+  // Day of the month in DD format.
+  optional int32 day = 1;
+
+  // Month of the year in MM format.
+  optional int32 month = 2;
+
+  // Year from the start of common era(CE) in YYYY format.
+  optional int32 year = 3;
+
+  // Hour of the day in hh format.
+  optional int32 hour = 4;
+
+  // Minute of the hour in mm format.
+  optional int32 minute = 5;
+
+  // Second of the minute in ss format.
+  optional int32 second = 6;
 }
 
 // Rekey mode.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8669,15 +8669,28 @@ message MkaBasicKeySourcePsk {
   // default = F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF
   optional string cak_name = 2;
 
-  // Key start offset time in HH:MM. This is relative to key chain start time.
-  MkaBasicOffsetTime start_offset_time = 3;
+  // 
+  MkaBasicStartOffsetTime start_offset_time = 3;
 
-  // Key end offset time in HH:MM. This is relative to key chain start time.
-  MkaBasicOffsetTime end_offset_time = 4;
+  // 
+  MkaBasicEndOffsetTime end_offset_time = 4;
 }
 
-// Offset time.
-message MkaBasicOffsetTime {
+// Key start offset time in HH:MM. This is relative to key chain start time.
+message MkaBasicStartOffsetTime {
+
+  // Hours in HH format.
+  // default = 0
+  optional uint32 hh = 1;
+
+  // Minutes in MM format.
+  // default = 0
+  optional uint32 mm = 2;
+}
+
+// Key end offset time in HH:MM. This is relative to key chain start time. A value of
+// 00:00 makes the key valid for lifetime.
+message MkaBasicEndOffsetTime {
 
   // Hours in HH format.
   // default = 0

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1678,6 +1678,9 @@ message Device {
 
   // Configuration for OSPFv2 router.
   DeviceOspfv2Router ospfv2 = 10;
+
+  // Configuration of MACsec device.
+  DeviceMacsec macsec = 11;
 }
 
 // Common options that apply to all configured protocols and interfaces.
@@ -8196,6 +8199,713 @@ message Ospfv2V4RRExtdPrefixFlags {
   // with a loopback address.
   // default = False
   optional bool n_flag = 2;
+}
+
+// A container of properties for a MACsec capable device.
+message DeviceMacsec {
+
+  // Ethernet Interfaces
+  repeated DeviceMacsecEthernetInterface ethernet_interfaces = 1;
+}
+
+// Configuration for single MACsec interface.
+message DeviceMacsecEthernetInterface {
+
+  // The unique name of the Ethernet interface on which MACsec is enabled.
+  // 
+  // x-constraint:
+  // - /components/schemas/Device.Ethernet/properties/name
+  // 
+  // required = true
+  optional string eth_name = 1;
+
+  // This contains the properties of Secure Entity (SecY).
+  // required = true
+  Macsec secy = 2;
+}
+
+// Configuration of a Secure Entity (SecY).
+message Macsec {
+
+  // Globally unique name of an object. It also serves as the primary key for arrays of
+  // objects.
+  // required = true
+  optional string name = 1;
+
+  // This contains the properties of key generation protocol of Secure Entity (SecY).
+  MacsecKeyGenerationProtocol key_generation_protocol = 2;
+
+  // This contains the properties of data plane of Secure Entity (SecY).
+  MacsecDataPlane data_plane = 3;
+}
+
+// Container of Key generation protocol configuration.
+message MacsecKeyGenerationProtocol {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      mka = 1;
+      static_key = 2;
+    }
+  }
+  // Key generation protocol choices. Choose mka for dynamic key distribution using MACsec
+  // key agreement(MKA) protocol. Choose static_key for static configuration of secure
+  // association key(SAK).
+  // default = Choice.Enum.mka
+  optional Choice.Enum choice = 1;
+
+  // This contains the properties of Key Agreement Entity (KaY) in MKA supplicant.
+  Mka kay = 2;
+
+  // Static key properties properties of SecY. Static key is used in absence MKA.
+  MacsecStaticKey static_key = 3;
+}
+
+// A container of data plane properties for a secure entity(SecY).
+message MacsecDataPlane {
+
+  // Tx properties of SecY.
+  MacsecDataPlaneTx tx = 1;
+
+  // Rx properties of SecY.
+  MacsecDataPlaneRx rx = 2;
+
+  // Crypto engine properties of SecY.
+  MacsecCryptoEngine crypto_engine = 3;
+}
+
+// A container of Tx properties of SecY.
+message MacsecDataPlaneTx {
+
+  // End station on not.
+  // default = False
+  optional bool end_station = 1;
+
+  // Include SCI on not.
+  // default = False
+  optional bool include_sci = 2;
+}
+
+// A container for Rx settings of SecY.
+message MacsecDataPlaneRx {
+
+  // Enable replay protection on not.
+  // default = False
+  optional bool replay_protection = 1;
+
+  // Replay window size.
+  // default = 1
+  optional uint32 replay_window = 2;
+}
+
+// A container of crypto engine properties of a SecY.
+message MacsecCryptoEngine {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      encrypt_only = 1;
+      encrypt_decrypt = 2;
+    }
+  }
+  // Engine type based on encryption and/ or decryption capability. Supported types: 1)
+  // encrypt_only - engine can only encrypt transmitted packets but such engine cannot
+  // decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such
+  // packets cannot be delivered to the receiving device. Hence only stateless traffic
+  // can be sent. 2) encrypt_decrypt - engine can both encrypt transmitted packets and
+  // decrypt packets on arrival. Such engine can have hardware acceleration for faster
+  // encryption/ ddecryption. As both encryption and decryption are possible, stateful
+  // (e.g. TCP) traffic can also be sent/ received.
+  // default = Choice.Enum.encrypt_only
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptOnly encrypt_only = 2;
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptDecrypt encrypt_decrypt = 3;
+}
+
+// The container for encrypt only engine configuration.
+message MacsecCryptoEngineEncryptOnly {
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptOnlyTxSc secure_channel = 1;
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptOnlyTrafficOptions traffic_options = 2;
+}
+
+// The container for encrypt and decrypt engine configuration.
+message MacsecCryptoEngineEncryptDecrypt {
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptDecryptTxSc secure_channel = 1;
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptDecryptHardwareAcceleration hardware_acceleration = 2;
+}
+
+// The container for Tx secure channel configuration.
+message MacsecCryptoEngineEncryptOnlyTxSc {
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptOnlyTxScTxPn tx_pn = 1;
+}
+
+// Tx packet number(PN) configuration.
+message MacsecCryptoEngineEncryptOnlyTxScTxPn {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      fixed_pn = 1;
+      incrementing_pn = 2;
+    }
+  }
+  // Types of Tx packet number(PN) series. Supported choices: 1) fixed PN - MACsec packets
+  // will be sent out with the configured fixed PN or lower half of configured fixed XPN.
+  // 2) incrementing PN - MACsec packets will be sent out by single device with an incrementing
+  // PN or XPN.
+  // default = Choice.Enum.fixed_pn
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptOnlyFixedPn fixed = 2;
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptOnlyIncrementingPn incrementing = 3;
+}
+
+// Fixed packet number(PN) configuration.
+message MacsecCryptoEngineEncryptOnlyFixedPn {
+
+  // Fixed Tx packet number(PN). 4 bytes PN with which all packets will be sent out.
+  // default = 6
+  optional uint32 pn = 1;
+
+  // Fixed Tx extended packet number(XPN). 8 bytes XPN with which all packets will be
+  // sent out.
+  // default = 0x0000000000000006
+  optional string xpn = 2;
+}
+
+// Incrementing packet number(PN) configuration.
+message MacsecCryptoEngineEncryptOnlyIncrementingPn {
+
+  // Count of packet numbers in series.
+  // default = 100
+  optional uint32 count = 1;
+
+  // The starting packet number(PN).
+  // default = 10000
+  optional uint32 starting_pn = 2;
+
+  // The starting extended packet number(XPN).
+  // default = 0x0000000000010000
+  optional string starting_xpn = 3;
+}
+
+// Encrypt only traffic options.
+message MacsecCryptoEngineEncryptOnlyTrafficOptions {
+
+  // Send gratuitous ARP or not.
+  // default = True
+  optional bool send_gratuitous_arp = 1;
+}
+
+// Secure channel configuration.
+message MacsecCryptoEngineEncryptDecryptTxSc {
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptDecryptTxScTxPn tx_pn = 1;
+}
+
+// Starting packet number(PN) configuration.
+message MacsecCryptoEngineEncryptDecryptTxScTxPn {
+
+  // Initial Tx packet number(PN).
+  // default = 1
+  optional uint32 starting_pn = 1;
+
+  // The starting extended packet number(XPN).
+  // default = 0x0000000000000001
+  optional string starting_xpn = 3;
+}
+
+// Hardware acceleration configuration for offloading MACsec processing to hardware.
+message MacsecCryptoEngineEncryptDecryptHardwareAcceleration {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      none = 1;
+      inline_crypto = 2;
+    }
+  }
+  // Hardware acceleration types.
+  // default = Choice.Enum.none
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  MacsecCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto inline_crypto = 2;
+}
+
+// Inline cryto engine configuration. Encryption/ decryption are offloaded to hardware.
+// Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated
+// in MACsec header on transmit.
+message MacsecCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto {
+
+  // Offset of Rx secTAG from the first byte in packet.
+  // default = 12
+  optional uint32 rx_sectag_offset = 1;
+
+  message TypeOfCa {
+    enum Enum {
+      unspecified = 0;
+      pairwise_ca = 1;
+      group_ca_single_dut = 2;
+      group_ca_multipe_duts = 3;
+    }
+  }
+  // Type of connectivity association(CA).
+  optional TypeOfCa.Enum type_of_ca = 2;
+
+  // The maximum number of CAs configured on the port. The maximum count supported per
+  // port is 256 for Pair-wise CA, each CA having one MACsec device.
+  // default = 256
+  optional uint32 max_ca_count = 3;
+
+  // The maximum number of DUT transmit SCs that can be supported per CA. The count should
+  // be number of Tx SCs supported by the DUT per CA, multiplied by number of DUTs in
+  // the CA in case of group CA with multiple DUTs scenario.
+  // default = 1
+  optional uint32 max_dut_tx_sc_per_ca = 4;
+
+  // The maximum number of MACsec devices at test port that can be supported on each CA.
+  // This number is calculated automatically based on the values configured for Max CA
+  // Count and Max DUT Tx SC Per CA. Number of MACsec devices at test port should be configured
+  // accordingly.
+  // default = 256
+  optional uint32 max_device_per_ca = 5;
+
+  message RxScIdentifyingField {
+    enum Enum {
+      unspecified = 0;
+      source_mac = 1;
+      sci_sytem_id = 2;
+      sci_port_id = 3;
+    }
+  }
+  // The field based on which secure channel(SC) will be identified by the receiving port.
+  // Supported fields are:- - 1) source MAC - identify SC based on source MAC field. 2)
+  // SCI system ID - identify SC bbased on SCI system ID field. 3) SCI port ID - identify
+  // based on SCI port ID field.
+  // default = RxScIdentifyingField.Enum.source_mac
+  optional RxScIdentifyingField.Enum rx_sc_identifying_field = 6;
+}
+
+// Configuration of a Key Agreement Entity (KaY).
+message Mka {
+
+  // Globally unique name of an object. It also serves as the primary key for arrays of
+  // objects.
+  // required = true
+  optional string name = 1;
+
+  // This contains the basic properties of KaY.
+  // required = true
+  MkaBasic basic = 2;
+
+  // Key server attributes.
+  MkaKeyServer key_server = 3;
+
+  // Properties for Tx secure channels.
+  repeated MkaTxSc txscs = 4;
+}
+
+// A container of basic properties for a KaY.
+message MkaBasic {
+
+  message KeyDerivationFunction {
+    enum Enum {
+      unspecified = 0;
+      aes_cmac_128 = 1;
+      aes_cmac_256 = 2;
+    }
+  }
+  // Key Derivation Function.
+  // default = KeyDerivationFunction.Enum.aes_cmac_128
+  optional KeyDerivationFunction.Enum key_derivation_function = 1;
+
+  // Key source.
+  // required = true
+  MkaBasicKeySource key_source = 2;
+
+  // Actor priority.
+  // default = 70
+  optional string actor_priority = 3;
+
+  // Determines whether MACsec is desired or not. It is advertised in periodic Hellos.
+  // default = True
+  optional bool macsec_desired = 4;
+
+  message MacsecCapability {
+    enum Enum {
+      unspecified = 0;
+      macsec_not_implemented = 1;
+      macsec_integrity_without_confidentiality = 2;
+      macsec_integrity_with_no_confidentiality_offset = 3;
+      macsec_integrity_with_confidentiality_offset = 4;
+    }
+  }
+  // MACSec Capability.
+  // default = MacsecCapability.Enum.macsec_integrity_with_confidentiality_offset
+  optional MacsecCapability.Enum macsec_capability = 5;
+
+  // Supported Cipher Suites.
+  MkaBasicSupportedCipherSuites supported_cipher_suites = 6;
+
+  // MKA Version.
+  // default = 3
+  optional uint32 mka_version = 7;
+
+  // MKA Hello Time (msec).
+  // default = 2000
+  optional uint32 mka_hello_time = 8;
+
+  // MKA Life Time (sec).
+  // default = 6
+  optional uint32 mka_life_time = 9;
+
+  // Send ICV Indicator in MKPDU.
+  // default = True
+  optional bool send_icv_indicatior_in_mkpdu = 10;
+
+  // Delay Protect.
+  // default = True
+  optional bool delay_protect = 11;
+
+  // Rekey Mode.
+  MkaBasicRekeyMode rekey_mode = 12;
+}
+
+// The container for supported cipher suites.
+message MkaBasicSupportedCipherSuites {
+
+  // GCM-AES-128.
+  // default = True
+  optional bool gcm_aes_128 = 1;
+
+  // GCM-AES-256.
+  // default = True
+  optional bool gcm_aes_256 = 2;
+
+  // GCM-AES-XPN-128.
+  // default = True
+  optional bool gcm_aes_xpn_128 = 3;
+
+  // GCM-AES-XPN-256.
+  // default = True
+  optional bool gcm_aes_xpn_256 = 4;
+}
+
+// The container for key source settings.
+message MkaBasicKeySource {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      psk = 1;
+      msk = 2;
+    }
+  }
+  // Key source. Choose one from PSK or MSK.
+  // default = Choice.Enum.psk
+  optional Choice.Enum choice = 1;
+
+  // PSK chain.
+  repeated MkaBasicKeySourcePsk psks = 2;
+}
+
+// The container for Pre-shared key(PSK).
+message MkaBasicKeySourcePsk {
+
+  // Connectivity association key(CAK) value.
+  // default = F123456789ABCDEF0123456789ABCDEF
+  optional string cak_value = 1;
+
+  // Connectivity association key(CAK) name.
+  // default = F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF
+  optional string cak_name = 2;
+
+  // Key start time in HH:MM. This is relative to test start time.
+  // default = 00:00
+  optional string start_time = 3;
+
+  // Key end time in HH:MM. This is relative to test start time.
+  // default = 00:00
+  optional string end_time = 4;
+}
+
+// Rekey mode.
+message MkaBasicRekeyMode {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      dont_rekey = 1;
+      timer_based = 2;
+      pn_based = 3;
+    }
+  }
+  // Mode choices.
+  // default = Choice.Enum.dont_rekey
+  optional Choice.Enum choice = 1;
+
+  // Container for timer based periodic rekey properties.
+  MkaBasicRekeyModeTimerBased timer_based = 2;
+}
+
+// Timer based periodic rekey properties.
+message MkaBasicRekeyModeTimerBased {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      continuous = 1;
+      fixed_count = 2;
+    }
+  }
+  // Periodic Rekey count.
+  // default = Choice.Enum.continuous
+  optional Choice.Enum choice = 1;
+
+  // Fixed rekey attempts.
+  // default = 10
+  optional uint32 fixed_count = 2;
+
+  // Periodic rekey interval (sec).
+  // default = 300
+  optional uint32 interval = 3;
+}
+
+// Key server attributes of a KaY.
+message MkaKeyServer {
+
+  message ConfidentialtyOffset {
+    enum Enum {
+      unspecified = 0;
+      no_confidentiality = 1;
+      no_confidentiality_offset = 2;
+      confidentiality_offset_30_octets = 3;
+      confidentiality_offset_50_octets = 4;
+    }
+  }
+  // Confidentiality Offset.
+  // default = ConfidentialtyOffset.Enum.no_confidentiality_offset
+  optional ConfidentialtyOffset.Enum confidentialty_offset = 1;
+
+  message CipherSuite {
+    enum Enum {
+      unspecified = 0;
+      gcm_aes_128 = 1;
+      gcm_aes_256 = 2;
+      gcm_aes_xpn_128 = 3;
+      gcm_aes_xpn_256 = 4;
+    }
+  }
+  // The cipher suite. Choose one from GCM-AES-128 GCM-AES-256 GCM-AES-XPN-128 GCM-AES-XPN-256
+  // default = CipherSuite.Enum.gcm_aes_128
+  optional CipherSuite.Enum cipher_suite = 2;
+
+  // Starting Key Number.
+  // default = 1
+  optional uint32 starting_key_number = 3;
+
+  // Starting Distributed AN.
+  // default = 0
+  optional uint32 starting_distributed_an = 4;
+
+  // Determines the PN rekey threshold.
+  // default = C0000000
+  optional string rekey_threshold_pn = 5;
+
+  // Determines the XPN rekey threshold.
+  // default = C000000000000000
+  optional string rekey_threshold_xpn = 6;
+}
+
+// Tx secure channel(SC) properties.
+message MkaTxSc {
+
+  // Tx SC name.
+  // required = true
+  optional string name = 1;
+
+  // System ID.
+  // required = true
+  optional string system_id = 2;
+
+  // Port ID.
+  // default = 1
+  optional uint32 port_id = 3;
+
+  // Starting Message Number.
+  // default = 1
+  optional uint64 starting_message_number = 4;
+}
+
+// A container of static key properties for a secure entity(SecY). This configuration
+// is applicable when no dynamic key management protocol i.e. MACsec key agreement(MKA)
+// is configured. If MKA is configured, any static key configuration is not applicable.
+message MacsecStaticKey {
+
+  message CipherSuite {
+    enum Enum {
+      unspecified = 0;
+      gcm_aes_128 = 1;
+      gcm_aes_256 = 2;
+      gcm_aes_xpn_128 = 3;
+      gcm_aes_xpn_256 = 4;
+    }
+  }
+  // The cipher suite. Choose one from GCM-AES-128 GCM-AES-128 GCM-AES-256 GCM-AES-XPN-128
+  // GCM-AES-XPN-256
+  // default = CipherSuite.Enum.gcm_aes_128
+  optional CipherSuite.Enum cipher_suite = 1;
+
+  // Encrypt or not.
+  // default = True
+  optional bool confidentiality = 2;
+
+  message ConfidentialityOffset {
+    enum Enum {
+      unspecified = 0;
+      zero = 1;
+      thirty = 2;
+      fifty = 3;
+    }
+  }
+  // Confidentiality offset.
+  // default = ConfidentialityOffset.Enum.zero
+  optional ConfidentialityOffset.Enum confidentiality_offset = 3;
+
+  // Tx properties of SecY.
+  MacsecStaticKeyTx tx = 4;
+
+  // Rx properties of SecY.
+  MacsecStaticKeyRx rx = 5;
+}
+
+// Rekey mode.
+message MacsecStaticKeyRekeyMode {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      dont_rekey = 1;
+      timer_based = 2;
+      pn_based = 3;
+    }
+  }
+  // Rekey mode choices.
+  // default = Choice.Enum.dont_rekey
+  optional Choice.Enum choice = 1;
+
+  // Container for timer based periodic rekey properties.
+  MacsecStaticKeyRekeyModeTimerBased timer_based = 2;
+}
+
+// Timer based periodic rekey properties.
+message MacsecStaticKeyRekeyModeTimerBased {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      continuous = 1;
+      fixed_count = 2;
+    }
+  }
+  // Periodic rekey attempt choices.
+  // default = Choice.Enum.continuous
+  optional Choice.Enum choice = 1;
+
+  // Fixed rekey attempts.
+  // default = 10
+  optional uint32 fixed_count = 2;
+
+  // Periodic rekey interval (sec).
+  // default = 300
+  optional uint32 interval = 3;
+}
+
+// The container for SAK.
+message MacsecStaticKeySak {
+
+  // Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending
+  // on the citpher suite chosen.
+  // default = F123456789ABCDEF0123456789ABCDEF
+  optional string sak = 1;
+
+  // 4 bytes short SCI(SSCI) used in case of XPN cipher suites.
+  // default = 00000001
+  optional string ssci = 2;
+
+  // 12 bytes salt used in case of XPN cipher suites.
+  // default = 000000000000000000000001
+  optional string salt = 3;
+}
+
+// A container of static key Tx properties.
+message MacsecStaticKeyTx {
+
+  // Tx secure channels.
+  repeated MacsecStaticKeyTxSc secure_channels = 1;
+
+  // Description missing in models
+  MacsecStaticKeyRekeyMode rekey_mode = 2;
+}
+
+// Tx SC setting for static key.
+message MacsecStaticKeyTxSc {
+
+  // System ID.
+  optional string system_id = 1;
+
+  // Port ID.
+  // default = 1
+  optional uint32 port_id = 2;
+
+  // Tx SAK pool.
+  repeated MacsecStaticKeySak saks = 3;
+}
+
+// A container of static key Rx properties.
+message MacsecStaticKeyRx {
+
+  // Rx secure channels.
+  repeated MacsecStaticKeyRxSc secure_channels = 1;
+}
+
+// Rx SC settings.
+message MacsecStaticKeyRxSc {
+
+  // System ID in DUT SCI.
+  optional string dut_sci_system_id = 1;
+
+  // Port ID in DUT SCI.
+  // default = 1
+  optional uint32 dut_sci_port_id = 2;
+
+  // DUT MSB of XPN. The 32 most significant bits of the XPN that DUT will be using to
+  // construct the 64 bits XPN value when test starts.
+  // default = 0
+  optional uint32 dut_msb_xpn = 3;
+
+  // Rx SAK pool.
+  repeated MacsecStaticKeySak saks = 4;
 }
 
 // A high level data plane traffic flow.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8615,8 +8615,9 @@ message MkaBasic {
   // Rekey Mode.
   MkaBasicRekeyMode rekey_mode = 13;
 
-  // Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. The
-  // key start time will be relative to this value.
+  // Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this
+  // time is set, the key start time will be relative to this value. Otherwise if this
+  // value is not set, key start time will be relative to test start time.
   MkaBasicTime psk_chain_start_time = 14;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8327,25 +8327,17 @@ message SecureEntityCryptoEngine {
     enum Enum {
       unspecified = 0;
       encrypt_only = 1;
-      encrypt_decrypt = 2;
     }
   }
-  // Engine type based on encryption and/ or decryption capability. Supported types: 1)
-  // encrypt_only - engine can only encrypt transmitted packets but such engine cannot
-  // decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such
-  // packets cannot be delivered to the receiving device. Hence only stateless traffic
-  // can be sent. 2) encrypt_decrypt - engine can both encrypt transmitted packets and
-  // decrypt packets on arrival. Such engine can have hardware acceleration for faster
-  // encryption/ ddecryption. As both encryption and decryption are possible, stateful
-  // (e.g. TCP) traffic can also be sent/ received.
+  // Engine type based on encryption and/ or decryption capability. Supported types: encrypt_only
+  // - engine can only encrypt transmitted packets but such engine cannot decrypt packets
+  // upon arrival. As the packets cannot be decrypted on arrival, such packets cannot
+  // be delivered to the receiving device. Hence only stateless traffic can be sent.
   // default = Choice.Enum.encrypt_only
   optional Choice.Enum choice = 1;
 
   // Description missing in models
   SecureEntityCryptoEngineEncryptOnly encrypt_only = 2;
-
-  // Description missing in models
-  SecureEntityCryptoEngineEncryptDecrypt encrypt_decrypt = 3;
 }
 
 // The container for encrypt only engine configuration.
@@ -8356,16 +8348,6 @@ message SecureEntityCryptoEngineEncryptOnly {
 
   // Description missing in models
   SecureEntityCryptoEngineEncryptOnlyTrafficOptions traffic_options = 2;
-}
-
-// The container for encrypt and decrypt engine configuration.
-message SecureEntityCryptoEngineEncryptDecrypt {
-
-  // Description missing in models
-  repeated SecureEntityCryptoEngineEncryptDecryptTxSc secure_channels = 1;
-
-  // Description missing in models
-  SecureEntityCryptoEngineEncryptDecryptHardwareAcceleration hardware_acceleration = 2;
 }
 
 // The container for Tx secure channel configuration.
@@ -8434,97 +8416,6 @@ message SecureEntityCryptoEngineEncryptOnlyTrafficOptions {
   // Send gratuitous ARP or not.
   // default = True
   optional bool send_gratuitous_arp = 1;
-}
-
-// Secure channel configuration.
-message SecureEntityCryptoEngineEncryptDecryptTxSc {
-
-  // Description missing in models
-  SecureEntityCryptoEngineEncryptDecryptTxScTxPn tx_pn = 1;
-}
-
-// Starting packet number(PN) configuration.
-message SecureEntityCryptoEngineEncryptDecryptTxScTxPn {
-
-  // Initial Tx packet number(PN).
-  // default = 1
-  optional uint32 starting_pn = 1;
-
-  // The starting extended packet number(XPN).
-  // default = 0x0000000000000001
-  optional string starting_xpn = 3;
-}
-
-// Hardware acceleration configuration for offloading MACsec processing to hardware.
-message SecureEntityCryptoEngineEncryptDecryptHardwareAcceleration {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      none = 1;
-      inline_crypto = 2;
-    }
-  }
-  // Hardware acceleration types.
-  // default = Choice.Enum.none
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  SecureEntityCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto inline_crypto = 2;
-}
-
-// Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware.
-// Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated
-// in MACsec header on transmit.
-message SecureEntityCryptoEngineEncryptDecryptHardwareAccelerationInlineCrypto {
-
-  // Offset of Rx secTAG from the first byte in packet.
-  // default = 12
-  optional uint32 rx_sectag_offset = 1;
-
-  message TypeOfCa {
-    enum Enum {
-      unspecified = 0;
-      pairwise_ca = 1;
-      group_ca_single_dut = 2;
-      group_ca_multipe_duts = 3;
-    }
-  }
-  // Type of connectivity association(CA).
-  optional TypeOfCa.Enum type_of_ca = 2;
-
-  // The maximum number of CAs configured on the port. The maximum count supported per
-  // port is 256 for Pair-wise CA, each CA having one MACsec device.
-  // default = 256
-  optional uint32 max_ca_count = 3;
-
-  // The maximum number of DUT transmit SCs that can be supported per CA. The count should
-  // be number of Tx SCs supported by the DUT per CA, multiplied by number of DUTs in
-  // the CA in case of group CA with multiple DUTs scenario.
-  // default = 1
-  optional uint32 max_dut_tx_sc_per_ca = 4;
-
-  // The maximum number of MACsec devices at test port that can be supported on each CA.
-  // This number is calculated automatically based on the values configured for Max CA
-  // Count and Max DUT Tx SC Per CA. Number of MACsec devices at test port should be configured
-  // accordingly.
-  // default = 256
-  optional uint32 max_device_per_ca = 5;
-
-  message RxScIdentifyingField {
-    enum Enum {
-      unspecified = 0;
-      source_mac = 1;
-      sci_sytem_id = 2;
-      sci_port_id = 3;
-    }
-  }
-  // The field based on which secure channel(SC) will be identified by the receiving port.
-  // Supported fields are:- - 1) source MAC - identify SC based on source MAC field. 2)
-  // SCI system ID - identify SC bbased on SCI system ID field. 3) SCI port ID - identify
-  // based on SCI port ID field.
-  // default = RxScIdentifyingField.Enum.source_mac
-  optional RxScIdentifyingField.Enum rx_sc_identifying_field = 6;
 }
 
 // Configuration of a MKA Key Agreement Entity (KaY). Reference https://1.ieee802.org/security/802-1x/.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8690,7 +8690,7 @@ message MkaBasicOffsetTime {
   optional uint32 mm = 2;
 }
 
-// Absolute time in a timezone.
+// Description missing in models
 message MkaBasicTime {
 
   message Choice {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8233,6 +8233,7 @@ message SecureEntity {
   optional string name = 1;
 
   // This contains the properties of key generation protocol of Secure Entity (SecY).
+  // required = true
   SecureEntityKeyGenerationProtocol key_generation_protocol = 2;
 
   // This contains the properties of data plane of Secure Entity (SecY).
@@ -8291,6 +8292,7 @@ message SecureEntityDataPlaneEncapsulation {
   SecureEntityDataPlaneRx rx = 2;
 
   // Crypto engine properties of SecY.
+  // required = true
   SecureEntityCryptoEngine crypto_engine = 3;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -8680,11 +8680,11 @@ message MkaBasicKeySourcePsk {
 // Offset time.
 message MkaBasicOffsetTime {
 
-  // Hours in hh.
+  // Hours in HH format.
   // default = 0
   optional int32 hh = 1;
 
-  // Minutes in mm.
+  // Minutes in MM format.
   // default = 0
   optional int32 mm = 2;
 }
@@ -8718,13 +8718,13 @@ message MkaBasicTimeUtc {
   // Year from the start of common era(CE) in YYYY format.
   optional int32 year = 3;
 
-  // Hour of the day in hh format.
+  // Hour of the day in HH format.
   optional int32 hour = 4;
 
-  // Minute of the hour in mm format.
+  // Minute of the hour in MM format.
   optional int32 minute = 5;
 
-  // Second of the minute in ss format.
+  // Second of the minute in SS format.
   optional int32 second = 6;
 }
 

--- a/device/device.yaml
+++ b/device/device.yaml
@@ -77,6 +77,11 @@ components:
             Configuration for OSPFv2 router.
           $ref: './ospfv2/router.yaml#/components/schemas/Device.Ospfv2Router'
           x-field-uid: 10
+        macsec:
+          description: >-
+            Configuration of MACsec device.
+          $ref: './macsec/macsec.yaml#/components/schemas/Device.Macsec'
+          x-field-uid: 11
       required: [name]
     Protocol.Options:
       description: >-

--- a/device/macsec/dataplane/cryptoengine.yaml
+++ b/device/macsec/dataplane/cryptoengine.yaml
@@ -7,21 +7,16 @@ components:
       properties:
         choice:
           description: >-
-            Engine type based on encryption and/ or decryption capability. Supported types: 1) encrypt_only - engine can only encrypt transmitted packets but such engine cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent. 2) encrypt_decrypt - engine can both encrypt transmitted packets and decrypt packets on arrival. Such engine can have hardware acceleration for faster encryption/ ddecryption. As both encryption and decryption are possible, stateful (e.g. TCP) traffic can also be sent/ received.
+            Engine type based on encryption and/ or decryption capability. Supported types: encrypt_only - engine can only encrypt transmitted packets but such engine cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent.
           type: string
           default: encrypt_only
           x-field-uid: 1
           x-enum:
             encrypt_only:
               x-field-uid: 1
-            encrypt_decrypt:
-              x-field-uid: 2
         encrypt_only:
           $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly'
           x-field-uid: 2
-        encrypt_decrypt:
-          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt'
-          x-field-uid: 3
     SecureEntity.CryptoEngine.EncryptOnly:
       description: >-
         The container for encrypt only engine configuration.
@@ -34,19 +29,6 @@ components:
           x-field-uid: 1
         traffic_options:
           $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.TrafficOptions'
-          x-field-uid: 2
-    SecureEntity.CryptoEngine.EncryptDecrypt:
-      description: >-
-        The container for encrypt and decrypt engine configuration.
-      type: object
-      properties:
-        secure_channels:
-          type: array
-          items:
-            $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.TxSc'
-          x-field-uid: 1
-        hardware_acceleration:
-          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
           x-field-uid: 2
     SecureEntity.CryptoEngine.EncryptOnly.TxSc:
       description: >-
@@ -145,116 +127,3 @@ components:
           type: boolean
           default: true 
           x-field-uid: 1
-    SecureEntity.CryptoEngine.EncryptDecrypt.TxSc:
-      description: >-
-        Secure channel configuration.
-      type: object
-      properties:
-        tx_pn:
-          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.TxSc.TxPn'
-          x-field-uid: 1
-    SecureEntity.CryptoEngine.EncryptDecrypt.TxSc.TxPn:
-      description: >-
-        Starting packet number(PN) configuration.
-      type: object
-      properties:
-        starting_pn:
-          description: >-
-            Initial Tx packet number(PN).
-          type: integer
-          format: uint32
-          minimum: 1
-          default: 1
-          x-field-uid: 1
-        starting_xpn:
-          description: >-
-            The starting extended packet number(XPN).
-          type: string
-          format: hex
-          minLength: 1
-          maxLength: 16
-          minimum: 1
-          default: "0x0000000000000001"
-          x-field-uid: 3
-    SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration:
-      description: >-
-        Hardware acceleration configuration for offloading MACsec processing to hardware.
-      type: object
-      properties:
-        choice:
-          description: >-
-            Hardware acceleration types.
-          type: string
-          default: none
-          x-field-uid: 1
-          x-enum:
-            none:
-              x-field-uid: 1
-            inline_crypto:
-              x-field-uid: 2
-        inline_crypto:
-          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto'
-          x-field-uid: 2
-    SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
-      description: >-
-        Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
-      type: object
-      properties:
-        rx_sectag_offset:
-          description: >-
-            Offset of Rx secTAG from the first byte in packet.
-          type: integer
-          format: uint32
-          default: 12
-          x-field-uid: 1
-        type_of_ca:
-          description: >-
-            Type of connectivity association(CA).
-          type: string
-          x-field-uid: 2
-          x-enum:
-            pairwise_ca:
-              x-field-uid: 1
-            group_ca_single_dut:
-              x-field-uid: 2
-            group_ca_multipe_duts:
-              x-field-uid: 3
-        max_ca_count:
-          description: >-
-            The maximum number of CAs configured on the port. The maximum count supported per port is 256 for Pair-wise CA, each CA having one MACsec device.
-          type: integer
-          format: uint32
-          minimum: 1
-          maximum: 256
-          default: 256
-          x-field-uid: 3
-        max_dut_tx_sc_per_ca:
-          description: >-
-            The maximum number of DUT transmit SCs that can be supported per CA. The count should be number of Tx SCs supported by the DUT per CA, multiplied by number of DUTs in the CA in case of group CA with multiple DUTs scenario.
-          type: integer
-          format: uint32
-          minimum: 1
-          maximum: 256
-          default: 1
-          x-field-uid: 4
-        max_device_per_ca:
-          description: >-
-            The maximum number of MACsec devices at test port that can be supported on each CA. This number is calculated automatically based on the values configured for Max CA Count and Max DUT Tx SC Per CA. Number of MACsec devices at test port should be configured accordingly.
-          type: integer
-          format: uint32
-          minimum: 1
-          default: 256
-          x-field-uid: 5
-        rx_sc_identifying_field:
-          description: >-
-            The field based on which secure channel(SC) will be identified by the receiving port. Supported fields are:- - 1) source MAC - identify SC based on source MAC field. 2) SCI system ID - identify SC bbased on SCI system ID field. 3) SCI port ID - identify based on SCI port ID field.
-          type: string
-          default: source_mac
-          x-field-uid: 6
-          x-enum:
-            source_mac:
-              x-field-uid: 1
-            sci_sytem_id:
-              x-field-uid: 2
-            sci_port_id:
-              x-field-uid: 3

--- a/device/macsec/dataplane/cryptoengine.yaml
+++ b/device/macsec/dataplane/cryptoengine.yaml
@@ -98,7 +98,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 8
+          maxLength: 16
           minimum: 1
           default: "0x0000000000000006"
           x-field-uid: 2
@@ -130,7 +130,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 8
+          maxLength: 16
           minimum: 1
           default: "0x0000000000010000"
           x-field-uid: 3
@@ -172,7 +172,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 8
+          maxLength: 16
           minimum: 1
           default: "0x0000000000000001"
           x-field-uid: 3

--- a/device/macsec/dataplane/cryptoengine.yaml
+++ b/device/macsec/dataplane/cryptoengine.yaml
@@ -7,7 +7,7 @@ components:
       properties:
         choice:
           description: >-
-            Engine type based on encryption and/ or decryption capability. Supported types: encrypt_only - engine can only encrypt transmitted packets but such engine cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent.
+            Engine type based on encryption and/ or decryption capability. Supported types: encrypt_only - engine can only encrypt transmitted packets but it cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent.
           type: string
           default: encrypt_only
           x-field-uid: 1

--- a/device/macsec/dataplane/cryptoengine.yaml
+++ b/device/macsec/dataplane/cryptoengine.yaml
@@ -197,7 +197,7 @@ components:
           x-field-uid: 2
     Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
       description: >-
-        Inline cryto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
+        Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
       type: object
       properties:
         rx_sectag_offset:

--- a/device/macsec/dataplane/cryptoengine.yaml
+++ b/device/macsec/dataplane/cryptoengine.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.CryptoEngine:
+    SecureEntity.CryptoEngine:
       description: >-
         A container of crypto engine properties of a SecY.
       type: object
@@ -17,12 +17,12 @@ components:
             encrypt_decrypt:
               x-field-uid: 2
         encrypt_only:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly'
           x-field-uid: 2
         encrypt_decrypt:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt'
           x-field-uid: 3
-    Macsec.CryptoEngine.EncryptOnly:
+    SecureEntity.CryptoEngine.EncryptOnly:
       description: >-
         The container for encrypt only engine configuration.
       type: object
@@ -30,12 +30,12 @@ components:
         secure_channels:
           type: array
           items:
-            $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc'
+            $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.TxSc'
           x-field-uid: 1
         traffic_options:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TrafficOptions'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.TrafficOptions'
           x-field-uid: 2
-    Macsec.CryptoEngine.EncryptDecrypt:
+    SecureEntity.CryptoEngine.EncryptDecrypt:
       description: >-
         The container for encrypt and decrypt engine configuration.
       type: object
@@ -43,20 +43,20 @@ components:
         secure_channels:
           type: array
           items:
-            $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc'
+            $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.TxSc'
           x-field-uid: 1
         hardware_acceleration:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
           x-field-uid: 2
-    Macsec.CryptoEngine.EncryptOnly.TxSc:
+    SecureEntity.CryptoEngine.EncryptOnly.TxSc:
       description: >-
         The container for Tx secure channel configuration.
       type: object
       properties:
         tx_pn:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc.TxPn'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.TxSc.TxPn'
           x-field-uid: 1
-    Macsec.CryptoEngine.EncryptOnly.TxSc.TxPn:
+    SecureEntity.CryptoEngine.EncryptOnly.TxSc.TxPn:
       description: >-
         Tx packet number(PN) configuration.
       type: object
@@ -73,12 +73,12 @@ components:
             incrementing_pn:
               x-field-uid: 2
         fixed:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.FixedPn'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.FixedPn'
           x-field-uid: 2
         incrementing:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.IncrementingPn'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptOnly.IncrementingPn'
           x-field-uid: 3
-    Macsec.CryptoEngine.EncryptOnly.FixedPn:
+    SecureEntity.CryptoEngine.EncryptOnly.FixedPn:
       description: >-
         Fixed packet number(PN) configuration.
       type: object
@@ -102,7 +102,7 @@ components:
           minimum: 1
           default: "0x0000000000000006"
           x-field-uid: 2
-    Macsec.CryptoEngine.EncryptOnly.IncrementingPn:
+    SecureEntity.CryptoEngine.EncryptOnly.IncrementingPn:
       description: >-
         Incrementing packet number(PN) configuration.
       type: object
@@ -134,7 +134,7 @@ components:
           minimum: 1
           default: "0x0000000000010000"
           x-field-uid: 3
-    Macsec.CryptoEngine.EncryptOnly.TrafficOptions:
+    SecureEntity.CryptoEngine.EncryptOnly.TrafficOptions:
       description: >-
         Encrypt only traffic options.
       type: object
@@ -145,15 +145,15 @@ components:
           type: boolean
           default: true 
           x-field-uid: 1
-    Macsec.CryptoEngine.EncryptDecrypt.TxSc:
+    SecureEntity.CryptoEngine.EncryptDecrypt.TxSc:
       description: >-
         Secure channel configuration.
       type: object
       properties:
         tx_pn:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc.TxPn'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.TxSc.TxPn'
           x-field-uid: 1
-    Macsec.CryptoEngine.EncryptDecrypt.TxSc.TxPn:
+    SecureEntity.CryptoEngine.EncryptDecrypt.TxSc.TxPn:
       description: >-
         Starting packet number(PN) configuration.
       type: object
@@ -176,7 +176,7 @@ components:
           minimum: 1
           default: "0x0000000000000001"
           x-field-uid: 3
-    Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration:
+    SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration:
       description: >-
         Hardware acceleration configuration for offloading MACsec processing to hardware.
       type: object
@@ -193,9 +193,9 @@ components:
             inline_crypto:
               x-field-uid: 2
         inline_crypto:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto'
+          $ref: '#/components/schemas/SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto'
           x-field-uid: 2
-    Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
+    SecureEntity.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
       description: >-
         Inline crypto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
       type: object

--- a/device/macsec/dataplane/cryptoengine.yaml
+++ b/device/macsec/dataplane/cryptoengine.yaml
@@ -27,8 +27,10 @@ components:
         The container for encrypt only engine configuration.
       type: object
       properties:
-        secure_channel:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc'
+        secure_channels:
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc'
           x-field-uid: 1
         traffic_options:
           $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TrafficOptions'
@@ -38,8 +40,10 @@ components:
         The container for encrypt and decrypt engine configuration.
       type: object
       properties:
-        secure_channel:
-          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc'
+        secure_channels:
+          type: array
+          items:
+            $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc'
           x-field-uid: 1
         hardware_acceleration:
           $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration'

--- a/device/macsec/dataplane/cryptoengine.yaml
+++ b/device/macsec/dataplane/cryptoengine.yaml
@@ -1,0 +1,256 @@
+components:
+  schemas:
+    Macsec.CryptoEngine:
+      description: >-
+        A container of crypto engine properties of a SecY.
+      type: object
+      properties:
+        choice:
+          description: >-
+            Engine type based on encryption and/ or decryption capability. Supported types: 1) encrypt_only - engine can only encrypt transmitted packets but such engine cannot decrypt packets upon arrival. As the packets cannot be decrypted on arrival, such packets cannot be delivered to the receiving device. Hence only stateless traffic can be sent. 2) encrypt_decrypt - engine can both encrypt transmitted packets and decrypt packets on arrival. Such engine can have hardware acceleration for faster encryption/ ddecryption. As both encryption and decryption are possible, stateful (e.g. TCP) traffic can also be sent/ received.
+          type: string
+          default: encrypt_only
+          x-field-uid: 1
+          x-enum:
+            encrypt_only:
+              x-field-uid: 1
+            encrypt_decrypt:
+              x-field-uid: 2
+        encrypt_only:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly'
+          x-field-uid: 2
+        encrypt_decrypt:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt'
+          x-field-uid: 3
+    Macsec.CryptoEngine.EncryptOnly:
+      description: >-
+        The container for encrypt only engine configuration.
+      type: object
+      properties:
+        secure_channel:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc'
+          x-field-uid: 1
+        traffic_options:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TrafficOptions'
+          x-field-uid: 2
+    Macsec.CryptoEngine.EncryptDecrypt:
+      description: >-
+        The container for encrypt and decrypt engine configuration.
+      type: object
+      properties:
+        secure_channel:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc'
+          x-field-uid: 1
+        hardware_acceleration:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration'
+          x-field-uid: 2
+    Macsec.CryptoEngine.EncryptOnly.TxSc:
+      description: >-
+        The container for Tx secure channel configuration.
+      type: object
+      properties:
+        tx_pn:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.TxSc.TxPn'
+          x-field-uid: 1
+    Macsec.CryptoEngine.EncryptOnly.TxSc.TxPn:
+      description: >-
+        Tx packet number(PN) configuration.
+      type: object
+      properties:
+        choice:
+          description: >-
+            Types of Tx packet number(PN) series. Supported choices: 1) fixed PN - MACsec packets will be sent out with the configured fixed PN or lower half of configured fixed XPN. 2) incrementing PN - MACsec packets will be sent out by single device with an incrementing PN or XPN.
+          type: string
+          default: fixed_pn
+          x-field-uid: 1
+          x-enum:
+            fixed_pn:
+              x-field-uid: 1
+            incrementing_pn:
+              x-field-uid: 2
+        fixed:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.FixedPn'
+          x-field-uid: 2
+        incrementing:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptOnly.IncrementingPn'
+          x-field-uid: 3
+    Macsec.CryptoEngine.EncryptOnly.FixedPn:
+      description: >-
+        Fixed packet number(PN) configuration.
+      type: object
+      properties:
+        pn:
+          description: >-
+            Fixed Tx packet number(PN). 4 bytes PN with which all packets will be sent out.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 4294967295
+          default: 6 
+          x-field-uid: 1
+        xpn:
+          description: >-
+            Fixed Tx extended packet number(XPN). 8 bytes XPN with which all packets will be sent out.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 8
+          minimum: 1
+          default: "0x0000000000000006"
+          x-field-uid: 2
+    Macsec.CryptoEngine.EncryptOnly.IncrementingPn:
+      description: >-
+        Incrementing packet number(PN) configuration.
+      type: object
+      properties:
+        count:
+          description: >-
+            Count of packet numbers in series. 
+          type: integer
+          format: uint32
+          minimum: 2
+          maximum: 1000000
+          default: 100
+          x-field-uid: 1
+        starting_pn:
+          description: >-
+            The starting packet number(PN).
+          type: integer
+          format: uint32
+          minimum: 1
+          default: 10000
+          x-field-uid: 2
+        starting_xpn:
+          description: >-
+            The starting extended packet number(XPN).
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 8
+          minimum: 1
+          default: "0x0000000000010000"
+          x-field-uid: 3
+    Macsec.CryptoEngine.EncryptOnly.TrafficOptions:
+      description: >-
+        Encrypt only traffic options.
+      type: object
+      properties:
+        send_gratuitous_arp:
+          description: >-
+            Send gratuitous ARP or not.
+          type: boolean
+          default: true 
+          x-field-uid: 1
+    Macsec.CryptoEngine.EncryptDecrypt.TxSc:
+      description: >-
+        Secure channel configuration.
+      type: object
+      properties:
+        tx_pn:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.TxSc.TxPn'
+          x-field-uid: 1
+    Macsec.CryptoEngine.EncryptDecrypt.TxSc.TxPn:
+      description: >-
+        Starting packet number(PN) configuration.
+      type: object
+      properties:
+        starting_pn:
+          description: >-
+            Initial Tx packet number(PN).
+          type: integer
+          format: uint32
+          minimum: 1
+          default: 1
+          x-field-uid: 1
+        starting_xpn:
+          description: >-
+            The starting extended packet number(XPN).
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 8
+          minimum: 1
+          default: "0x0000000000000001"
+          x-field-uid: 3
+    Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration:
+      description: >-
+        Hardware acceleration configuration for offloading MACsec processing to hardware.
+      type: object
+      properties:
+        choice:
+          description: >-
+            Hardware acceleration types.
+          type: string
+          default: none
+          x-field-uid: 1
+          x-enum:
+            none:
+              x-field-uid: 1
+            inline_crypto:
+              x-field-uid: 2
+        inline_crypto:
+          $ref: '#/components/schemas/Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto'
+          x-field-uid: 2
+    Macsec.CryptoEngine.EncryptDecrypt.HardwareAcceleration.InlineCrypto:
+      description: >-
+        Inline cryto engine configuration. Encryption/ decryption are offloaded to hardware. Also dynamic fields e.g. packet number(PN) and integrity check value(ICV) are updated in MACsec header on transmit.
+      type: object
+      properties:
+        rx_sectag_offset:
+          description: >-
+            Offset of Rx secTAG from the first byte in packet.
+          type: integer
+          format: uint32
+          default: 12
+          x-field-uid: 1
+        type_of_ca:
+          description: >-
+            Type of connectivity association(CA).
+          type: string
+          x-field-uid: 2
+          x-enum:
+            pairwise_ca:
+              x-field-uid: 1
+            group_ca_single_dut:
+              x-field-uid: 2
+            group_ca_multipe_duts:
+              x-field-uid: 3
+        max_ca_count:
+          description: >-
+            The maximum number of CAs configured on the port. The maximum count supported per port is 256 for Pair-wise CA, each CA having one MACsec device.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 256
+          default: 256
+          x-field-uid: 3
+        max_dut_tx_sc_per_ca:
+          description: >-
+            The maximum number of DUT transmit SCs that can be supported per CA. The count should be number of Tx SCs supported by the DUT per CA, multiplied by number of DUTs in the CA in case of group CA with multiple DUTs scenario.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 256
+          default: 1
+          x-field-uid: 4
+        max_device_per_ca:
+          description: >-
+            The maximum number of MACsec devices at test port that can be supported on each CA. This number is calculated automatically based on the values configured for Max CA Count and Max DUT Tx SC Per CA. Number of MACsec devices at test port should be configured accordingly.
+          type: integer
+          format: uint32
+          minimum: 1
+          default: 256
+          x-field-uid: 5
+        rx_sc_identifying_field:
+          description: >-
+            The field based on which secure channel(SC) will be identified by the receiving port. Supported fields are:- - 1) source MAC - identify SC based on source MAC field. 2) SCI system ID - identify SC bbased on SCI system ID field. 3) SCI port ID - identify based on SCI port ID field.
+          type: string
+          default: source_mac
+          x-field-uid: 6
+          x-enum:
+            source_mac:
+              x-field-uid: 1
+            sci_sytem_id:
+              x-field-uid: 2
+            sci_port_id:
+              x-field-uid: 3

--- a/device/macsec/dataplane/dataplane.yaml
+++ b/device/macsec/dataplane/dataplane.yaml
@@ -26,6 +26,7 @@ components:
       description: >-
         A container of encapsulation properties for a secure entity(SecY).
       type: object
+      required: [crypto_engine]
       properties:
         tx:
           description: >-

--- a/device/macsec/dataplane/dataplane.yaml
+++ b/device/macsec/dataplane/dataplane.yaml
@@ -2,7 +2,29 @@ components:
   schemas:
     Macsec.DataPlane:
       description: >-
-        A container of data plane properties for a secure entity(SecY).
+        A container of data plane properties.
+      type: object
+      properties:
+        choice:
+          description: >-
+            Choose "encapsulation" so that data packets are sent with MACsec encapsulation. Choose "no_encapsulation" so that data packets are sent without MACsec encapsulation.
+          type: string
+          default: encapsulation
+          x-field-uid: 1
+          x-enum:
+            encapsulation:
+              x-field-uid: 1
+            no_encapsulation:
+              x-field-uid: 2
+        encapsulation:
+          description: >-
+            A container of encapsulation properties for a secure entity(SecY).
+          $ref: './tx.yaml#/components/schemas/Macsec.DataPlane.Encapsulation'
+          x-field-uid: 2
+
+    Macsec.DataPlane.Encapsulation:
+      description: >-
+        A container of encapsulation properties for a secure entity(SecY).
       type: object
       properties:
         tx:

--- a/device/macsec/dataplane/dataplane.yaml
+++ b/device/macsec/dataplane/dataplane.yaml
@@ -1,0 +1,22 @@
+components:
+  schemas:
+    Macsec.DataPlane:
+      description: >-
+        A container of data plane properties for a secure entity(SecY).
+      type: object
+      properties:
+        tx:
+          description: >-
+            Tx properties of SecY.
+          $ref: './tx.yaml#/components/schemas/Macsec.DataPlane.Tx'
+          x-field-uid: 1
+        rx:
+          description: >-
+            Rx properties of SecY.
+          $ref: './rx.yaml#/components/schemas/Macsec.DataPlane.Rx'
+          x-field-uid: 2
+        crypto_engine:
+          description: >-
+            Crypto engine properties of SecY.
+          $ref: './cryptoengine.yaml#/components/schemas/Macsec.CryptoEngine'
+          x-field-uid: 3

--- a/device/macsec/dataplane/dataplane.yaml
+++ b/device/macsec/dataplane/dataplane.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.DataPlane:
+    SecureEntity.DataPlane:
       description: >-
         A container of data plane properties.
       type: object
@@ -19,10 +19,10 @@ components:
         encapsulation:
           description: >-
             A container of encapsulation properties for a secure entity(SecY).
-          $ref: './tx.yaml#/components/schemas/Macsec.DataPlane.Encapsulation'
+          $ref: './tx.yaml#/components/schemas/SecureEntity.DataPlane.Encapsulation'
           x-field-uid: 2
 
-    Macsec.DataPlane.Encapsulation:
+    SecureEntity.DataPlane.Encapsulation:
       description: >-
         A container of encapsulation properties for a secure entity(SecY).
       type: object
@@ -30,15 +30,15 @@ components:
         tx:
           description: >-
             Tx properties of SecY.
-          $ref: './tx.yaml#/components/schemas/Macsec.DataPlane.Tx'
+          $ref: './tx.yaml#/components/schemas/SecureEntity.DataPlane.Tx'
           x-field-uid: 1
         rx:
           description: >-
             Rx properties of SecY.
-          $ref: './rx.yaml#/components/schemas/Macsec.DataPlane.Rx'
+          $ref: './rx.yaml#/components/schemas/SecureEntity.DataPlane.Rx'
           x-field-uid: 2
         crypto_engine:
           description: >-
             Crypto engine properties of SecY.
-          $ref: './cryptoengine.yaml#/components/schemas/Macsec.CryptoEngine'
+          $ref: './cryptoengine.yaml#/components/schemas/SecureEntity.CryptoEngine'
           x-field-uid: 3

--- a/device/macsec/dataplane/rx.yaml
+++ b/device/macsec/dataplane/rx.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.DataPlane.Rx:
+    SecureEntity.DataPlane.Rx:
       description: >-
         A container for Rx settings of SecY.
       type: object

--- a/device/macsec/dataplane/rx.yaml
+++ b/device/macsec/dataplane/rx.yaml
@@ -1,0 +1,21 @@
+components:
+  schemas:
+    Macsec.DataPlane.Rx:
+      description: >-
+        A container for Rx settings of SecY.
+      type: object
+      properties:
+        replay_protection:
+          description: |-
+            Enable replay protection on not. 
+          type: boolean
+          default: false
+          x-field-uid: 1
+        replay_window:
+          description: |-
+            Replay window size. 
+          type: integer
+          format: uint32
+          minimum: 1
+          default: 1
+          x-field-uid: 2

--- a/device/macsec/dataplane/tx.yaml
+++ b/device/macsec/dataplane/tx.yaml
@@ -1,0 +1,19 @@
+components:
+  schemas:
+    Macsec.DataPlane.Tx:
+      description: >-
+        A container of Tx properties of SecY.
+      type: object
+      properties:
+        end_station:
+          description: |-
+            End station on not.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        include_sci:
+          description: |-
+            Include SCI on not.
+          type: boolean
+          default: false
+          x-field-uid: 2

--- a/device/macsec/dataplane/tx.yaml
+++ b/device/macsec/dataplane/tx.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.DataPlane.Tx:
+    SecureEntity.DataPlane.Tx:
       description: >-
         A container of Tx properties of SecY.
       type: object

--- a/device/macsec/macsec.yaml
+++ b/device/macsec/macsec.yaml
@@ -1,0 +1,82 @@
+components:
+  schemas:
+    Device.Macsec:
+      description: >-
+        A container of properties for a MACsec capable device.
+      type: object
+      required: [ethernet_interfaces]
+      properties:
+        ethernet_interfaces:
+          description: |-
+            Ethernet Interfaces
+          type: array
+          items:
+            $ref: '#/components/schemas/Device.Macsec.EthernetInterface'
+          x-field-uid: 1
+    Device.Macsec.EthernetInterface:
+      description: >-
+        Configuration for single MACsec interface.
+      type: object
+      required: [eth_name, secy]
+      properties:
+        eth_name:
+          description: >-
+            The unique name of the Ethernet interface on which MACsec
+            is enabled.
+          type: string
+          x-constraint:
+          - '/components/schemas/Device.Ethernet/properties/name'
+          x-field-uid: 1
+        secy:
+          description: >-
+            This contains the properties of Secure Entity (SecY).
+          $ref: '#/components/schemas/Macsec'
+          x-field-uid: 2
+
+    Macsec:
+      description: >-
+        Configuration of a Secure Entity (SecY).
+      type: object
+      required: [name]
+      properties:
+        name:
+          x-include: ../../common/common.yaml#/components/schemas/Named.Object/properties/name
+          x-field-uid: 1
+        key_generation_protocol:
+          description: >-
+            This contains the properties of key generation protocol of Secure Entity (SecY).
+          $ref: '#/components/schemas/Macsec.KeyGenerationProtocol'
+          x-field-uid: 2
+        data_plane:
+          description: >-
+            This contains the properties of data plane of Secure Entity (SecY).
+          $ref: './dataplane/dataplane.yaml#/components/schemas/Macsec.DataPlane'
+          x-field-uid: 3
+
+    Macsec.KeyGenerationProtocol:
+      description: >-
+        Container of Key generation protocol configuration.
+      type: object
+      properties:
+        choice:
+          description: >-
+            Key generation protocol choices. Choose "mka" for dynamic key distribution using MACsec key agreement(MKA) protocol. Choose "static_key" for static configuration of secure association key(SAK).
+          type: string
+          default: mka
+          x-field-uid: 1
+          x-enum:
+            mka:
+              x-field-uid: 1
+            static_key:
+              x-field-uid: 2
+        kay:
+          description: |-
+            This contains the properties of Key Agreement Entity (KaY) in MKA supplicant.
+          x-field-uid: 2
+          $ref: './mka/mka.yaml#/components/schemas/Mka'
+
+        static_key:
+          description: >-
+            Static key properties properties of SecY. Static key is used in absence MKA.
+          $ref: './statickey/statickey.yaml#/components/schemas/Macsec.StaticKey'
+          x-field-uid: 3

--- a/device/macsec/macsec.yaml
+++ b/device/macsec/macsec.yaml
@@ -2,7 +2,7 @@ components:
   schemas:
     Device.Macsec:
       description: >-
-        A container of properties for a MACsec capable device.
+        A container of properties for a MACsec capable device. Reference https://1.ieee802.org/security/802-1ae/.
       type: object
       required: [ethernet_interfaces]
       properties:

--- a/device/macsec/macsec.yaml
+++ b/device/macsec/macsec.yaml
@@ -37,7 +37,7 @@ components:
       description: >-
         Configuration of a Secure Entity (SecY).
       type: object
-      required: [name]
+      required: [name, key_generation_protocol]
       properties:
         name:
           x-include: ../../common/common.yaml#/components/schemas/Named.Object/properties/name

--- a/device/macsec/macsec.yaml
+++ b/device/macsec/macsec.yaml
@@ -17,7 +17,7 @@ components:
       description: >-
         Configuration for single MACsec interface.
       type: object
-      required: [eth_name, secy]
+      required: [eth_name, secure_entity]
       properties:
         eth_name:
           description: >-
@@ -27,7 +27,7 @@ components:
           x-constraint:
           - '/components/schemas/Device.Ethernet/properties/name'
           x-field-uid: 1
-        secy:
+        secure_entity:
           description: >-
             This contains the properties of Secure Entity (SecY).
           $ref: '#/components/schemas/Macsec'
@@ -69,7 +69,7 @@ components:
               x-field-uid: 1
             static_key:
               x-field-uid: 2
-        kay:
+        mka:
           description: |-
             This contains the properties of Key Agreement Entity (KaY) in MKA supplicant.
           x-field-uid: 2

--- a/device/macsec/macsec.yaml
+++ b/device/macsec/macsec.yaml
@@ -30,10 +30,10 @@ components:
         secure_entity:
           description: >-
             This contains the properties of Secure Entity (SecY).
-          $ref: '#/components/schemas/Macsec'
+          $ref: '#/components/schemas/SecureEntity'
           x-field-uid: 2
 
-    Macsec:
+    SecureEntity:
       description: >-
         Configuration of a Secure Entity (SecY).
       type: object
@@ -45,15 +45,15 @@ components:
         key_generation_protocol:
           description: >-
             This contains the properties of key generation protocol of Secure Entity (SecY).
-          $ref: '#/components/schemas/Macsec.KeyGenerationProtocol'
+          $ref: '#/components/schemas/SecureEntity.KeyGenerationProtocol'
           x-field-uid: 2
         data_plane:
           description: >-
             This contains the properties of data plane of Secure Entity (SecY).
-          $ref: './dataplane/dataplane.yaml#/components/schemas/Macsec.DataPlane'
+          $ref: './dataplane/dataplane.yaml#/components/schemas/SecureEntity.DataPlane'
           x-field-uid: 3
 
-    Macsec.KeyGenerationProtocol:
+    SecureEntity.KeyGenerationProtocol:
       description: >-
         Container of Key generation protocol configuration.
       type: object
@@ -78,5 +78,5 @@ components:
         static_key:
           description: >-
             Static key properties properties of SecY. Static key is used in absence MKA.
-          $ref: './statickey/statickey.yaml#/components/schemas/Macsec.StaticKey'
+          $ref: './statickey/statickey.yaml#/components/schemas/SecureEntity.StaticKey'
           x-field-uid: 3

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -57,44 +57,61 @@ components:
             Supported Cipher Suites.
           x-field-uid: 6
           $ref: '#/components/schemas/Mka.Basic.SupportedCipherSuites'
+        eapol_ethernet_type:
+          description: |-
+              EAPOL Ethernet type.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 4
+          default: "0x888E"     
+          x-field-uid: 7
         mka_version:
           description: |-
             MKA Version.
           type: integer
           format: uint32
           default: 3
-          x-field-uid: 7
+          x-field-uid: 8
         mka_hello_time:
           description: |-
             MKA Hello Time (msec).
           type: integer
           format: uint32
           default: 2000
-          x-field-uid: 8
+          x-field-uid: 9
         mka_life_time:
           description: |-
             MKA Life Time (sec).
           type: integer
           format: uint32
           default: 6
-          x-field-uid: 9
+          x-field-uid: 10
         send_icv_indicatior_in_mkpdu:
           description: |-
             Send ICV Indicator in MKPDU.
           type: boolean
           default: true
-          x-field-uid: 10
+          x-field-uid: 11
         delay_protect:
           description: |-
             Delay Protect.
           type: boolean
           default: true
-          x-field-uid: 11
+          x-field-uid: 12
         rekey_mode:
           description: >-
             Rekey Mode.
-          x-field-uid: 12
+          x-field-uid: 13
           $ref: '#/components/schemas/Mka.Basic.RekeyMode'
+        psk_chain_start_time:
+          description: |-
+              Pre-shared key(PSK) chain start time (in UTC - DD-MM-YYYY HH:MM:SS). The key start time will be relative to this value.
+          type: string
+          minLength: 19
+          maxLength: 19
+          default: "00-00-0000 00:00:00"     
+          x-field-uid: 14
 
     Mka.Basic.SupportedCipherSuites:
       description: >-

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -106,7 +106,7 @@ components:
           $ref: '#/components/schemas/Mka.Basic.RekeyMode'
         psk_chain_start_time:
           description: |-
-              Pre-shared key(PSK) chain start time (in UTC - DD-MM-YYYY HH:MM:SS). The key start time will be relative to this value.
+              Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. The key start time will be relative to this value.
           type: string
           minLength: 19
           maxLength: 19
@@ -192,13 +192,13 @@ components:
           x-field-uid: 2
         start_time:
           description: |-
-              Key start time in HH:MM. This is relative to test start time.
+              Key start time in HH:MM. This is relative to key chain start time.
           type: string
           default: "00:00"
           x-field-uid: 3
         end_time:
           description: |-
-              Key end time in HH:MM. This is relative to test start time.
+              Key end time in HH:MM. This is relative to key chain start time.
           type: string
           default: "00:00"
           x-field-uid: 4

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -209,14 +209,14 @@ components:
       properties:
         hh:
           description: |-
-            Hours in hh.
+            Hours in HH format.
           type: integer
           minimum: 0
           default: 0
           x-field-uid: 1
         mm:
           description: |-
-            Minutes in mm.
+            Minutes in MM format.
           type: integer
           minimum: 0
           default: 0
@@ -270,21 +270,21 @@ components:
           x-field-uid: 3
         hour:
           description: |-
-              Hour of the day in hh format.
+              Hour of the day in HH format.
           type: integer
           minimum: 0
           maximum: 23
           x-field-uid: 4
         minute:
           description: |-
-              Minute of the hour in mm format.
+              Minute of the hour in MM format.
           type: integer
           minimum: 0
           maximum: 59
           x-field-uid: 5
         second:
           description: |-
-              Second of the minute in ss format.
+              Second of the minute in SS format.
           type: integer
           minimum: 0
           maximum: 59

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -1,0 +1,246 @@
+components:
+  schemas:
+    Mka.Basic:
+      description: >-
+        A container of basic properties for a KaY.
+      type: object
+      required: [key_source]
+      properties:
+        key_derivation_function:
+          description: >-
+            Key Derivation Function.
+          type: string
+          default: aes_cmac_128
+          x-field-uid: 1
+          x-enum:
+            aes_cmac_128:
+              x-field-uid: 1
+            aes_cmac_256:
+              x-field-uid: 2
+        key_source:
+          description: >-
+            Key source.
+          x-field-uid: 2
+          $ref: '#/components/schemas/Mka.Basic.KeySource'
+        actor_priority:
+          description: |-
+              Actor priority.
+          type: string
+          format: hex
+          minLength: 2
+          maxLength: 2
+          default: "70"
+          x-field-uid: 3
+        macsec_desired:
+          description: |-
+            Determines whether MACsec is desired or not. It is advertised in periodic Hellos.
+          type: boolean
+          default: true
+          x-field-uid: 4
+        macsec_capability:
+          description: |-
+              MACSec Capability.
+          type: string
+          default: macsec_integrity_with_confidentiality_offset
+          x-field-uid: 5
+          x-enum:
+            macsec_not_implemented:
+              x-field-uid: 1
+            macsec_integrity_without_confidentiality:
+              x-field-uid: 2
+            macsec_integrity_with_no_confidentiality_offset:
+              x-field-uid: 3
+            macsec_integrity_with_confidentiality_offset:
+              x-field-uid: 4
+        supported_cipher_suites:
+          description: |-
+            Supported Cipher Suites.
+          x-field-uid: 6
+          $ref: '#/components/schemas/Mka.Basic.SupportedCipherSuites'
+        mka_version:
+          description: |-
+            MKA Version.
+          type: integer
+          format: uint32
+          default: 3
+          x-field-uid: 7
+        mka_hello_time:
+          description: |-
+            MKA Hello Time (msec).
+          type: integer
+          format: uint32
+          default: 2000
+          x-field-uid: 8
+        mka_life_time:
+          description: |-
+            MKA Life Time (sec).
+          type: integer
+          format: uint32
+          default: 6
+          x-field-uid: 9
+        send_icv_indicatior_in_mkpdu:
+          description: |-
+            Send ICV Indicator in MKPDU.
+          type: boolean
+          default: true
+          x-field-uid: 10
+        delay_protect:
+          description: |-
+            Delay Protect.
+          type: boolean
+          default: true
+          x-field-uid: 11
+        rekey_mode:
+          description: >-
+            Rekey Mode.
+          x-field-uid: 12
+          $ref: '#/components/schemas/Mka.Basic.RekeyMode'
+
+    Mka.Basic.SupportedCipherSuites:
+      description: >-
+        The container for supported cipher suites.
+      type: object
+      properties:
+        gcm_aes_128:
+          description: |-
+              GCM-AES-128.
+          type: boolean
+          default: true
+          x-field-uid: 1
+        gcm_aes_256:
+          description: |-
+              GCM-AES-256.
+          type: boolean
+          default: true
+          x-field-uid: 2
+        gcm_aes_xpn_128:
+          description: |-
+              GCM-AES-XPN-128.
+          type: boolean
+          default: true
+          x-field-uid: 3
+        gcm_aes_xpn_256:
+          description: |-
+              GCM-AES-XPN-256.
+          type: boolean
+          default: true
+          x-field-uid: 4
+
+    Mka.Basic.KeySource:
+      description: >-
+        The container for key source settings.
+      type: object
+      properties:
+        choice:
+          description: |-
+              Key source. Choose one from PSK or MSK.
+          type: string
+          default: psk
+          x-field-uid: 1
+          x-enum:
+            psk:
+              x-field-uid: 1
+            msk:
+              x-field-uid: 2
+        psks:
+          description: |-
+            PSK chain.
+          type: array
+          items:
+            $ref: '#/components/schemas/Mka.Basic.KeySource.Psk'
+          x-field-uid: 2
+
+    Mka.Basic.KeySource.Psk:
+      description: >-
+        The container for Pre-shared key(PSK).
+      type: object
+      properties:
+        cak_value:
+          description: |-
+              Connectivity association key(CAK) value.
+          type: string
+          format: hex
+          minLength: 16
+          maxLength: 32
+          default: "F123456789ABCDEF0123456789ABCDEF"     
+          x-field-uid: 1
+        cak_name:
+          description: |-
+              Connectivity association key(CAK) name.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 32
+          default: "F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF"
+          x-field-uid: 2
+        start_time:
+          description: |-
+              Key start time in HH:MM. This is relative to test start time.
+          type: string
+          default: "00:00"
+          x-field-uid: 3
+        end_time:
+          description: |-
+              Key end time in HH:MM. This is relative to test start time.
+          type: string
+          default: "00:00"
+          x-field-uid: 4
+
+    Mka.Basic.RekeyMode:
+      description: >-
+        Rekey mode.
+      type: object
+      properties:
+        choice:
+          description: |-
+              Mode choices.
+          type: string
+          default: dont_rekey
+          x-field-uid: 1
+          x-enum:
+            dont_rekey:
+              x-field-uid: 1
+            timer_based:
+              x-field-uid: 2
+            pn_based:
+              x-field-uid: 3
+        timer_based:
+          description: |-
+              Container for timer based periodic rekey properties.
+          x-field-uid: 2
+          $ref: '#/components/schemas/Mka.Basic.RekeyMode.TimerBased'
+
+    Mka.Basic.RekeyMode.TimerBased:
+      description: >-
+          Timer based periodic rekey properties.
+      type: object
+      properties:
+        choice:
+          description: |-
+              Periodic Rekey count.
+          type: string
+          default: continuous
+          x-field-uid: 1
+          x-enum:
+            continuous:
+              x-field-uid: 1
+            fixed_count:
+              x-field-uid: 2
+        fixed_count:
+          description: |-
+              Fixed rekey attempts.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 10
+          x-field-uid: 2
+        interval:
+          description: |-
+              Periodic rekey interval (sec).
+          type: integer
+          format: uint32
+          minimum: 30
+          maximum: 65535
+          default: 300
+          x-field-uid: 3

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -99,7 +99,7 @@ components:
           x-field-uid: 11
         delay_protect:
           description: |-
-            Delay Protect or not. When delay protect is enabled, it guards against delaying the delivery of MACsec encrypted frames by an attacker to the receipient.
+            Delay Protect or not. When delay protect is enabled, it guards against delaying the delivery of MACsec encrypted frames by an attacker to the recipient.
           type: boolean
           default: true
           x-field-uid: 12
@@ -197,15 +197,102 @@ components:
         start_offset_time:
           description: |-
               Key start offset time in HH:MM. This is relative to key chain start time.
-          type: string
-          default: "00:00"
+          $ref: '#/components/schemas/Mka.Basic.OffsetTime'
           x-field-uid: 3
         end_offset_time:
           description: |-
               Key end offset time in HH:MM. This is relative to key chain start time.
-          type: string
-          default: "00:00"
+          $ref: '#/components/schemas/Mka.Basic.OffsetTime'
           x-field-uid: 4
+
+    Mka.Basic.OffsetTime:
+      description: >-
+        Offset time.
+      type: object
+      properties:
+        hh:
+          description: |-
+            Hours in hh.
+          type: integer
+          minimum: 0
+          default: 0
+          x-field-uid: 1
+      properties:
+        mm:
+          description: |-
+            Minutes in mm.
+          type: integer
+          minimum: 0
+          default: 0
+          x-field-uid: 2
+
+    Mka.Basic.Time:
+      description: >-
+        Absolute time in a timezone.
+      type: object
+      properties:
+        choice:
+          description: |-
+            Timezone choice. Currently only Coordinated Universal Time(UTC) is supported.
+          type: string
+          default: utc
+          x-field-uid: 1
+          x-enum:
+            utc:
+              x-field-uid: 1
+        utc:
+          description: |-
+            Coordinated Universal Time(UTC) time.
+          $ref: '#/components/schemas/Mka.Basic.TimeUtc'
+          x-field-uid: 2
+
+    Mka.Basic.TimeUtc:
+      description: >-
+        Coordinated Universal Time(UTC).
+      type: object
+      properties:
+        day:
+          description: |-
+              Day of the month in DD format.
+          type: integer
+          minimum: 1
+          maximum: 31
+          x-field-uid: 1
+        month:
+          description: |-
+              Month of the year in MM format.
+          type: integer
+          minimum: 1
+          maximum: 12
+          x-field-uid: 2
+        year:
+          description: |-
+              Year from the start of common era(CE) in YYYY format.
+          type: integer
+          minimum: 0
+          maximum: 9999
+          x-field-uid: 3
+        hour:
+          description: |-
+              Hour of the day in hh format.
+          type: integer
+          minimum: 0
+          maximum: 23
+          x-field-uid: 4
+        minute:
+          description: |-
+              Minute of the hour in mm format.
+          type: integer
+          minimum: 0
+          maximum: 59
+          x-field-uid: 5
+        second:
+          description: |-
+              Second of the minute in ss format.
+          type: integer
+          minimum: 0
+          maximum: 59
+          x-field-uid: 6
 
     Mka.Basic.RekeyMode:
       description: >-

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -109,9 +109,7 @@ components:
           $ref: '#/components/schemas/Mka.Basic.RekeyMode'
           x-field-uid: 13
         psk_chain_start_time:
-          description: |-
-              Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this time is set, the key start time will be relative to this value. Otherwise if this value is not set, key start time will be relative to test start time.
-          $ref: '#/components/schemas/Mka.Basic.Time'
+          $ref: '#/components/schemas/Mka.Basic.PskChainStartTime'
           x-field-uid: 14
 
     Mka.Basic.SupportedCipherSuites:
@@ -224,7 +222,9 @@ components:
           default: 0
           x-field-uid: 2
 
-    Mka.Basic.Time:
+    Mka.Basic.PskChainStartTime:
+      description: >-
+        Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this time is set, the key start time will be relative to this value. Otherwise if this value is not set, key start time will be relative to test start time.
       type: object
       properties:
         choice:

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -78,6 +78,8 @@ components:
             MKA Hello Time (msec).
           type: integer
           format: uint32
+          minimum: 500
+          maximum: 10000
           default: 2000
           x-field-uid: 9
         mka_life_time:
@@ -85,6 +87,8 @@ components:
             MKA Life Time (sec).
           type: integer
           format: uint32
+          minimum: 1
+          maximum: 255
           default: 6
           x-field-uid: 10
         send_icv_indicatior_in_mkpdu:
@@ -95,7 +99,7 @@ components:
           x-field-uid: 11
         delay_protect:
           description: |-
-            Delay Protect.
+            Delay Protect or not. When delay protect is enabled, it guards against delaying the delivery of MACsec encrypted frames by an attacker to the receipient.
           type: boolean
           default: true
           x-field-uid: 12
@@ -190,15 +194,15 @@ components:
           maxLength: 64
           default: "F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF"
           x-field-uid: 2
-        start_time:
+        start_offset_time:
           description: |-
-              Key start time in HH:MM. This is relative to key chain start time.
+              Key start offset time in HH:MM. This is relative to key chain start time.
           type: string
           default: "00:00"
           x-field-uid: 3
-        end_time:
+        end_offset_time:
           description: |-
-              Key end time in HH:MM. This is relative to key chain start time.
+              Key end offset time in HH:MM. This is relative to key chain start time.
           type: string
           default: "00:00"
           x-field-uid: 4

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -217,6 +217,7 @@ components:
           type: integer
           format: uint32
           minimum: 0
+          maximum: 59
           default: 0
           x-field-uid: 2
 
@@ -239,6 +240,7 @@ components:
           type: integer
           format: uint32
           minimum: 0
+          maximum: 59
           default: 0
           x-field-uid: 2
 

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -211,6 +211,7 @@ components:
           description: |-
             Hours in HH format.
           type: integer
+          format: uint32
           minimum: 0
           default: 0
           x-field-uid: 1
@@ -218,6 +219,7 @@ components:
           description: |-
             Minutes in MM format.
           type: integer
+          format: uint32
           minimum: 0
           default: 0
           x-field-uid: 2
@@ -251,6 +253,7 @@ components:
           description: |-
               Day of the month in DD format.
           type: integer
+          format: uint32
           minimum: 1
           maximum: 31
           x-field-uid: 1
@@ -258,6 +261,7 @@ components:
           description: |-
               Month of the year in MM format.
           type: integer
+          format: uint32
           minimum: 1
           maximum: 12
           x-field-uid: 2
@@ -265,6 +269,7 @@ components:
           description: |-
               Year from the start of common era(CE) in YYYY format.
           type: integer
+          format: uint32
           minimum: 0
           maximum: 9999
           x-field-uid: 3
@@ -272,6 +277,7 @@ components:
           description: |-
               Hour of the day in HH format.
           type: integer
+          format: uint32
           minimum: 0
           maximum: 23
           x-field-uid: 4
@@ -279,6 +285,7 @@ components:
           description: |-
               Minute of the hour in MM format.
           type: integer
+          format: uint32
           minimum: 0
           maximum: 59
           x-field-uid: 5
@@ -286,6 +293,7 @@ components:
           description: |-
               Second of the minute in SS format.
           type: integer
+          format: uint32
           minimum: 0
           maximum: 59
           x-field-uid: 6

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -106,15 +106,12 @@ components:
         rekey_mode:
           description: >-
             Rekey Mode.
-          x-field-uid: 13
           $ref: '#/components/schemas/Mka.Basic.RekeyMode'
+          x-field-uid: 13
         psk_chain_start_time:
           description: |-
               Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. The key start time will be relative to this value.
-          type: string
-          minLength: 19
-          maxLength: 19
-          default: "00-00-0000 00:00:00"     
+          $ref: '#/components/schemas/Mka.Basic.Time'
           x-field-uid: 14
 
     Mka.Basic.SupportedCipherSuites:
@@ -196,12 +193,12 @@ components:
           x-field-uid: 2
         start_offset_time:
           description: |-
-              Key start offset time in HH:MM. This is relative to key chain start time.
+            Key start offset time in HH:MM. This is relative to key chain start time.
           $ref: '#/components/schemas/Mka.Basic.OffsetTime'
           x-field-uid: 3
         end_offset_time:
           description: |-
-              Key end offset time in HH:MM. This is relative to key chain start time.
+            Key end offset time in HH:MM. This is relative to key chain start time.
           $ref: '#/components/schemas/Mka.Basic.OffsetTime'
           x-field-uid: 4
 
@@ -217,7 +214,6 @@ components:
           minimum: 0
           default: 0
           x-field-uid: 1
-      properties:
         mm:
           description: |-
             Minutes in mm.

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -225,8 +225,6 @@ components:
           x-field-uid: 2
 
     Mka.Basic.Time:
-      description: >-
-        Absolute time in a timezone.
       type: object
       properties:
         choice:

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -27,7 +27,7 @@ components:
               Actor priority.
           type: string
           format: hex
-          minLength: 2
+          minLength: 1
           maxLength: 2
           default: "70"
           x-field-uid: 3
@@ -64,7 +64,7 @@ components:
           format: hex
           minLength: 1
           maxLength: 4
-          default: "0x888E"     
+          default: "888E"     
           x-field-uid: 7
         mka_version:
           description: |-
@@ -174,11 +174,11 @@ components:
       properties:
         cak_value:
           description: |-
-              Connectivity association key(CAK) value.
+              Connectivity association key(CAK) value. It can be 128 bits or 256 bits long depending on the chosen MKA key derivation function.
           type: string
           format: hex
-          minLength: 16
-          maxLength: 32
+          minLength: 1
+          maxLength: 64
           default: "F123456789ABCDEF0123456789ABCDEF"     
           x-field-uid: 1
         cak_name:
@@ -187,7 +187,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 32
+          maxLength: 64
           default: "F123456789ABCDEF0123456789ABCDEFF123456789ABCDEF0123456789ABCDEF"
           x-field-uid: 2
         start_time:

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -110,7 +110,7 @@ components:
           x-field-uid: 13
         psk_chain_start_time:
           description: |-
-              Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. The key start time will be relative to this value.
+              Pre-shared key(PSK) chain start time in UTC time format DD-MM-YYYY HH:MM:SS. If this time is set, the key start time will be relative to this value. Otherwise if this value is not set, key start time will be relative to test start time.
           $ref: '#/components/schemas/Mka.Basic.Time'
           x-field-uid: 14
 

--- a/device/macsec/mka/basic.yaml
+++ b/device/macsec/mka/basic.yaml
@@ -191,18 +191,38 @@ components:
           x-field-uid: 2
         start_offset_time:
           description: |-
-            Key start offset time in HH:MM. This is relative to key chain start time.
-          $ref: '#/components/schemas/Mka.Basic.OffsetTime'
+          $ref: '#/components/schemas/Mka.Basic.StartOffsetTime'
           x-field-uid: 3
         end_offset_time:
           description: |-
-            Key end offset time in HH:MM. This is relative to key chain start time.
-          $ref: '#/components/schemas/Mka.Basic.OffsetTime'
+          $ref: '#/components/schemas/Mka.Basic.EndOffsetTime'
           x-field-uid: 4
 
-    Mka.Basic.OffsetTime:
+    Mka.Basic.StartOffsetTime:
       description: >-
-        Offset time.
+        Key start offset time in HH:MM. This is relative to key chain start time.
+      type: object
+      properties:
+        hh:
+          description: |-
+            Hours in HH format.
+          type: integer
+          format: uint32
+          minimum: 0
+          default: 0
+          x-field-uid: 1
+        mm:
+          description: |-
+            Minutes in MM format.
+          type: integer
+          format: uint32
+          minimum: 0
+          default: 0
+          x-field-uid: 2
+
+    Mka.Basic.EndOffsetTime:
+      description: >-
+        Key end offset time in HH:MM. This is relative to key chain start time. A value of "00:00" makes the key valid for lifetime.
       type: object
       properties:
         hh:

--- a/device/macsec/mka/keyserver.yaml
+++ b/device/macsec/mka/keyserver.yaml
@@ -1,0 +1,72 @@
+components:
+  schemas:
+    Mka.KeyServer:
+      description: >-
+        Key server attributes of a KaY.
+      properties:
+        confidentialty_offset:
+          description: >-
+            Confidentiality Offset.
+          type: string
+          default: no_confidentiality_offset
+          x-field-uid: 1
+          x-enum:
+            no_confidentiality:
+              x-field-uid: 1
+            no_confidentiality_offset:
+              x-field-uid: 2
+            confidentiality_offset_30_octets:
+              x-field-uid: 3
+            confidentiality_offset_50_octets:
+              x-field-uid: 4
+        cipher_suite:
+          description: |-
+              The cipher suite. Choose one from GCM-AES-128 GCM-AES-256 GCM-AES-XPN-128 GCM-AES-XPN-256
+          type: string
+          default: gcm_aes_128
+          x-field-uid: 2
+          x-enum:
+            gcm_aes_128:
+              x-field-uid: 1
+            gcm_aes_256:
+              x-field-uid: 2
+            gcm_aes_xpn_128:
+              x-field-uid: 3
+            gcm_aes_xpn_256:
+              x-field-uid: 4
+        starting_key_number:
+          description: |-
+              Starting Key Number.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 1
+          x-field-uid: 3
+        starting_distributed_an:
+          description: |-
+              Starting Distributed AN.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 3
+          default: 0
+          x-field-uid: 4
+        rekey_threshold_pn:
+          description: |-
+              Determines the PN rekey threshold.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 4
+          default: "C0000000"
+          x-field-uid: 5
+        rekey_threshold_xpn:
+          description: |-
+              Determines the XPN rekey threshold.
+          type: string
+          format: hex
+          minLength: 1
+          maxLength: 8
+          default: "C000000000000000"
+          x-field-uid: 6

--- a/device/macsec/mka/keyserver.yaml
+++ b/device/macsec/mka/keyserver.yaml
@@ -58,7 +58,7 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 4
+          maxLength: 8
           default: "C0000000"
           x-field-uid: 5
         rekey_threshold_xpn:
@@ -67,6 +67,6 @@ components:
           type: string
           format: hex
           minLength: 1
-          maxLength: 8
+          maxLength: 16
           default: "C000000000000000"
           x-field-uid: 6

--- a/device/macsec/mka/mka.yaml
+++ b/device/macsec/mka/mka.yaml
@@ -2,7 +2,7 @@ components:
   schemas:
     Mka:
       description: >-
-        Configuration of a Key Agreement Entity (KaY).
+        Configuration of a MKA Key Agreement Entity (KaY). Reference https://1.ieee802.org/security/802-1x/.
       type: object
       required: [name, basic, tx]
       properties:

--- a/device/macsec/mka/mka.yaml
+++ b/device/macsec/mka/mka.yaml
@@ -4,7 +4,7 @@ components:
       description: >-
         Configuration of a Key Agreement Entity (KaY).
       type: object
-      required: [name, basic, txscs]
+      required: [name, basic, tx]
       properties:
         name:
           x-include: ../../common/common.yaml#/components/schemas/Named.Object/properties/name
@@ -19,10 +19,10 @@ components:
             Key server attributes.
           $ref: './keyserver.yaml#/components/schemas/Mka.KeyServer'
           x-field-uid: 3
-        txscs:
+        tx:
           description: >-
-            Properties for Tx secure channels.
+            Tx Properties.
           type: array
           items:
-            $ref: './txsc.yaml#/components/schemas/Mka.TxSc'
+            $ref: './tx.yaml#/components/schemas/Mka.Tx'
           x-field-uid: 4

--- a/device/macsec/mka/mka.yaml
+++ b/device/macsec/mka/mka.yaml
@@ -21,6 +21,6 @@ components:
           x-field-uid: 3
         tx:
           description: >-
-            The Tx Properties.
+            Tx Properties.
           $ref: './tx.yaml#/components/schemas/Mka.Tx'
           x-field-uid: 4

--- a/device/macsec/mka/mka.yaml
+++ b/device/macsec/mka/mka.yaml
@@ -21,6 +21,6 @@ components:
           x-field-uid: 3
         tx:
           description: >-
-            Tx Properties.
+            The Tx Properties.
           $ref: './tx.yaml#/components/schemas/Mka.Tx'
           x-field-uid: 4

--- a/device/macsec/mka/mka.yaml
+++ b/device/macsec/mka/mka.yaml
@@ -22,7 +22,5 @@ components:
         tx:
           description: >-
             Tx Properties.
-          type: array
-          items:
-            $ref: './tx.yaml#/components/schemas/Mka.Tx'
+          $ref: './tx.yaml#/components/schemas/Mka.Tx'
           x-field-uid: 4

--- a/device/macsec/mka/mka.yaml
+++ b/device/macsec/mka/mka.yaml
@@ -1,0 +1,28 @@
+components:
+  schemas:
+    Mka:
+      description: >-
+        Configuration of a Key Agreement Entity (KaY).
+      type: object
+      required: [name, basic, txscs]
+      properties:
+        name:
+          x-include: ../../common/common.yaml#/components/schemas/Named.Object/properties/name
+          x-field-uid: 1
+        basic:
+          description: >-
+            This contains the basic properties of KaY.
+          $ref: './basic.yaml#/components/schemas/Mka.Basic'
+          x-field-uid: 2
+        key_server:
+          description: >-
+            Key server attributes.
+          $ref: './keyserver.yaml#/components/schemas/Mka.KeyServer'
+          x-field-uid: 3
+        txscs:
+          description: >-
+            Properties for Tx secure channels.
+          type: array
+          items:
+            $ref: './txsc.yaml#/components/schemas/Mka.TxSc'
+          x-field-uid: 4

--- a/device/macsec/mka/tx.yaml
+++ b/device/macsec/mka/tx.yaml
@@ -9,7 +9,5 @@ components:
         secure_channels:
           description: >-
             Tx secure channels.
-          type: array
-          items:
-            $ref: './txsc.yaml#/components/schemas/Mka.TxSc'
+          $ref: './txsc.yaml#/components/schemas/Mka.TxSc'
           x-field-uid: 1

--- a/device/macsec/mka/tx.yaml
+++ b/device/macsec/mka/tx.yaml
@@ -8,7 +8,7 @@ components:
       properties:
         secure_channels:
           description: >-
-            The Tx secure channels.
+            Tx secure channels.
           type: array
           items:
             $ref: './txsc.yaml#/components/schemas/Mka.TxSc'

--- a/device/macsec/mka/tx.yaml
+++ b/device/macsec/mka/tx.yaml
@@ -9,5 +9,7 @@ components:
         secure_channels:
           description: >-
             Tx secure channels.
-          $ref: './txsc.yaml#/components/schemas/Mka.TxSc'
+          type: array
+          items:
+            $ref: './txsc.yaml#/components/schemas/Mka.TxSc'
           x-field-uid: 1

--- a/device/macsec/mka/tx.yaml
+++ b/device/macsec/mka/tx.yaml
@@ -8,7 +8,7 @@ components:
       properties:
         secure_channels:
           description: >-
-            Tx secure channels.
+            The Tx secure channels.
           type: array
           items:
             $ref: './txsc.yaml#/components/schemas/Mka.TxSc'

--- a/device/macsec/mka/tx.yaml
+++ b/device/macsec/mka/tx.yaml
@@ -1,0 +1,15 @@
+components:
+  schemas:
+    Mka.Tx:
+      description: >-
+        A container of Tx properties.
+      type: object
+      required: [secure_channels]
+      properties:
+        secure_channels:
+          description: >-
+            Tx secure channels.
+          type: array
+          items:
+            $ref: './txsc.yaml#/components/schemas/Mka.TxSc'
+          x-field-uid: 1

--- a/device/macsec/mka/txsc.yaml
+++ b/device/macsec/mka/txsc.yaml
@@ -1,0 +1,37 @@
+components:
+  schemas:
+    Mka.TxSc:
+      description: >-
+        Tx secure channel(SC) properties.
+      type: object
+      required: [name, system_id]
+      properties:
+        name:
+          description: |-
+            Tx SC name.
+          type: string
+          x-field-uid: 1
+        system_id:
+          description: |-
+            System ID. 
+          type: string
+          format: mac
+          x-field-uid: 2
+        port_id:
+          description: |-
+            Port ID. 
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 1
+          x-field-uid: 3
+        starting_message_number:
+          description: |-
+            Starting Message Number.
+          type: integer
+          format: uint64
+          minimum: 1
+          maximum: 4294967295
+          default: 1
+          x-field-uid: 4

--- a/device/macsec/statickey/rx.yaml
+++ b/device/macsec/statickey/rx.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.StaticKey.Rx:
+    SecureEntity.StaticKey.Rx:
       description: >-
         A container of static key Rx properties.
       type: object
@@ -10,5 +10,5 @@ components:
             Rx secure channels.
           type: array
           items:
-            $ref: './rxsc.yaml#/components/schemas/Macsec.StaticKey.RxSc'
+            $ref: './rxsc.yaml#/components/schemas/SecureEntity.StaticKey.RxSc'
           x-field-uid: 1

--- a/device/macsec/statickey/rx.yaml
+++ b/device/macsec/statickey/rx.yaml
@@ -1,0 +1,14 @@
+components:
+  schemas:
+    Macsec.StaticKey.Rx:
+      description: >-
+        A container of static key Rx properties.
+      type: object
+      properties:
+        secure_channels:
+          description: >-
+            Rx secure channels.
+          type: array
+          items:
+            $ref: './rxsc.yaml#/components/schemas/Macsec.StaticKey.RxSc'
+          x-field-uid: 1

--- a/device/macsec/statickey/rxsc.yaml
+++ b/device/macsec/statickey/rxsc.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.StaticKey.RxSc:
+    SecureEntity.StaticKey.RxSc:
       description: |-
         Rx SC settings.
       type: object
@@ -34,5 +34,5 @@ components:
             Rx SAK pool.
           type: array
           items:
-            $ref: './statickey.yaml#/components/schemas/Macsec.StaticKey.Sak'
+            $ref: './statickey.yaml#/components/schemas/SecureEntity.StaticKey.Sak'
           x-field-uid: 4

--- a/device/macsec/statickey/rxsc.yaml
+++ b/device/macsec/statickey/rxsc.yaml
@@ -1,0 +1,38 @@
+components:
+  schemas:
+    Macsec.StaticKey.RxSc:
+      description: |-
+        Rx SC settings.
+      type: object
+      properties:
+        dut_sci_system_id:
+          description: |-
+            System ID in DUT SCI. 
+          type: string
+          format: mac
+          x-field-uid: 1
+        dut_sci_port_id:
+          description: |-
+            Port ID in DUT SCI. 
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 1
+          x-field-uid: 2
+        dut_msb_xpn:
+          description: |-
+            DUT MSB of XPN. The 32 most significant bits of the XPN that DUT will be using to construct the 64 bits XPN value when test starts.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 4294967295
+          default: 0x00000000
+          x-field-uid: 3
+        saks:
+          description: |-
+            Rx SAK pool.
+          type: array
+          items:
+            $ref: './statickey.yaml#/components/schemas/Macsec.StaticKey.Sak'
+          x-field-uid: 4

--- a/device/macsec/statickey/statickey.yaml
+++ b/device/macsec/statickey/statickey.yaml
@@ -1,0 +1,140 @@
+components:
+  schemas:
+    Macsec.StaticKey:
+      description: >-
+        A container of static key properties for a secure entity(SecY). This configuration is applicable when no dynamic key management protocol i.e. MACsec key agreement(MKA) is configured. If MKA is configured, any static key configuration is not applicable.
+      type: object
+      properties:
+        cipher_suite:
+          description: |-
+              The cipher suite. Choose one from GCM-AES-128 GCM-AES-128 GCM-AES-256 GCM-AES-XPN-128 GCM-AES-XPN-256
+          type: string
+          default: gcm_aes_128
+          x-field-uid: 1
+          x-enum:
+            gcm_aes_128:
+              x-field-uid: 1
+            gcm_aes_256:
+              x-field-uid: 2
+            gcm_aes_xpn_128:
+              x-field-uid: 3
+            gcm_aes_xpn_256:
+              x-field-uid: 4
+        confidentiality:
+          description: |-
+            Encrypt or not. 
+          type: boolean
+          default: true
+          x-field-uid: 2
+        confidentiality_offset:
+          description: |-
+            Confidentiality offset.
+          type: string
+          default: zero
+          x-field-uid: 3
+          x-enum:
+            zero:
+              x-field-uid: 1
+            thirty:
+              x-field-uid: 2
+            fifty:
+              x-field-uid: 3
+        tx:
+          description: >-
+            Tx properties of SecY.
+          $ref: './tx.yaml#/components/schemas/Macsec.StaticKey.Tx'
+          x-field-uid: 4
+        rx:
+          description: >-
+            Rx properties of SecY.
+          $ref: './rx.yaml#/components/schemas/Macsec.StaticKey.Rx'
+          x-field-uid: 5
+    Macsec.StaticKey.RekeyMode:
+      description: |-
+        Rekey mode.
+      type: object
+      properties:
+        choice:
+          description: >-
+            Rekey mode choices.
+          type: string
+          default: dont_rekey
+          x-field-uid: 1
+          x-enum:
+            dont_rekey:
+              x-field-uid: 1
+            timer_based:
+              x-field-uid: 2
+            pn_based:
+              x-field-uid: 3
+        timer_based:
+          description: |-
+              Container for timer based periodic rekey properties.
+          x-field-uid: 2
+          $ref: '#/components/schemas/Macsec.StaticKey.RekeyMode.TimerBased'
+    Macsec.StaticKey.RekeyMode.TimerBased:
+      description: >-
+          Timer based periodic rekey properties.
+      type: object
+      properties:
+        choice:
+          description: |-
+              Periodic rekey attempt choices.
+          type: string
+          default: continuous
+          x-field-uid: 1
+          x-enum:
+            continuous:
+              x-field-uid: 1
+            fixed_count:
+              x-field-uid: 2
+        fixed_count:
+          description: |-
+              Fixed rekey attempts.
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 10
+          x-field-uid: 2
+        interval:
+          description: |-
+              Periodic rekey interval (sec).
+          type: integer
+          format: uint32
+          minimum: 30
+          maximum: 65535
+          default: 300
+          x-field-uid: 3
+    Macsec.StaticKey.Sak:
+      description: >-
+        The container for SAK.
+      type: object
+      properties:
+        sak:
+          description: |-
+            Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending on the citpher suite chosen.
+          type: string
+          format: hex
+          minLength: 16
+          maxLength: 32
+          default: "F123456789ABCDEF0123456789ABCDEF"
+          x-field-uid: 1
+        ssci:
+          description: |-
+            4 bytes short SCI(SSCI) used in case of XPN cipher suites.
+          type: string
+          format: hex
+          minLength: 4
+          maxLength: 4
+          default: "00000001"
+          x-field-uid: 2
+        salt:
+          description: |-
+            12 bytes salt used in case of XPN cipher suites.
+          type: string
+          format: hex
+          minLength: 12
+          maxLength: 12
+          default: "000000000000000000000001"
+          x-field-uid: 3

--- a/device/macsec/statickey/statickey.yaml
+++ b/device/macsec/statickey/statickey.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.StaticKey:
+    SecureEntity.StaticKey:
       description: >-
         A container of static key properties for a secure entity(SecY). This configuration is applicable when no dynamic key management protocol i.e. MACsec key agreement(MKA) is configured. If MKA is configured, any static key configuration is not applicable.
       type: object
@@ -42,14 +42,14 @@ components:
         tx:
           description: >-
             Tx properties of SecY.
-          $ref: './tx.yaml#/components/schemas/Macsec.StaticKey.Tx'
+          $ref: './tx.yaml#/components/schemas/SecureEntity.StaticKey.Tx'
           x-field-uid: 4
         rx:
           description: >-
             Rx properties of SecY.
-          $ref: './rx.yaml#/components/schemas/Macsec.StaticKey.Rx'
+          $ref: './rx.yaml#/components/schemas/SecureEntity.StaticKey.Rx'
           x-field-uid: 5
-    Macsec.StaticKey.RekeyMode:
+    SecureEntity.StaticKey.RekeyMode:
       description: |-
         Rekey mode.
       type: object
@@ -71,8 +71,8 @@ components:
           description: |-
               Container for timer based periodic rekey properties.
           x-field-uid: 2
-          $ref: '#/components/schemas/Macsec.StaticKey.RekeyMode.TimerBased'
-    Macsec.StaticKey.RekeyMode.TimerBased:
+          $ref: '#/components/schemas/SecureEntity.StaticKey.RekeyMode.TimerBased'
+    SecureEntity.StaticKey.RekeyMode.TimerBased:
       description: >-
           Timer based periodic rekey properties.
       type: object
@@ -106,7 +106,7 @@ components:
           maximum: 65535
           default: 300
           x-field-uid: 3
-    Macsec.StaticKey.Sak:
+    SecureEntity.StaticKey.Sak:
       description: >-
         The container for SAK.
       type: object

--- a/device/macsec/statickey/statickey.yaml
+++ b/device/macsec/statickey/statickey.yaml
@@ -113,11 +113,11 @@ components:
       properties:
         sak:
           description: |-
-            Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending on the citpher suite chosen.
+            Secure association key(SAK) bits as hex string. Either 128 bits or 256 bits depending on the chosen cipher suite.
           type: string
           format: hex
-          minLength: 16
-          maxLength: 32
+          minLength: 1
+          maxLength: 64
           default: "F123456789ABCDEF0123456789ABCDEF"
           x-field-uid: 1
         ssci:
@@ -125,8 +125,8 @@ components:
             4 bytes short SCI(SSCI) used in case of XPN cipher suites.
           type: string
           format: hex
-          minLength: 4
-          maxLength: 4
+          minLength: 1
+          maxLength: 8
           default: "00000001"
           x-field-uid: 2
         salt:
@@ -134,7 +134,7 @@ components:
             12 bytes salt used in case of XPN cipher suites.
           type: string
           format: hex
-          minLength: 12
-          maxLength: 12
+          minLength: 1
+          maxLength: 24
           default: "000000000000000000000001"
           x-field-uid: 3

--- a/device/macsec/statickey/tx.yaml
+++ b/device/macsec/statickey/tx.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.StaticKey.Tx:
+    SecureEntity.StaticKey.Tx:
       description: >-
         A container of static key Tx properties.
       type: object
@@ -10,8 +10,8 @@ components:
             Tx secure channels.
           type: array
           items:
-            $ref: './txsc.yaml#/components/schemas/Macsec.StaticKey.TxSc'
+            $ref: './txsc.yaml#/components/schemas/SecureEntity.StaticKey.TxSc'
           x-field-uid: 1
         rekey_mode:
-          $ref: './statickey.yaml#/components/schemas/Macsec.StaticKey.RekeyMode'
+          $ref: './statickey.yaml#/components/schemas/SecureEntity.StaticKey.RekeyMode'
           x-field-uid: 2

--- a/device/macsec/statickey/tx.yaml
+++ b/device/macsec/statickey/tx.yaml
@@ -1,0 +1,17 @@
+components:
+  schemas:
+    Macsec.StaticKey.Tx:
+      description: >-
+        A container of static key Tx properties.
+      type: object
+      properties:
+        secure_channels:
+          description: >-
+            Tx secure channels.
+          type: array
+          items:
+            $ref: './txsc.yaml#/components/schemas/Macsec.StaticKey.TxSc'
+          x-field-uid: 1
+        rekey_mode:
+          $ref: './statickey.yaml#/components/schemas/Macsec.StaticKey.RekeyMode'
+          x-field-uid: 2

--- a/device/macsec/statickey/txsc.yaml
+++ b/device/macsec/statickey/txsc.yaml
@@ -1,0 +1,29 @@
+components:
+  schemas:
+    Macsec.StaticKey.TxSc:
+      description: >-
+        Tx SC setting for static key.
+      type: object
+      properties:
+        system_id:
+          description: |-
+            System ID. 
+          type: string
+          format: mac
+          x-field-uid: 1
+        port_id:
+          description: |-
+            Port ID. 
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 65535
+          default: 1
+          x-field-uid: 2
+        saks:
+          description: |-
+            Tx SAK pool.
+          type: array
+          items:
+            $ref: './statickey.yaml#/components/schemas/Macsec.StaticKey.Sak'
+          x-field-uid: 3

--- a/device/macsec/statickey/txsc.yaml
+++ b/device/macsec/statickey/txsc.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    Macsec.StaticKey.TxSc:
+    SecureEntity.StaticKey.TxSc:
       description: >-
         Tx SC setting for static key.
       type: object
@@ -25,5 +25,5 @@ components:
             Tx SAK pool.
           type: array
           items:
-            $ref: './statickey.yaml#/components/schemas/Macsec.StaticKey.Sak'
+            $ref: './statickey.yaml#/components/schemas/SecureEntity.StaticKey.Sak'
           x-field-uid: 3

--- a/result/macsec.yaml
+++ b/result/macsec.yaml
@@ -1,0 +1,199 @@
+openapi: 3.0.3
+info:
+  title: MACsec results model
+  version: ^0.0.0
+components:
+  schemas:
+    Macsec.Metrics.Request:
+      description: >-
+        The request to retrieve MACsec per secure entity(secY) metrics/statistics.
+      type: object
+      properties:
+        secure_entity_names:
+          description: >-
+            The names of secure entities(secYs) to return results for.
+            An empty list will return results for all secYs.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - "/components/schemas/Macsec/properties/name"
+          x-field-uid: 1
+        column_names:
+          description: >-
+            The list of column names that the returned result set will contain.
+            If the list is empty then all columns will be returned except for
+            any result_groups. The name of the secure entity(secY) cannot be excluded.
+          type: array
+          items:
+            type: string
+            x-enum:
+              session_state:
+                x-field-uid: 1
+              session_flap_count:
+                x-field-uid: 2
+              out_pkts_protected:
+                x-field-uid: 3
+              out_pkts_encrypted:
+                x-field-uid: 4
+              in_pkts_ok:
+                x-field-uid: 5
+              in_pkts_bad:
+                x-field-uid: 6
+              in_pkts_bad_tag:
+                x-field-uid: 7
+              in_pkts_late:
+                x-field-uid: 8
+              in_pkts_no_sci:
+                x-field-uid: 9
+              in_pkts_not_using_sa:
+                x-field-uid: 10
+              in_pkts_not_valid:
+                x-field-uid: 11
+              in_pkts_unknown_sci:
+                x-field-uid: 12
+              in_pkts_unused_sa:
+                x-field-uid: 13
+              in_pkts_invalid:
+                x-field-uid: 14
+              in_pkts_untagged:
+                x-field-uid: 15
+              out_octets_protected:
+                x-field-uid: 16
+              out_octets_encrypted:
+                x-field-uid: 17
+              in_octets_validated:
+                x-field-uid: 18
+              in_octets_decrypted:
+                x-field-uid: 19 
+          x-field-uid: 2
+    Macsec.Metric:
+      description: >-
+        MACsec per secure entity(secY) statistics information.
+      type: object
+      properties:
+        name:
+          description: >-
+            The name of a configured MACsec secure entity(secY).
+          type: string
+          x-field-uid: 1
+        session_state:
+          description: >-
+            Session state as up or down.
+            Up refers to an Established state and Down refers to any
+            other state.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+        session_flap_count:
+          description: >-
+            Number of times the session went from Up to Down state.
+          type: integer
+          format: uint64
+          x-field-uid: 3
+        out_pkts_protected:
+          description: >-
+            OutPktsProtected, the number of protected packets transmitted.
+          type: integer
+          format: uint64
+          x-field-uid: 4
+        out_pkts_encrypted:
+          description: >-
+            OutPktsEncrypted, the number of encrypted packets transmitted.
+          type: integer
+          format: uint64
+          x-field-uid: 5
+        in_pkts_ok:
+          description: >-
+            InPktsOk, the number of valid packets received.
+          type: integer
+          format: uint64
+          x-field-uid: 6
+        bad_pkts_rx:
+          description: >-
+            The number of bad packets received.
+          type: integer
+          format: uint64
+          x-field-uid: 7
+        in_pkts_bad_tag:
+          description: >-
+            InPktsBadTag, the number of packets discarded due to bad tag/ICV.
+          type: integer
+          format: uint64
+          x-field-uid: 8
+        in_pkts_late:
+          description: >-
+            InPktsLate, the number of packets discarded out of window.
+          type: integer
+          format: uint64
+          x-field-uid: 9
+        in_pkts_no_sci:
+          description: >-
+            InPktsNoSCI,the number of packets discarded due to unknown SCI.
+          type: integer
+          format: uint64
+          x-field-uid: 10
+        in_pkts_not_using_sa:
+          description: >-
+            InPktsNotUsingSA, the number of packets discarded due to unused SA.
+          type: integer
+          format: uint64
+          x-field-uid: 11
+        in_pkts_not_valid:
+          description: >-
+            InPktsNotValid, the number of packets discarded due to invalid ICV.
+          type: integer
+          format: uint64
+          x-field-uid: 12
+        in_pkts_unknown_sci:
+          description: >-
+            InPktsUnknownSCI, the number of packets received with unknown SCI.
+          type: integer
+          format: uint64
+          x-field-uid: 13
+        in_pkts_unused_sa:
+          description: >-
+            InPktsUnusedSA, the number of packets received with unused SA.
+          type: integer
+          format: uint64
+          x-field-uid: 14
+        in_pkts_invalid:
+          description: >-
+            InPktsInvalid, the number of packets received with invalid ICV.
+          type: integer
+          format: uint64
+          x-field-uid: 15
+        in_pkts_untagged:
+          description: >-
+            InPktsUntagged, the number of non-MACsec packets received.
+          type: integer
+          format: uint64
+          x-field-uid: 16
+        out_octets_protected:
+          description: >-
+            OutOctetsProtected, the number of bytes transmitted as protected.
+          type: integer
+          format: uint64
+          x-field-uid: 17
+        out_octets_encrypted:
+          description: >-
+            OutOctetsEncrypted, the number of bytes transmitted as encrypted.
+          type: integer
+          format: uint64
+          x-field-uid: 18
+        in_octets_validated:
+          description: >-
+            InOctetsValidated, the number of received bytes validated.
+          type: integer
+          format: uint64
+          x-field-uid: 19
+        in_octets_decrypted:
+          description: >-
+            InOctetsDecrypted, the number of received bytes decrypted.
+          type: integer
+          format: uint64
+          x-field-uid: 20

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -133,11 +133,11 @@ components:
               x-field-uid: 13
             ospfv2_metrics:
               x-field-uid: 14
-            macsec_metrics:
-              x-field-uid: 15
-            mka_metrics:
-              x-field-uid: 16
             convergence_metrics:
+              x-field-uid: 15
+            macsec_metrics:
+              x-field-uid: 16
+            mka_metrics:
               x-field-uid: 17
         port_metrics:
           type: array

--- a/result/metrics.yaml
+++ b/result/metrics.yaml
@@ -40,6 +40,10 @@ components:
               x-field-uid: 14
             convergence:
               x-field-uid: 15
+            macsec:
+              x-field-uid: 16
+            mka:
+              x-field-uid: 17
         port:
           $ref: './port.yaml#/components/schemas/Port.Metrics.Request'
           x-field-uid: 2
@@ -85,6 +89,12 @@ components:
         convergence:
           $ref: './convergence.yaml#/components/schemas/Convergence.Request'
           x-field-uid: 16
+        macsec:
+          $ref: './macsec.yaml#/components/schemas/Macsec.Metrics.Request'
+          x-field-uid: 17
+        mka:
+          $ref: './mka.yaml#/components/schemas/Mka.Metrics.Request'
+          x-field-uid: 18
     Metrics.Response:
       description: >-
         Response containing chosen traffic generator metrics.
@@ -123,8 +133,12 @@ components:
               x-field-uid: 13
             ospfv2_metrics:
               x-field-uid: 14
-            convergence_metrics:
+            macsec_metrics:
               x-field-uid: 15
+            mka_metrics:
+              x-field-uid: 16
+            convergence_metrics:
+              x-field-uid: 17
         port_metrics:
           type: array
           items:
@@ -200,3 +214,13 @@ components:
           items:
             $ref: './convergence.yaml#/components/schemas/Convergence.Metric'
           x-field-uid: 16
+        macsec_metrics:
+          type: array
+          items:
+            $ref: './macsec.yaml#/components/schemas/Macsec.Metric'
+          x-field-uid: 17
+        mka_metrics:
+          type: array
+          items:
+            $ref: './mka.yaml#/components/schemas/Mka.Metric'
+          x-field-uid: 18

--- a/result/mka.yaml
+++ b/result/mka.yaml
@@ -1,0 +1,128 @@
+openapi: 3.0.3
+info:
+  title: MKA results model
+  version: ^0.0.0
+components:
+  schemas:
+    Mka.Metrics.Request:
+      description: >-
+        The request to retrieve MKA per peer metrics/statistics.
+      type: object
+      properties:
+        peer_names:
+          description: >-
+            The names of peers to return results for.
+            An empty list will return results for all peers.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - "/components/schemas/Mka/properties/name"
+          x-field-uid: 1
+        column_names:
+          description: >-
+            The list of column names that the returned result set will contain.
+            If the list is empty then all columns will be returned except for
+            any result_groups. The name of the peer cannot be excluded.
+          type: array
+          items:
+            type: string
+            x-enum:
+              session_state:
+                x-field-uid: 1
+              session_flap_count:
+                x-field-uid: 2
+              mkpdu_tx:
+                x-field-uid: 3
+              mkpdu_rx:
+                x-field-uid: 4
+              live_peer_count:
+                x-field-uid: 5
+              potential_peer_count:
+                x-field-uid: 6
+              latest_key_tx_peer_count:
+                x-field-uid: 7
+              latest_key_rx_peer_count:
+                x-field-uid: 8
+              malformed_mkpdu:
+                x-field-uid: 9
+              icv_mismatch:
+                x-field-uid: 10
+          x-field-uid: 2
+
+    Mka.Metric:
+      description: >-
+        MKA per peer statistics information.
+      type: object
+      properties:
+        name:
+          description: >-
+            The name of a configured MKA peer.
+          type: string
+          x-field-uid: 1
+        session_state:
+          description: >-
+            Session state as up or down.
+            Up refers to an Established state and Down refers to any
+            other state.
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+        session_flap_count:
+          description: >-
+            Number of times the session went from Up to Down state.
+          type: integer
+          format: uint64
+          x-field-uid: 3
+        mkpdu_tx:
+          description: >-
+            Number of MKA protocol data unit(MKPDU) frames Tx.
+          type: integer
+          format: uint64
+          x-field-uid: 4
+        mkpdu_rx:
+          description: >-
+            Number of MKA protocol data unit(MKPDU) frames Rx.
+          type: integer
+          format: uint64
+          x-field-uid: 5
+        live_peer_count:
+          description: >-
+            Number of MKA live peers.
+          type: integer
+          format: uint64
+          x-field-uid: 6
+        potential_peer_count:
+          description: >-
+            Number of MKA potential peers.
+          type: integer
+          format: uint64
+          x-field-uid: 7
+        latest_key_tx_peer_count:
+          description: >-
+            Number of MKA latest key Tx peers.
+          type: integer
+          format: uint64
+          x-field-uid: 8
+        latest_key_rx_peer_count:
+          description: >-
+            Number of MKA latest key Rx peers.
+          type: integer
+          format: uint64
+          x-field-uid: 9
+        malformed_mkpdu:
+          description: >-
+            Number of malformed MKA Protocol Data Unit(MKPDU) frames Rx.
+          type: integer
+          format: uint64
+          x-field-uid: 10
+        icv_mismatch:
+          description: >-
+            Number of MKA Protocol Data Unit(MKPDU) frames with ICV mismatch Rx.
+          type: integer
+          format: uint64
+          x-field-uid: 11


### PR DESCRIPTION
MACsec/ MKA model reworked (on dev_macsec brnach ) based on review comments from PR https://github.com/open-traffic-generator/models/pull/408 (on macsec branch)

Redocli view : https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev_macsec/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config

Config Changes:
============
- MKA
   - moved inside MACsec
   - Tx SC property restuctured
   - kay name changed to mka for easy understanding
   - eapol ethernet type, PSK key chain start time added to basic
   
- MACsec
  - encapsulation choice in MACsec:
  - secy renamed to secure_channel
  - crypto engine type names changed to: encrypt_only and encrypt_decrypt
  - all hex string min/ max lengths corrected

Metric: changes:
=============
- MACsec
  - secy_names renamed to secure_entity_names

- MKA
  - kay_names renamed to peer_names

Changes not done
=============
- key start time field string format HH:MM kept as it is instead of splitting into sub fields hh and mm
- PSK key chain start time field kept as DD-MM-YYYY HH:MM:SS. Shall we split into 6 sub fields - dd, mm, yyyy, hh, mm, ss too?

Open items:
========
1. How do we add IP over MACsec?
   - This is allowed only for encrypt_decrypt crypto engine type.
   - If MACsec is configured on an emulated ethernet interface, any protocol (e.g. IP) except (MKA) configured on the ethernet will be added on MACsec.
  
2. Can we add IP over ethernet and IP over MACsec for same emulated ethernet interface?
 - No, we cannot do. It will always be IP over MACsec as mentioned in item 1) above.
 - We cannot send mix of MACsec and non-MACsec IP packets from same ethernet address.
 - However we can send non-MACsec IP packet from one ethernet address and MACsec IP packet from another ethernet address.

3. Additional metrics for hardware acceleration
 - One set of stats will include stats for all crypo engine variants. snappi or other model user should validate if unsupported stat is fetched for a variant i.e. hardware acceleration specific metric e.g. multicast MACsec bytes/ packets Tx cannot be fetched when hardware acceleration is off.