### PR TITLE
One metric name change in MACsec model

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -20402,9 +20402,9 @@ components:
           type: integer
           format: uint64
           x-field-uid: 6
-        bad_pkts_rx:
+        in_pkts_bad:
           description: |-
-            The number of bad packets received.
+            The total number of received bad packets that failed atleast one validation check.
           type: integer
           format: uint64
           x-field-uid: 7

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14845,8 +14845,8 @@ message MacsecMetric {
   // InPktsOk, the number of valid packets received.
   optional uint64 in_pkts_ok = 6;
 
-  // The number of bad packets received.
-  optional uint64 bad_pkts_rx = 7;
+  // The total number of received bad packets that failed atleast one validation check.
+  optional uint64 in_pkts_bad = 7;
 
   // InPktsBadTag, the number of packets discarded due to bad tag/ICV.
   optional uint64 in_pkts_bad_tag = 8;

--- a/result/macsec.yaml
+++ b/result/macsec.yaml
@@ -113,9 +113,9 @@ components:
           type: integer
           format: uint64
           x-field-uid: 6
-        bad_pkts_rx:
+        in_pkts_bad:
           description: >-
-            The number of bad packets received.
+            The total number of received bad packets that failed atleast one validation check.
           type: integer
           format: uint64
           x-field-uid: 7


### PR DESCRIPTION
Rename metric name from bad_pkts_rx to in_pkts_bad in MACsec model