### PR TITLE
Addition of optional Tx offset in egress only tracking settings

### DIFF
--- a/api/info.yaml
+++ b/api/info.yaml
@@ -8,7 +8,7 @@ info:
     Contributions can be made in the following ways:
     - [open an issue](https://github.com/open-traffic-generator/models/issues) in the models repository
     - [fork the models repository](https://github.com/open-traffic-generator/models) and submit a PR
-  version: 1.30.0
+  version: 1.31.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -16868,7 +16868,7 @@ components:
           x-field-uid: 4
     EgressOnlyTracking.TxOffset:
       description: |-
-        A container of Tx offset properties. Offset in bits relative to start of the transmitted packet from the transmitting port. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and while fetching egress only stats by enabling "tx_metric" in get_metrics/egress_only_tracking/tagged_metric/metric_names
+        A container of Tx offset properties. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and while fetching egress only stats by enabling "tx_metric" in get_metrics/egress_only_tracking/tagged_metric/metric_names
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.32.0
+  version: 1.33.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -2623,6 +2623,11 @@ components:
             Optional Segment Routing (SR).
           $ref: '#/components/schemas/Isis.SegmentRouting'
           x-field-uid: 10
+        graceful_restart:
+          description: |-
+            Optional IS-IS Graceful Restart Configuration.
+          $ref: '#/components/schemas/Isis.GracefulRestart'
+          x-field-uid: 11
     Device.IsisMultiInstance:
       description: "This container properties of an Multi-Instance-capable router\
         \ (MI-RTR). "
@@ -3936,6 +3941,18 @@ components:
           minimum: 1
           maximum: 4294967295
           x-field-uid: 2
+    Isis.GracefulRestart:
+      description: |-
+        Contains IS-IS Graceful configuration parameters.
+        Reference: https://datatracker.ietf.org/doc/html/rfc8706
+      type: object
+      properties:
+        helper_mode:
+          description: |-
+            The emulated IS-IS router will acting in as the "Helper" for the DUT that is restarting.  It acknowledges the Restart TLV sent by the DUT by sending an IIH containing a Restart TLV with the RA (Restart Acknowledgment) bit set.
+          type: boolean
+          default: true
+          x-field-uid: 1
     Device.BgpRouter:
       description: |-
         Configuration for one or more IPv4 or IPv6 BGP peers.
@@ -10703,7 +10720,8 @@ components:
             Routing metric associated with the interface..
           type: integer
           format: uint32
-          default: 0
+          maximum: 65535
+          default: 10
           x-field-uid: 3
         priority:
           description: "The Priority for (Backup) Designated Router election.    \
@@ -18163,11 +18181,14 @@ components:
               x-field-uid: 2
             bgp:
               x-field-uid: 3
+            isis:
+              x-field-uid: 4
           x-field-uid: 1
           enum:
           - ipv4
           - ipv6
           - bgp
+          - isis
         ipv4:
           $ref: '#/components/schemas/Action.Protocol.Ipv4'
           x-field-uid: 2
@@ -18177,6 +18198,9 @@ components:
         bgp:
           $ref: '#/components/schemas/Action.Protocol.Bgp'
           x-field-uid: 4
+        isis:
+          $ref: '#/components/schemas/Action.Protocol.Isis'
+          x-field-uid: 5
     Action.Response.Protocol:
       description: |-
         Response for actions associated with protocols on configured resources.
@@ -18641,6 +18665,88 @@ components:
         custom:
           $ref: '#/components/schemas/Device.Bgp.CustomError'
           x-field-uid: 9
+    Action.Protocol.Isis:
+      description: |-
+        Actions associated with IS-IS on configured resources.
+      type: object
+      required:
+      - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            initiate_graceful_restart:
+              x-field-uid: 1
+          x-field-uid: 1
+          enum:
+          - initiate_graceful_restart
+        initiate_graceful_restart:
+          description: |-
+            Configuration for the initiation of the IS-IS Graceful Restart.
+          $ref: '#/components/schemas/Action.Protocol.Isis.InitiateRestart'
+          x-field-uid: 2
+    Action.Protocol.Isis.InitiateRestart:
+      description: "Timers T1 and T2 are used both by a restarting router and a starting\
+        \ router. Timer T3 is used only by a restarting router.\n- Timer T1 is maintained\
+        \ per interface and indicates the time after which an unacknowledged (re)start\
+        \ attempt will be repeated. Its value is 3 seconds.\n- Timer T2 is maintained\
+        \ for each LSP database (LSDB) for Level 1 and Level 2. Default value is 90\
+        \ seconds.\n  When the timer T2 expires or is canceled, indicating that synchronization\
+        \ of that level is complete and SPF for that level is run.\n- Timer T3 is\
+        \ maintained for the entire system after which the router will declare that\
+        \ it has failed to achieve database synchronization \n  (by setting the overload\
+        \ bit in its own LSP). Its initial value is 65535 seconds and is set to minimum\
+        \ of the remaining times of received IIHs \n  containing a Restart TLV with\
+        \ the RA set."
+      type: object
+      properties:
+        router_names:
+          description: |
+            The names of device objects to control.
+
+            x-constraint:
+            - /components/schemas/Device.IsisRouter/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Device.IsisRouter/properties/name
+          x-field-uid: 1
+        choice:
+          type: string
+          default: unplanned
+          x-field-uid: 2
+          x-enum:
+            unplanned:
+              x-field-uid: 1
+          enum:
+          - unplanned
+        unplanned:
+          $ref: '#/components/schemas/Action.Protocol.Isis.UnplannedRestart'
+          x-field-uid: 3
+    Action.Protocol.Isis.UnplannedRestart:
+      description: |-
+        Initiates IS-IS Unplanned Graceful Restart process for the selected IS-IS routers. If no name is specified then Graceful Restart will be sent to all configured IS-IS routers. When an emulated IS-IS router is in the unplanned "Restarting" mode, it sends an IIH PDU containing a Restart TLV with the RR (Restart Request) bit set and holding_time updated to as specified by user to indicate the maximum time within which this router  or routers will complete the graceful restart.  It waits for RA (Restart Acknowledge) in an IIH PDU from Neigbhor(s).  The timer T1 is maintained per interface and indicates the time after which an unacknowledged (re)start attempt will be repeated.
+      type: object
+      properties:
+        holding_time:
+          description: |-
+            This is the estimated duration (in seconds) it will take for the IS-IS session to be re-established after a restart. The hold-timer in the IIH PDU is updated with this time.
+          type: integer
+          format: uint32
+          maximum: 4096
+          default: 30
+          minimum: 1
+          x-field-uid: 1
+        restart_after:
+          description: |-
+            Once it receives Restarting TLV having RA bit set in a IIH PDU and CSNP PDU, time (in seconds), after which IIH PDU, having Restart Tlv with RR bit unset, will be sent. This should result in IIH to be transmitted indicating restart is Completed,  not started i.e. RR bit is cleared and hold_timer is reset to normal.
+          type: integer
+          format: uint32
+          maximum: 4096
+          default: 10
+          minimum: 0
+          x-field-uid: 2
     Metrics.Request:
       description: |-
         Request to traffic generator for metrics of choice.
@@ -20151,6 +20257,14 @@ components:
                 x-field-uid: 25
               l2_lsp_received:
                 x-field-uid: 26
+              gr_initiated:
+                x-field-uid: 27
+              gr_succeeded:
+                x-field-uid: 28
+              neighbor_gr_initiated:
+                x-field-uid: 29
+              neighbor_gr_succeeded:
+                x-field-uid: 30
             enum:
             - l1_sessions_up
             - l1_session_flap
@@ -20178,6 +20292,10 @@ components:
             - l2_csnp_received
             - l2_lsp_sent
             - l2_lsp_received
+            - gr_initiated
+            - gr_succeeded
+            - neighbor_gr_initiated
+            - neighbor_gr_succeeded
           x-field-uid: 2
     Isis.Metric:
       description: |-
@@ -20345,6 +20463,30 @@ components:
           type: integer
           format: uint64
           x-field-uid: 27
+        gr_initiated:
+          description: "Number of Graceful Restarts that were initiated by this router. "
+          type: integer
+          format: uint64
+          x-field-uid: 28
+        gr_succeeded:
+          description: |-
+            Number of Graceful Restarts succeeded that were initiated by a this router. This counter is incremented if the Graceful Restart completes succesfully before the T3 timer expires. Timer T3 is maintained for the entire system after which  the router will declare that it has failed to achieve database synchronization.
+          type: integer
+          format: uint64
+          x-field-uid: 29
+        neighbor_gr_initiated:
+          description: "Number of Graceful Restarts that were initiated by a Neighbor.\
+            \ This counter is incremented for Restart TLV having RR bit set in the\
+            \ received IIH PDU. "
+          type: integer
+          format: uint64
+          x-field-uid: 30
+        neighbor_gr_succeeded:
+          description: |-
+            Number of Graceful Restarts succeeded that were initiated by a Neighbor. This counter is incremented when Restart TLV having RR bit unset in the received IIH PDU after the Graceful Restart was initiated by a Neighbor.
+          type: integer
+          format: uint64
+          x-field-uid: 31
     Lag.Metrics.Request:
       description: |-
         The request to retrieve per LAG metrics/statistics.
@@ -23694,6 +23836,8 @@ components:
               x-field-uid: 11
             ospfv3_lsas:
               x-field-uid: 12
+            isis_adjacencies:
+              x-field-uid: 13
           enum:
           - ipv4_neighbors
           - ipv6_neighbors
@@ -23707,6 +23851,7 @@ components:
           - dhcpv6_leases
           - ospfv2_lsas
           - ospfv3_lsas
+          - isis_adjacencies
         ipv4_neighbors:
           $ref: '#/components/schemas/Neighborsv4.States.Request'
           x-field-uid: 2
@@ -23743,6 +23888,9 @@ components:
         ospfv3_lsas:
           $ref: '#/components/schemas/Ospfv3Lsas.State.Request'
           x-field-uid: 13
+        isis_adjacencies:
+          $ref: '#/components/schemas/IsisIIHs.State.Request'
+          x-field-uid: 14
     States.Response:
       description: |-
         Response containing chosen traffic generator states
@@ -23777,6 +23925,8 @@ components:
               x-field-uid: 11
             ospfv3_lsas:
               x-field-uid: 12
+            isis_adjacencies:
+              x-field-uid: 13
           enum:
           - ipv4_neighbors
           - ipv6_neighbors
@@ -23790,6 +23940,7 @@ components:
           - dhcpv6_leases
           - ospfv2_lsas
           - ospfv3_lsas
+          - isis_adjacencies
         ipv4_neighbors:
           type: array
           items:
@@ -23850,6 +24001,11 @@ components:
           items:
             $ref: '#/components/schemas/Ospfv3Lsa.State'
           x-field-uid: 13
+        isis_adjacencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisIIHs.State'
+          x-field-uid: 14
     Neighborsv4.States.Request:
       description: |-
         The request to retrieve IPv4 Neighbor state (ARP cache entries) of a network interface(s).
@@ -26926,6 +27082,367 @@ components:
           type: integer
           format: uint32
           x-field-uid: 2
+    IsisIIHs.State.Request:
+      description: |-
+        The request to retrieve ISIS IIH information exchanged by the ISIS routers.
+      type: object
+      properties:
+        isis_router_names:
+          description: |
+            The names of ISIS routers for which learned information is requested. An empty list will return results of IIH States for all ISIS routers.
+
+            x-constraint:
+            - /components/schemas/Device.IsisRouter/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Device.IsisRouter/properties/name
+          x-field-uid: 1
+    IsisIIHs.State:
+      description: |-
+        The result of ISIS IIH information that are exchanged.
+      type: object
+      properties:
+        isis_router_name:
+          description: |-
+            The name of the ISIS Router.
+          type: string
+          x-field-uid: 1
+        adjacency_states:
+          description: "Current state of adjacencies. "
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLocalIIH.AdjacencyStates'
+          x-field-uid: 2
+    IsisLocalIIH.AdjacencyStates:
+      description: |-
+        Information for a local adjacency.
+      type: object
+      properties:
+        neighbor_system_id:
+          description: |-
+            System ID of a neighbor in the hex format, e.g. '650000000001'.
+          type: string
+          x-field-uid: 1
+        interface_name:
+          description: |-
+            Interface name on which adjacency is created.
+          type: string
+          x-field-uid: 2
+        local_state:
+          description: |-
+            Local adjacency state of this ISIS router.
+          $ref: '#/components/schemas/IsisLocalIIH.State'
+          x-field-uid: 3
+        neighbor_state:
+          description: |-
+            A IS-IS neighbor that are learned by this ISIS router.
+          $ref: '#/components/schemas/IsisNeighborIIH.State'
+          x-field-uid: 4
+    IsisLocalIIH.State:
+      description: |-
+        Information for a local adjacency.
+      type: object
+      properties:
+        level_type:
+          description: "This indicates whether this IS-IS router is participating\
+            \ in Level-1 (L1), \nLevel-2 (L2) or both L1 and L2 domains on this interface."
+          type: string
+          x-field-uid: 1
+          x-enum:
+            level_1:
+              x-field-uid: 1
+            level_2:
+              x-field-uid: 2
+            level_1_2:
+              x-field-uid: 3
+          enum:
+          - level_1
+          - level_2
+          - level_1_2
+        hold_timer:
+          description: |-
+            Hold timer being sent in the IIH PDU.
+          type: integer
+          format: uint32
+          x-field-uid: 2
+        restarting_status:
+          description: |-
+            Reference to Restarting Information.
+          $ref: '#/components/schemas/IsisIIH.LocalRestartStatus'
+          x-field-uid: 3
+    IsisNeighborIIH.State:
+      description: |-
+        Information for neighbor adjacency State.
+      type: object
+      properties:
+        level_type:
+          description: "This indicates whether Neighbor IS-IS router is participating\
+            \ in Level-1 (L1), \nLevel-2 (L2) or both L1 and L2 domains on this interface."
+          type: string
+          x-field-uid: 1
+          x-enum:
+            level_1:
+              x-field-uid: 1
+            level_2:
+              x-field-uid: 2
+            level_1_2:
+              x-field-uid: 3
+          enum:
+          - level_1
+          - level_2
+          - level_1_2
+        hold_timer:
+          description: |-
+            Hold timer received in the IIH PDU sent by the neighbor..
+          type: integer
+          format: uint32
+          x-field-uid: 2
+        restarting_status:
+          description: |-
+            Reference to Restarting Information.
+          $ref: '#/components/schemas/IsisIIH.NeighborRestartStatus'
+          x-field-uid: 3
+        tlvs:
+          description: |-
+            It refers to IIH PDU TLVs container.
+          $ref: '#/components/schemas/IsisIIH.NeighborTlvs'
+          x-field-uid: 4
+    IsisIIH.LocalRestartStatus:
+      description: |-
+        This contains the Restarting/Starting/Running state of this router.
+      type: object
+      properties:
+        state:
+          description: |-
+            Current State of this router.
+            - starting: Is in Starting state when Restarting Tlv has been sent with SA bit set.
+            - running: Is in Running state when Restarting Tlv is not present or Restarting Tlv has been sent with SA or RR bits unset.
+            - restarting: Is in Restarting state when Restarting Tlv has been sent with RR bits set.
+          type: string
+          x-field-uid: 1
+          x-enum:
+            running:
+              x-field-uid: 1
+            starting:
+              x-field-uid: 2
+            restarting:
+              x-field-uid: 3
+          enum:
+          - running
+          - starting
+          - restarting
+        last_attempt_status:
+          description: |-
+            This container holds the information of the last Graceful Restart initiated on this router.
+          $ref: '#/components/schemas/IsisIIH.LocalGRLastAttemptStatus'
+          x-field-uid: 2
+    IsisIIH.NeighborRestartStatus:
+      description: |-
+        This contains the Restarting/Starting/Running state of a neighbor router.
+      type: object
+      properties:
+        state:
+          description: |-
+            Current State of Neighbor router.
+            - starting: Is in Starting state when Restarting Tlv has been received with SA bit set.
+            - running: Is in Running state when Restarting Tlv is not present or Restarting Tlv has been received with SA or RR bits unset.
+            - restarting: Is in Restarting state when Restarting Tlv has been received with RR bits set.
+          type: string
+          x-field-uid: 1
+          x-enum:
+            running:
+              x-field-uid: 1
+            starting:
+              x-field-uid: 2
+            restarting:
+              x-field-uid: 3
+          enum:
+          - running
+          - starting
+          - restarting
+        last_attempt_status:
+          description: |-
+            This container holds the information of the last Graceful Restart initiated  by the neighbor since the adjacency was established.
+          $ref: '#/components/schemas/IsisIIH.NeighborGRLastAttemptStatus'
+          x-field-uid: 2
+    IsisIIH.LocalGRLastAttemptStatus:
+      description: |-
+        This object contains the status of the last attempted Graceful Restart status of this router.
+        - succeeded: Choice is set if the last Graceful Status is successful.
+        - failed: The last Graceful Status is unsuccessful.
+        - inprogress: The last Graceful Restart status is in progress.
+        - unavailable: The last Graceful Restart status is not initiated.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          x-enum:
+            succeeded:
+              x-field-uid: 1
+            failed:
+              x-field-uid: 2
+            inprogress:
+              x-field-uid: 3
+            unavailable:
+              x-field-uid: 4
+          enum:
+          - succeeded
+          - failed
+          - inprogress
+          - unavailable
+        succeeded:
+          $ref: '#/components/schemas/IsisIIH.LocalGRLastAttemptSucceeded'
+          x-field-uid: 2
+        failed:
+          $ref: '#/components/schemas/IsisIIH.LocalGRLastAttemptFailed'
+          x-field-uid: 3
+    IsisIIH.LocalGRLastAttemptFailed:
+      description: |-
+        This container contains the failure status of the last Graceful Restart initiated by this router.
+      type: object
+      properties:
+        reason:
+          description: |-
+            Failure reason of last Graceful Restart.
+          type: string
+          x-field-uid: 1
+    IsisIIH.LocalGRLastAttemptSucceeded:
+      description: |-
+        This container contains details about the successful status of the last Graceful Restart initiated by this router.
+      type: object
+      properties:
+        lsdb_syncup_time:
+          description: |-
+            The time (in seconds) is taken to synchronize the L1 and L2 LSDB by this Restarting router.
+            By this time, the CSNP list is cleared and all LSPs are collected by the neighbor(s).
+          type: integer
+          format: uint32
+          x-field-uid: 1
+        adjacency_bring_up_time:
+          description: "The time (in seconds) is measured from when the Restart TLV\
+            \ with RR bit set is sent \nin an IIH PDU upto the time when Restart TLV\
+            \ is sent with RR bit unset."
+          type: integer
+          format: uint32
+          x-field-uid: 3
+    IsisIIH.NeighborGRLastAttemptStatus:
+      description: |-
+        This object contains the status of the last attempted Graceful Restart status of an ISIS neighbor.
+        - succeeded: Choice is set if the last Graceful was successful.
+        - failed: The last Graceful attempt was unsuccessful.
+        - inprogress: The last Graceful Restart is in progress.
+        - unavailable: Graceful Restart has never been initiated by the neighbor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          x-enum:
+            succeeded:
+              x-field-uid: 1
+            failed:
+              x-field-uid: 2
+            inprogress:
+              x-field-uid: 3
+            unavailable:
+              x-field-uid: 4
+          enum:
+          - succeeded
+          - failed
+          - inprogress
+          - unavailable
+        succeeded:
+          $ref: '#/components/schemas/IsisIIH.NeighborGRLastAttemptSucceeded'
+          x-field-uid: 2
+        failed:
+          $ref: '#/components/schemas/IsisIIH.NeighborGRLastAttemptFailed'
+          x-field-uid: 3
+    IsisIIH.NeighborGRLastAttemptFailed:
+      description: |-
+        This container contains the failure status of the last Graceful Restart initiated by this neighbor.
+      type: object
+      properties:
+        reason:
+          description: |-
+            Failure reason of last Graceful Restart in readable string.
+          type: string
+          x-field-uid: 1
+    IsisIIH.NeighborGRLastAttemptSucceeded:
+      description: |-
+        This object contains the result of a successful graceful restart status in the last attempted by a Neighbor.
+      type: object
+      properties:
+        adjacency_bring_up_time:
+          description: "The time (in second) is measured from when the Restart TLV\
+            \ with RR bit set in a IIH PDU is received up to the time \nwhen it receives\
+            \ the Restart TLV with RR bit and SA bit unset in a IIH PDU from the Neighbor\
+            \ Router."
+          type: integer
+          format: uint32
+          x-field-uid: 1
+    IsisIIH.NeighborTlvs:
+      description: |-
+        This contains the list of TLVs present in a IIH PDU received from a neighbor IS-IS router.
+      type: object
+      properties:
+        restart_tlv:
+          description: |-
+            Restart Tlv.
+          $ref: '#/components/schemas/IsisIIH.RestartTlv'
+          x-field-uid: 1
+    IsisIIH.RestartTlv:
+      description: |-
+        Container of Restart TLV in IIH PDU. Reference: https://datatracker.ietf.org/doc/html/rfc8706#name-restart-tlv
+      type: object
+      properties:
+        flags:
+          description: "One octet Restart flags in the Restart TLV. "
+          $ref: '#/components/schemas/IsisIIHRestart.Flags'
+          x-field-uid: 1
+        remaining_time:
+          description: |-
+            Remaining Holding Time (in seconds).
+          type: integer
+          format: uint32
+          x-field-uid: 2
+        restarting_neighbor_id:
+          description: |-
+            Restarting Neighbor's System ID in hex format without "0x" at the beginning. e.g. '640000000001'
+          type: string
+          x-field-uid: 3
+    IsisIIHRestart.Flags:
+      description: |-
+        Restarting flags in Restarting TLV in IIH PDU.
+      type: object
+      properties:
+        rr_bit:
+          description: |-
+            Restart Request bit.
+          type: boolean
+          x-field-uid: 1
+        ra_bit:
+          description: |-
+            Restart Acknowledgement.
+          type: boolean
+          x-field-uid: 2
+        sa_bit:
+          description: |-
+            Suppress Adjacency Advertisement.
+          type: boolean
+          x-field-uid: 3
+        pr_bit:
+          description: |-
+            Restart Planned.
+          type: boolean
+          x-field-uid: 4
+        pa_bit:
+          description: |-
+            Planned Pestart Acknowledgement.
+          type: boolean
+          x-field-uid: 5
     Capture.Request:
       description: |-
         The capture result request to the traffic generator. Stops the port capture on the port_name and returns the capture.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -16842,19 +16842,19 @@ components:
         name:
           description: |-
             The name used to identify the metric tracked at configured Rx offset and of configured
-            length. Tx offset configuration is optional.
+            length.
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         rx_offset:
           description: |-
-            Rx Offset in bits relative to start of the packet.
+            Offset in bits relative to start of the received packet on the receiving port.
           type: integer
           format: uint32
           x-field-uid: 2
         tx_offset:
           description: |-
-            Tx Offset in bits relative to start of the packet.
+            Offset in bits relative to start of the transmitted packet from the transmitting port.
           $ref: '#/components/schemas/EgressOnlyTracking.TxOffset'
           x-field-uid: 3
         length:
@@ -16868,12 +16868,12 @@ components:
           x-field-uid: 4
     EgressOnlyTracking.TxOffset:
       description: |-
-        A container of Tx offset properties.
+        A container of Tx offset properties. Offset in bits relative to start of the transmitted packet from the transmitting port. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and while fetching egress only stats by enabling "tx_metric" in get_metrics/egress_only_tracking/tagged_metric/metric_names
       type: object
       properties:
         choice:
           description: |-
-            Choose "auto" when optional Tx statistics in egress only tracking are required while fetching egress only stats by opting "tx_metric" in get_metrics - egress_only_tracking - tagged_metric - metric_names.  or both Tx and Rx offset of tracked field in packet is the same. Otherwise choose "custom" when the Tx and Rx offsets are different due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different configuration such that the MACSec header is added/modified or removed.
+            Choose "auto" when both offsets of tracked field in Tx/ Rx packets are the same. Otherwise choose "custom".
           type: string
           default: auto
           x-field-uid: 1
@@ -16887,7 +16887,7 @@ components:
           - custom
         custom:
           description: |-
-            A container of custom Tx offset.
+            A container of custom Tx offset. Choose "custom" when the Tx and Rx offsets are different due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different configuration such that the MACSec header is added/modified or removed.
           $ref: '#/components/schemas/EgressOnlyTracking.TxOffset.Custom'
           x-field-uid: 2
     EgressOnlyTracking.TxOffset.Custom:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.30.0
+  version: 1.31.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -16868,7 +16868,7 @@ components:
           x-field-uid: 4
     EgressOnlyTracking.TxOffset:
       description: |-
-        A container of Tx offset properties. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and while fetching egress only stats by enabling "tx_metric" in get_metrics/egress_only_tracking/tagged_metric/metric_names
+        A container of Tx offset properties. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and when fetching egress only stats with "tx_metric" also enabled in get_metrics/egress_only_tracking/tagged_metric/metric_names.
       type: object
       properties:
         choice:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -16840,11 +16840,9 @@ components:
       - rx_offset
       properties:
         name:
-          description: "The Name used to identify the metrics associated with the\
-            \ values applicable\nfor configured Rx offset, optionally Tx offset adjustment\
-            \ and length inside\ncorresponding header field. When offset of tracked\
-            \ metric at Tx is more than \nthe offset at Rx, the difference should\
-            \ be configured as Tx offset adjustment."
+          description: |-
+            The name used to identify the metric tracked at configured Rx offset and of configured
+            length. Tx offset configuration is optional.
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
@@ -16875,7 +16873,7 @@ components:
       properties:
         choice:
           description: |-
-            Choose "auto" when Tx statistics in egress only tracking is not implemented or both Tx and Rx offset of tracked field in packet is the same. Otherwise choose "custom" when the offsets are different when DUT adds/ strips an encapsulation protocol header e.g. MACsec and tracked field is encapsulated in the protocol e.g. MACsec at wither Tx or Rx side.
+            Choose "auto" when optional Tx statistics in egress only tracking are required while fetching egress only stats by opting "tx_metric" in get_metrics - egress_only_tracking - tagged_metric - metric_names.  or both Tx and Rx offset of tracked field in packet is the same. Otherwise choose "custom" when the Tx and Rx offsets are different due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different configuration such that the MACSec header is added/modified or removed.
           type: string
           default: auto
           x-field-uid: 1

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.33.0
+  version: 1.38.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -396,7 +396,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
       required:
       - name
@@ -439,7 +438,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
       required:
       - name
@@ -622,7 +620,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Device.Ethernet:
       description: |-
@@ -674,7 +671,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         dhcpv4_interfaces:
           description: "List of DHCPv4 Clients Configuration. "
@@ -847,7 +843,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
       required:
       - name
@@ -889,7 +884,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Device.Ipv4Loopback:
       description: |-
@@ -921,7 +915,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Device.Ipv4GatewayMAC:
       description: |-
@@ -994,7 +987,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Device.Ipv6Loopback:
       description: |-
@@ -1023,7 +1015,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Device.Ipv6GatewayMAC:
       description: |-
@@ -1070,7 +1061,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         choice:
           description: |-
@@ -1148,7 +1138,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         rapid_commit:
           description: |-
@@ -2026,7 +2015,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Layer1.AutoNegotiation:
       description: |-
@@ -2270,7 +2258,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Capture.Filter:
       description: |-
@@ -2512,7 +2499,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         rsvp:
           description: |-
@@ -2616,7 +2602,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         segment_routing:
           description: |-
@@ -2761,7 +2746,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         adjacency_sids:
           description: |-
@@ -3380,7 +3364,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         prefix_attr_enabled:
           x-field-uid: 6
@@ -3682,7 +3665,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         prefix_attr_enabled:
           x-field-uid: 6
@@ -4258,7 +4240,6 @@ components:
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         graceful_restart:
           x-field-uid: 14
@@ -4830,7 +4811,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
       required:
       - name
@@ -5212,7 +5192,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         ext_communities:
           x-status:
@@ -5744,7 +5723,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         ext_communities:
           x-status:
@@ -5877,7 +5855,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         active:
           x-field-uid: 15
@@ -5921,7 +5898,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         active:
           x-field-uid: 10
@@ -6116,7 +6092,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         active:
           x-field-uid: 4
@@ -6226,7 +6201,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         active:
           x-field-uid: 14
@@ -6800,7 +6774,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         active:
           x-field-uid: 15
@@ -6844,7 +6817,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         active:
           x-field-uid: 10
@@ -8759,7 +8731,6 @@ components:
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         graceful_restart:
           x-field-uid: 15
@@ -9124,7 +9095,6 @@ components:
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Vxlan.V6Tunnel:
       description: |-
@@ -9164,7 +9134,6 @@ components:
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Vxlan.V4Tunnel.DestinationIPMode:
       description: |-
@@ -9333,7 +9302,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
     Rsvp.Ipv4Interface:
       description: |-
@@ -9467,7 +9435,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         refresh_interval:
           description: "The time in seconds between successive transmissions of RESV\
@@ -9533,7 +9500,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         remote_address:
           description: |-
@@ -10004,7 +9970,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         ipv4_name:
           description: |
@@ -10035,7 +10000,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         lease_time:
           description: |-
@@ -10126,7 +10090,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         ipv6_name:
           description: |
@@ -10381,7 +10344,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         router_id:
           description: |-
@@ -10566,7 +10528,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         ipv4_name:
           description: "The globally unique name of the IPv4 interface connected to\
@@ -10921,7 +10882,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         addresses:
           description: |-
@@ -11129,7 +11089,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         key_generation_protocol:
           description: |-
@@ -11395,7 +11354,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         basic:
           description: |-
@@ -12206,7 +12164,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         lsa_retransmit_time:
           description: |-
@@ -12329,7 +12286,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         ipv6_name:
           description: "The globally unique name of the IPv6 interface connected to\
@@ -12532,7 +12488,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         addresses:
           description: |-
@@ -12705,7 +12660,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         destination_ip_address:
           description: |-
@@ -12733,7 +12687,6 @@ components:
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           x-field-uid: 1
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         connection_type:
           $ref: '#/components/schemas/Rocev2.ConnectionType'
@@ -12878,7 +12831,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         destination_ip_address:
           description: |-
@@ -12960,8 +12912,12 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
+        payload:
+          description: |-
+            The pattern of the bytes in the transmitted frames for the flow after the protocol headers.
+          $ref: '#/components/schemas/Flow.Payload'
+          x-field-uid: 8
     Flow.TxRx:
       description: "A container for different types of transmit and receive \nendpoint\
         \ containers."
@@ -13244,6 +13200,8 @@ components:
               x-field-uid: 21
             macsec:
               x-field-uid: 22
+            lacp:
+              x-field-uid: 23
           enum:
           - custom
           - ethernet
@@ -13267,6 +13225,7 @@ components:
           - snmpv2c
           - rsvp
           - macsec
+          - lacp
         custom:
           $ref: '#/components/schemas/Flow.Custom'
           x-field-uid: 2
@@ -13333,6 +13292,9 @@ components:
         macsec:
           $ref: '#/components/schemas/Flow.Macsec'
           x-field-uid: 23
+        lacp:
+          $ref: '#/components/schemas/Flow.Lacp'
+          x-field-uid: 24
     Flow.Custom:
       type: object
       description: |-
@@ -13344,7 +13306,7 @@ components:
           description: |-
             A custom packet header defined as a string of hex bytes. The string MUST contain sequence of valid hex bytes. Spaces or colons can be part of the bytes but will be discarded. This packet header can be used in multiple places in the packet.
           type: string
-          pattern: '^[A-Fa-f0-9: ]+$'
+          pattern: '^(?:0[xX])?[A-Fa-f0-9: ]+$'
           x-field-uid: 1
         metric_tags:
           description: |-
@@ -13369,7 +13331,6 @@ components:
             Name used to identify the metrics associated with the values applicable
             for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -15617,6 +15578,205 @@ components:
               x-field-uid: 1
           enum:
           - auto
+    Flow.Lacp:
+      description: |-
+        Defines the fields of a Link Aggregation Control Protocol (LACP) Data Unit (PDU) as specified by IEEE 802.3ad. The ethernet ether type, if set to auto, will be updated to '0x8809' and the destination address, if set to auto, will be updated to "01:80:C2:00:00:02" for LACP. Flows[i].metrics.enable should be set to false to avoid insertion of additional instrumentation bytes in the generated packets.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: lacpdu
+          x-field-uid: 1
+          x-enum:
+            lacpdu:
+              x-field-uid: 1
+          enum:
+          - lacpdu
+        version:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Version'
+        lacpdu:
+          $ref: '#/components/schemas/Flow.Lacp.Lacpdu'
+          x-field-uid: 3
+    Flow.Lacp.Lacpdu:
+      description: |-
+        Defines the TLV fields of a Link Aggregation Control Protocol (LACP)
+        Data Unit (PDU) as specified by IEEE 802.3ad.
+      type: object
+      properties:
+        actor:
+          $ref: '#/components/schemas/Flow.Lacpdu.Actor'
+          x-field-uid: 1
+        partner:
+          $ref: '#/components/schemas/Flow.Lacpdu.Partner'
+          x-field-uid: 2
+        collector:
+          $ref: '#/components/schemas/Flow.Lacpdu.Collector'
+          x-field-uid: 3
+        terminator:
+          $ref: '#/components/schemas/Flow.Lacpdu.Terminator'
+          x-field-uid: 4
+    Flow.Lacpdu.Actor:
+      description: |-
+        Information about the local (actor) system.
+      type: object
+      properties:
+        type:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Type'
+        length:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Length'
+        system_priority:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.SystemPriority'
+        system_id:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.SystemId'
+        key:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Key'
+        port_priority:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.PortPriority'
+        port_number:
+          x-field-uid: 7
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.PortNumber'
+        actor_state:
+          $ref: '#/components/schemas/Flow.Lacpdu.Actor.State'
+          x-field-uid: 8
+        reserved:
+          x-field-uid: 9
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Reserved'
+    Flow.Lacpdu.Partner:
+      description: |-
+        Information about the remote (partner) system.
+      type: object
+      properties:
+        type:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Type'
+        length:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Length'
+        system_priority:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.SystemPriority'
+        system_id:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.SystemId'
+        key:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Key'
+        port_priority:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.PortPriority'
+        port_number:
+          x-field-uid: 7
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.PortNumber'
+        partner_state:
+          $ref: '#/components/schemas/Flow.Lacpdu.Partner.State'
+          x-field-uid: 8
+        reserved:
+          x-field-uid: 9
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Reserved'
+    Flow.Lacpdu.Collector:
+      description: |-
+        Information about frame collection parameters.
+      type: object
+      properties:
+        type:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.Type'
+        length:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.Length'
+        max_delay:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.MaxDelay'
+        reserved:
+          description: |-
+            Reserved field for future use in the Collector TLV. 12 bytes long and should be set to all zeros.
+          type: string
+          format: hex
+          default: '000000000000000000000000'
+          x-field-uid: 4
+    Flow.Lacpdu.Terminator:
+      description: |-
+        Marks the end of the LACPDU message.
+      type: object
+      properties:
+        type:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Terminator.Type'
+        length:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Terminator.Length'
+        reserved:
+          description: |-
+            Final block of reserved bytes to pad the PDU. It is 50 bytes long.
+          type: string
+          format: hex
+          default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+          x-field-uid: 3
+    Flow.Lacpdu.Actor.State:
+      description: |-
+        This field indicates the Actor's state.
+      type: object
+      properties:
+        activity:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Activity'
+        timeout:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Timeout'
+        aggregation:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Aggregation'
+        synchronization:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Synchronization'
+        collecting:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Collecting'
+        distributing:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Distributing'
+        defaulted:
+          x-field-uid: 7
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Defaulted'
+        expired:
+          x-field-uid: 8
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Expired'
+    Flow.Lacpdu.Partner.State:
+      description: |-
+        This field indicates the Partner's state.
+      type: object
+      properties:
+        activity:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Activity'
+        timeout:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Timeout'
+        aggregation:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Aggregation'
+        synchronization:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Synchronization'
+        collecting:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Collecting'
+        distributing:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Distributing'
+        defaulted:
+          x-field-uid: 7
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Defaulted'
+        expired:
+          x-field-uid: 8
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Expired'
     Flow.Size:
       description: |-
         The frame size which overrides the total length of the packet
@@ -16196,6 +16356,62 @@ components:
       description: |-
         This is for cases where one copy of Tx packet is received on all Rx ports and so the sum total of Rx packets
         received across all Rx ports is a multiple of Rx port count and Tx packets.
+    Flow.Payload:
+      description: |-
+        A container for different types of payload, which is the data in the frame after protocol headers.
+        Some part of the payload could be overwritten with instrumentation data, contents and placement of  which is implementation specific.
+      type: object
+      properties:
+        choice:
+          description: |-
+            A choice used to determine the pattern of the bytes in the payload following the protocol headers.
+            Example of expected behaviour of each choice is as mentioned below,
+            - fixed: this would insert user defined pattern in the payload bytes.
+            - increment_byte: this would set the first byte as 00, second as 01 and so on, upto ff and then the pattern would be repeated.
+            - decrement_byte: this would set the first byte as ff, second as fe and so on, upto 00 and then the pattern would be repeated.
+            - increment_word: this would set the first 2 bytes as 00 00, second as 00 01 and so on, upto ff ff and then the pattern would be repeated.
+            - decrement_word: this would set the first 2 bytes as ff ff, second as ff fe and so on, upto 00 00 and then the pattern would be repeated.
+          type: string
+          default: fixed
+          x-field-uid: 1
+          x-enum:
+            fixed:
+              x-field-uid: 1
+            increment_byte:
+              x-field-uid: 2
+            decrement_byte:
+              x-field-uid: 3
+            increment_word:
+              x-field-uid: 4
+            decrement_word:
+              x-field-uid: 5
+          enum:
+          - fixed
+          - increment_byte
+          - decrement_byte
+          - increment_word
+          - decrement_word
+        fixed:
+          $ref: '#/components/schemas/FlowPayload.Fixed'
+          x-field-uid: 2
+    FlowPayload.Fixed:
+      description: |-
+        Payload with user defined pattern.
+      type: object
+      properties:
+        pattern:
+          type: string
+          format: hex
+          default: '00'
+          minLength: 2
+          x-field-uid: 1
+        repeat:
+          description: |-
+            - If enabled, the given pattern would repeat till end of payload.
+            - If disabled, after the pattern, rest of the payload will be zero-padded.
+          type: boolean
+          default: true
+          x-field-uid: 2
     Event:
       description: "Under Review: Event configuration is currently under review for\
         \ pending exploration on use cases.\n\nThe optional container for event configuration.\n\
@@ -16363,7 +16579,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         org_infos:
           description: |-
@@ -16730,7 +16945,6 @@ components:
           description: |-
             Globally unique name of an object. It also serves as the primary key for arrays of objects.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-unique: global
         rocev2_verb:
           $ref: '#/components/schemas/Rocev2.Verb'
@@ -16869,7 +17083,6 @@ components:
             The name used to identify the metric tracked at configured Rx offset and of configured
             length.
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         rx_offset:
           description: |-
@@ -18719,11 +18932,17 @@ components:
           x-enum:
             unplanned:
               x-field-uid: 1
+            planned:
+              x-field-uid: 2
           enum:
           - unplanned
+          - planned
         unplanned:
           $ref: '#/components/schemas/Action.Protocol.Isis.UnplannedRestart'
           x-field-uid: 3
+        planned:
+          $ref: '#/components/schemas/Action.Protocol.Isis.PlannedRestart'
+          x-field-uid: 4
     Action.Protocol.Isis.UnplannedRestart:
       description: |-
         Initiates IS-IS Unplanned Graceful Restart process for the selected IS-IS routers. If no name is specified then Graceful Restart will be sent to all configured IS-IS routers. When an emulated IS-IS router is in the unplanned "Restarting" mode, it sends an IIH PDU containing a Restart TLV with the RR (Restart Request) bit set and holding_time updated to as specified by user to indicate the maximum time within which this router  or routers will complete the graceful restart.  It waits for RA (Restart Acknowledge) in an IIH PDU from Neigbhor(s).  The timer T1 is maintained per interface and indicates the time after which an unacknowledged (re)start attempt will be repeated.
@@ -18747,6 +18966,29 @@ components:
           default: 10
           minimum: 0
           x-field-uid: 2
+    Action.Protocol.Isis.PlannedRestart:
+      description: |-
+        Initiates IS-IS Planned Graceful Restart process for the selected IS-IS routers. If no name is specified then Graceful Restart will be sent to all configured IS-IS routers. When an emulated IS-IS router is in the planned "Restarting" mode, it sends an IIH PDU containing a Restart TLV with the PR (Planned Restart Request) bit set and sets the Remaining Time with the restart_time greater than the expected control-plane restart time that is the maximum time within which this router or routers will complete the graceful restart. It waits for PA (Planned Restart Acknowledge) in an IIH PDU from Neighbor(s). The use of the PR bit provides a means to safely support restart periods that are significantly longer than standard Holding Times. The PR bit SHOULD remain set in IIHs until the restart is initiated. Reference: https://datatracker.ietf.org/doc/html/rfc8706#section-3.2.3. Once the Restarting Router receives the Restart Tlv with PA bit is set, it intiates the Restart Request with the RR bit is set. The holding_time is set as the Remaining Time as received in Restart Tlv or by the remaining time of restart_time that was sent in the Planned Restart Request Tlv. This is left to the choice of the implementation.
+      type: object
+      properties:
+        restart_time:
+          description: |-
+            This is the estimated duration (in seconds) it will take for the IS-IS session to be re-established after a Planned Restart Request. The Remaining Time is set with the restart_time in the Restarting Tlv.
+          type: integer
+          format: uint32
+          maximum: 4096
+          default: 30
+          minimum: 1
+          x-field-uid: 1
+        restart_after:
+          description: |-
+            Once it receives Restarting TLV having PA bit set in a IIH PDU from a neighbor, the time (in seconds), after which IIH PDU, having Restart Tlv with RA & RR bits unset, will be sent. This should result in IIH to be transmitted indicating restart is Completed, and hold_timer is reset to normal.
+          type: integer
+          format: uint32
+          maximum: 4096
+          default: 10
+          minimum: 0
+          x-field-uid: 3
     Metrics.Request:
       description: |-
         Request to traffic generator for metrics of choice.
@@ -27445,7 +27687,8 @@ components:
           x-field-uid: 5
     Capture.Request:
       description: |-
-        The capture result request to the traffic generator. Stops the port capture on the port_name and returns the capture.
+        The capture result request to the traffic generator.
+        Stops the port capture on the port_name and returns the capture.
       type: object
       required:
       - port_name
@@ -27460,6 +27703,73 @@ components:
           x-constraint:
           - /components/schemas/Port/properties/name
           x-field-uid: 1
+        packets:
+          description: |-
+            Specification of the packets to be returned in the capture result from  the set of captured packets as per capture configuration.
+          $ref: '#/components/schemas/CaptureRequest.Packets'
+          x-field-uid: 2
+    CaptureRequest.Packets:
+      description: |-
+        Packets to be returned in the capture result from  the set of captured packets as per capture configuration.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: all
+          x-field-uid: 1
+          x-enum:
+            all:
+              x-field-uid: 1
+            slice:
+              x-field-uid: 2
+          enum:
+          - all
+          - slice
+        slice:
+          $ref: '#/components/schemas/CaptureRequest.CaptureSlice'
+          x-field-uid: 2
+    CaptureRequest.CaptureSlice:
+      description: "Packets to be returned as part of the capture result from the\
+        \ set of captured packets as per \ncapture configuration and specification\
+        \ of capture slice.\nTo be noted,\n- definition of capture slice works in\
+        \ conjunction with capture filter parameters in set_config.\n- if 'initial'\
+        \ set of packets is desired to be returned in the capture result, 'overwrite'\
+        \ attribute in 'captures' \n  settings of set_config should be disabled."
+      type: object
+      properties:
+        choice:
+          type: string
+          default: initial
+          x-field-uid: 1
+          x-enum:
+            initial:
+              x-field-uid: 1
+          enum:
+          - initial
+        initial:
+          $ref: '#/components/schemas/CaptureRequest.CaptureSliceInitial'
+          x-field-uid: 2
+    CaptureRequest.CaptureSliceInitial:
+      description: |-
+        Specification of capture slice to retrieve captured packets from begining of captured packet sequence.
+      type: object
+      properties:
+        start:
+          description: |-
+            Position of the packet (Nth) in the captured packet sequence starting from which  packets would be returned as part of the capture result.
+          type: integer
+          format: uint64
+          minimum: 1
+          default: 1
+          x-field-uid: 1
+        count:
+          description: |-
+            Maximum number of packets to be returned as part of the capture result starting from the position of 'start' packet.
+          type: integer
+          format: uint64
+          minimum: 1
+          default: 100
+          x-field-uid: 2
     Pattern.Flow.Ethernet.Dst.Counter:
       description: |-
         mac counter pattern
@@ -27491,7 +27801,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -27602,7 +27911,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -27710,7 +28018,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -27833,7 +28140,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -27937,7 +28243,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28041,7 +28346,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28145,7 +28449,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28255,7 +28558,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28365,7 +28667,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28469,7 +28770,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28573,7 +28873,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28690,7 +28989,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28794,7 +29092,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -28898,7 +29195,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29015,7 +29311,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29132,7 +29427,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29236,7 +29530,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29340,7 +29633,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29444,7 +29736,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29548,7 +29839,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29652,7 +29942,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29756,7 +30045,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -29910,7 +30198,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -30054,7 +30341,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -30416,7 +30702,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -30542,7 +30827,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -30673,7 +30957,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -30791,7 +31074,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -30907,7 +31189,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31017,7 +31298,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31127,7 +31407,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31237,7 +31516,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31344,7 +31622,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31448,7 +31725,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31552,7 +31828,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31656,7 +31931,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31801,7 +32075,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -31930,7 +32203,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32059,7 +32331,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32160,7 +32431,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32265,7 +32535,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32370,7 +32639,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32469,7 +32737,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32573,7 +32840,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32679,7 +32945,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32783,7 +33048,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32887,7 +33151,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -32991,7 +33254,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33095,7 +33357,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33199,7 +33460,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33303,7 +33563,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33407,7 +33666,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33511,7 +33769,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33615,7 +33872,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33716,7 +33972,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33815,7 +34070,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -33919,7 +34173,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34025,7 +34278,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34129,7 +34381,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34233,7 +34484,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34378,7 +34628,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34520,7 +34769,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34619,7 +34867,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34721,7 +34968,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34825,7 +35071,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -34929,7 +35174,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35033,7 +35277,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35137,7 +35380,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35241,7 +35483,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35345,7 +35586,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35448,7 +35688,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35551,7 +35790,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35654,7 +35892,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35757,7 +35994,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -35901,7 +36137,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -36046,7 +36281,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -36191,7 +36425,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -36335,7 +36568,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -36439,7 +36671,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -36543,7 +36774,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -36650,7 +36880,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -36810,7 +37039,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -36914,7 +37142,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37018,7 +37245,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37122,7 +37348,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37226,7 +37451,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37330,7 +37554,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37434,7 +37657,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37538,7 +37760,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37642,7 +37863,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37743,7 +37963,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37845,7 +38064,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -37949,7 +38167,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38053,7 +38270,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38157,7 +38373,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38261,7 +38476,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38365,7 +38579,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38469,7 +38682,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38573,7 +38785,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38677,7 +38888,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38781,7 +38991,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38885,7 +39094,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -38989,7 +39197,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39090,7 +39297,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39192,7 +39398,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39296,7 +39501,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39402,7 +39606,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39511,7 +39714,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39618,7 +39820,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39722,7 +39923,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39829,7 +40029,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -39933,7 +40132,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40032,7 +40230,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40131,7 +40328,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40230,7 +40426,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40335,7 +40530,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40442,7 +40636,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40586,7 +40779,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40690,7 +40882,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40834,7 +41025,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -40938,7 +41128,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41045,7 +41234,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41152,7 +41340,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41256,7 +41443,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41360,7 +41546,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41546,7 +41731,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41654,7 +41838,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41760,7 +41943,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41877,7 +42059,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -41984,7 +42165,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -42091,7 +42271,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -42232,7 +42411,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -42334,7 +42512,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -42451,7 +42628,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -42555,7 +42731,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -42672,7 +42847,6 @@ components:
           description: |-
             Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
           type: string
-          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         offset:
           description: |-
@@ -45786,6 +45960,2542 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacp.Version.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacp.Version:
+      description: |-
+        The LACP version number.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Version.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Version.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacpdu.Actor.Type:
+      description: |-
+        TLV Type for Actor Information. The value 0x01 identifies this TLV as containing information about the sending device (the Actor).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 20
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacpdu.Actor.Length:
+      description: |-
+        The length of the Actor Information TLV payload in bytes.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 20
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 20
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.SystemPriority.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Actor.SystemPriority:
+      description: |-
+        The priority assigned to the Actor's system for use in aggregation. A lower numerical value indicates a higher priority. Used to select the active System ID when forming an aggregator.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.SystemPriority.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.SystemPriority.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.SystemId.Counter:
+      description: |-
+        mac counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 00:00:00:00:00:00
+          format: mac
+        step:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:01
+          format: mac
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Lacpdu.Actor.SystemId:
+      description: |-
+        The Actor's System ID, which is a globally unique MAC address assigned to the system containing the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:00
+          format: mac
+        values:
+          type: array
+          items:
+            type: string
+            format: mac
+          x-field-uid: 3
+          default:
+          - 00:00:00:00:00:00
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.SystemId.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.SystemId.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.Key.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Actor.Key:
+      description: |-
+        The operational Key value assigned to the Actor's port. The key is generated based on port configuration (e.g., speed, duplex, trunk ID) and is used to identify potential aggregation groups. Only links with the same key can be aggregated together.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Key.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Key.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.PortPriority.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Actor.PortPriority:
+      description: |-
+        The priority assigned to the Actor's port. A lower numerical value indicates a higher priority. Used to prioritize ports for inclusion in a Link Aggregation Group (LAG) when the group is full.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.PortPriority.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.PortPriority.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.PortNumber.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Actor.PortNumber:
+      description: |-
+        The port number assigned to the Actor's port. It is a unique identifier for the port within the system.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.PortNumber.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.PortNumber.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.Reserved.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 16777215
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 16777215
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 16777215
+    Pattern.Flow.Lacpdu.Actor.Reserved:
+      description: |-
+        Reserved field for future use in the Actor TLV. Should be set to all zeros.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 16777215
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 16777215
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Reserved.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.Reserved.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 2
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacpdu.Partner.Type:
+      description: |-
+        TLV Type for Partner Information. The value 0x02 identifies this TLV as containing information about the remote device (the Partner), as understood by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 2
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 2
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 20
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacpdu.Partner.Length:
+      description: |-
+        The length of the Partner Information TLV payload in bytes.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 20
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 20
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.SystemPriority.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Partner.SystemPriority:
+      description: |-
+        The priority of the Partner's system, as received by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.SystemPriority.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.SystemPriority.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.SystemId.Counter:
+      description: |-
+        mac counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 00:00:00:00:00:00
+          format: mac
+        step:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:01
+          format: mac
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Lacpdu.Partner.SystemId:
+      description: |-
+        The Partner's System ID (MAC address), as received by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:00
+          format: mac
+        values:
+          type: array
+          items:
+            type: string
+            format: mac
+          x-field-uid: 3
+          default:
+          - 00:00:00:00:00:00
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.SystemId.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.SystemId.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.Key.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Partner.Key:
+      description: |-
+        The operational Key value of the Partner's port, as received by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Key.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Key.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.PortPriority.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Partner.PortPriority:
+      description: |-
+        The priority of the Partner's port, as received by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.PortPriority.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.PortPriority.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.PortNumber.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Partner.PortNumber:
+      description: |-
+        The port number of the Partner's port, as received by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.PortNumber.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.PortNumber.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.Reserved.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 16777215
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 16777215
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 16777215
+    Pattern.Flow.Lacpdu.Partner.Reserved:
+      description: |-
+        Reserved field for future use in the Partner TLV. Should be set to all zeros.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 16777215
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 16777215
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Reserved.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.Reserved.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Collector.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 3
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacpdu.Collector.Type:
+      description: |-
+        TLV Type for Collector Information. The value 0x03 identifies this TLV.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 3
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 3
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Collector.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 16
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacpdu.Collector.Length:
+      description: |-
+        The length of the Collector Information TLV payload in bytes. The value must be 16 (0x10).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 16
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 16
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Collector.MaxDelay.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacpdu.Collector.MaxDelay:
+      description: |-
+        Indicates the maximum delay, in units of 10 microseconds, that the transmitting system's aggregator will take to buffer frames from its collector before emitting a frame.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.MaxDelay.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Collector.MaxDelay.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Terminator.Type.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacpdu.Terminator.Type:
+      description: |-
+        TLV Type for Terminator Information. The value 0x00 indicates the end of the TLV list.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Terminator.Type.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Terminator.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Terminator.Length.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacpdu.Terminator.Length:
+      description: |-
+        The length of the Terminator TLV payload. The value must be 0.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Terminator.Length.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Terminator.Length.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.State.Activity.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Actor.State.Activity:
+      description: |-
+        LACP Activity (1=Active, 0=Passive)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Activity.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Activity.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.State.Timeout.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Actor.State.Timeout:
+      description: |-
+        LACP Timeout (1=Fast timeout, 0=Slow timeout)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Timeout.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Timeout.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.State.Aggregation.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Actor.State.Aggregation:
+      description: |-
+        Aggregation (1=Aggregatable, 0=Individual)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Aggregation.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Aggregation.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.State.Synchronization.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Actor.State.Synchronization:
+      description: |-
+        Synchronization (1=In Sync, 0=Out of Sync)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Synchronization.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Synchronization.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.State.Collecting.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Actor.State.Collecting:
+      description: |-
+        Collecting (1=Enabled, 0=Disabled)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Collecting.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Collecting.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.State.Distributing.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Actor.State.Distributing:
+      description: |-
+        Distributing (1=Enabled, 0=Disabled)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Distributing.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Distributing.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.State.Defaulted.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Actor.State.Defaulted:
+      description: |-
+        Defaulted (1=Using defaulted partner info, 0=Using received partner info)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Defaulted.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Defaulted.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Actor.State.Expired.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Actor.State.Expired:
+      description: |-
+        Expired (1=Expired, 0=Not Expired)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Expired.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Actor.State.Expired.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.State.Activity.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Partner.State.Activity:
+      description: |-
+        LACP Activity (1=Active, 0=Passive)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Activity.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Activity.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.State.Timeout.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Partner.State.Timeout:
+      description: |-
+        LACP Timeout (1=Fast timeout, 0=Slow timeout)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Timeout.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Timeout.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.State.Aggregation.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Partner.State.Aggregation:
+      description: |-
+        Aggregation (1=Aggregatable, 0=Individual)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Aggregation.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Aggregation.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.State.Synchronization.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Partner.State.Synchronization:
+      description: |-
+        Synchronization (1=In Sync, 0=Out of Sync)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Synchronization.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Synchronization.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.State.Collecting.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Partner.State.Collecting:
+      description: |-
+        Collecting (1=Enabled, 0=Disabled)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Collecting.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Collecting.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.State.Distributing.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Partner.State.Distributing:
+      description: |-
+        Distributing (1=Enabled, 0=Disabled)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Distributing.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Distributing.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.State.Defaulted.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Partner.State.Defaulted:
+      description: |-
+        Defaulted (1=Using defaulted partner info, 0=Using received partner info)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Defaulted.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Defaulted.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacpdu.Partner.State.Expired.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 1
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 1
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 1
+    Pattern.Flow.Lacpdu.Partner.State.Expired:
+      description: |-
+        Expired (1=Expired, 0=Not Expired)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 1
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 1
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Expired.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacpdu.Partner.State.Expired.Counter'
           x-field-uid: 6
     Version:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.31.0
+  version: 1.32.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -22,6 +22,7 @@ paths:
       tags:
       - Configuration
       operationId: set_config
+      x-stream: client
       description: |-
         Sets configuration resources on the traffic generator.
       requestBody:
@@ -41,6 +42,7 @@ paths:
       tags:
       - Configuration
       operationId: get_config
+      x-stream: server
       responses:
         '200':
           description: |-
@@ -118,6 +120,7 @@ paths:
       tags:
       - Control
       operationId: set_control_state
+      x-stream: client
       description: |-
         Sets the operational state of configured resources.
       requestBody:
@@ -138,6 +141,7 @@ paths:
       tags:
       - Control
       operationId: set_control_action
+      x-stream: client
       description: |-
         Triggers actions against configured resources.
       requestBody:
@@ -165,6 +169,7 @@ paths:
       tags:
       - Monitor
       operationId: get_metrics
+      x-stream: server
       requestBody:
         description: |-
           Request to traffic generator for metrics of choice
@@ -192,6 +197,7 @@ paths:
       tags:
       - Monitor
       operationId: get_states
+      x-stream: server
       requestBody:
         description: |-
           Request to traffic generator for states of choice
@@ -219,6 +225,7 @@ paths:
       tags:
       - Monitor
       operationId: get_capture
+      x-stream: server
       requestBody:
         description: |-
           Capture results request to the traffic generator.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.33.0
+/* Open Traffic Generator API 1.38.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -9482,6 +9482,10 @@ message Flow {
   // objects.
   // required = true
   optional string name = 7;
+
+  // The pattern of the bytes in the transmitted frames for the flow after the protocol
+  // headers.
+  FlowPayload payload = 8;
 }
 
 // A container for different types of transmit and receive
@@ -9665,6 +9669,7 @@ message FlowHeader {
       snmpv2c = 20;
       rsvp = 21;
       macsec = 22;
+      lacp = 23;
     }
   }
   // The available types of flow headers. If one is not provided the
@@ -9737,6 +9742,9 @@ message FlowHeader {
 
   // Description missing in models
   FlowMacsec macsec = 23;
+
+  // Description missing in models
+  FlowLacp lacp = 24;
 }
 
 // Custom packet header
@@ -11714,6 +11722,197 @@ message FlowMacsec {
   optional Choice.Enum choice = 1;
 }
 
+// Defines the fields of a Link Aggregation Control Protocol (LACP) Data Unit (PDU)
+// as specified by IEEE 802.3ad. The ethernet ether type, if set to auto, will be updated
+// to '0x8809' and the destination address, if set to auto, will be updated to 01:80:C2:00:00:02
+// for LACP. Flows[i].metrics.enable should be set to false to avoid insertion of additional
+// instrumentation bytes in the generated packets.
+message FlowLacp {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      lacpdu = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.lacpdu
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  PatternFlowLacpVersion version = 2;
+
+  // Description missing in models
+  FlowLacpLacpdu lacpdu = 3;
+}
+
+// Defines the TLV fields of a Link Aggregation Control Protocol (LACP)
+// Data Unit (PDU) as specified by IEEE 802.3ad.
+message FlowLacpLacpdu {
+
+  // Description missing in models
+  FlowLacpduActor actor = 1;
+
+  // Description missing in models
+  FlowLacpduPartner partner = 2;
+
+  // Description missing in models
+  FlowLacpduCollector collector = 3;
+
+  // Description missing in models
+  FlowLacpduTerminator terminator = 4;
+}
+
+// Information about the local (actor) system.
+message FlowLacpduActor {
+
+  // Description missing in models
+  PatternFlowLacpduActorType type = 1;
+
+  // Description missing in models
+  PatternFlowLacpduActorLength length = 2;
+
+  // Description missing in models
+  PatternFlowLacpduActorSystemPriority system_priority = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorSystemId system_id = 4;
+
+  // Description missing in models
+  PatternFlowLacpduActorKey key = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorPortPriority port_priority = 6;
+
+  // Description missing in models
+  PatternFlowLacpduActorPortNumber port_number = 7;
+
+  // Description missing in models
+  FlowLacpduActorState actor_state = 8;
+
+  // Description missing in models
+  PatternFlowLacpduActorReserved reserved = 9;
+}
+
+// Information about the remote (partner) system.
+message FlowLacpduPartner {
+
+  // Description missing in models
+  PatternFlowLacpduPartnerType type = 1;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerLength length = 2;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerSystemPriority system_priority = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerSystemId system_id = 4;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerKey key = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerPortPriority port_priority = 6;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerPortNumber port_number = 7;
+
+  // Description missing in models
+  FlowLacpduPartnerState partner_state = 8;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerReserved reserved = 9;
+}
+
+// Information about frame collection parameters.
+message FlowLacpduCollector {
+
+  // Description missing in models
+  PatternFlowLacpduCollectorType type = 1;
+
+  // Description missing in models
+  PatternFlowLacpduCollectorLength length = 2;
+
+  // Description missing in models
+  PatternFlowLacpduCollectorMaxDelay max_delay = 3;
+
+  // Reserved field for future use in the Collector TLV. 12 bytes long and should be set
+  // to all zeros.
+  // default = 000000000000000000000000
+  optional string reserved = 4;
+}
+
+// Marks the end of the LACPDU message.
+message FlowLacpduTerminator {
+
+  // Description missing in models
+  PatternFlowLacpduTerminatorType type = 1;
+
+  // Description missing in models
+  PatternFlowLacpduTerminatorLength length = 2;
+
+  // Final block of reserved bytes to pad the PDU. It is 50 bytes long.
+  // default = 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  optional string reserved = 3;
+}
+
+// This field indicates the Actor's state.
+message FlowLacpduActorState {
+
+  // Description missing in models
+  PatternFlowLacpduActorStateActivity activity = 1;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateTimeout timeout = 2;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateAggregation aggregation = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateSynchronization synchronization = 4;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateCollecting collecting = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateDistributing distributing = 6;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateDefaulted defaulted = 7;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateExpired expired = 8;
+}
+
+// This field indicates the Partner's state.
+message FlowLacpduPartnerState {
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateActivity activity = 1;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateTimeout timeout = 2;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateAggregation aggregation = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateSynchronization synchronization = 4;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateCollecting collecting = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateDistributing distributing = 6;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateDefaulted defaulted = 7;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateExpired expired = 8;
+}
+
 // The frame size which overrides the total length of the packet
 message FlowSize {
 
@@ -12148,6 +12347,54 @@ message FlowRxTxRatio {
 // the sum total of Rx packets
 // received across all Rx ports is a multiple of Rx port count and Tx packets.
 message FlowRxTxRatioRxCount {
+}
+
+// A container for different types of payload, which is the data in the frame after
+// protocol headers.
+// Some part of the payload could be overwritten with instrumentation data, contents
+// and placement of  which is implementation specific.
+message FlowPayload {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      fixed = 1;
+      increment_byte = 2;
+      decrement_byte = 3;
+      increment_word = 4;
+      decrement_word = 5;
+    }
+  }
+  // A choice used to determine the pattern of the bytes in the payload following the
+  // protocol headers.
+  // Example of expected behaviour of each choice is as mentioned below,
+  // - fixed: this would insert user defined pattern in the payload bytes.
+  // - increment_byte: this would set the first byte as 00, second as 01 and so on, upto
+  // ff and then the pattern would be repeated.
+  // - decrement_byte: this would set the first byte as ff, second as fe and so on, upto
+  // 00 and then the pattern would be repeated.
+  // - increment_word: this would set the first 2 bytes as 00 00, second as 00 01 and
+  // so on, upto ff ff and then the pattern would be repeated.
+  // - decrement_word: this would set the first 2 bytes as ff ff, second as ff fe and
+  // so on, upto 00 00 and then the pattern would be repeated.
+  // default = Choice.Enum.fixed
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  FlowPayloadFixed fixed = 2;
+}
+
+// Payload with user defined pattern.
+message FlowPayloadFixed {
+
+  // Description missing in models
+  // default = 00
+  optional string pattern = 1;
+
+  // - If enabled, the given pattern would repeat till end of payload.
+  // - If disabled, after the pattern, rest of the payload will be zero-padded.
+  // default = True
+  optional bool repeat = 2;
 }
 
 // Under Review: Event configuration is currently under review for pending exploration
@@ -14126,6 +14373,7 @@ message ActionProtocolIsisInitiateRestart {
     enum Enum {
       unspecified = 0;
       unplanned = 1;
+      planned = 2;
     }
   }
   // Description missing in models
@@ -14134,6 +14382,9 @@ message ActionProtocolIsisInitiateRestart {
 
   // Description missing in models
   ActionProtocolIsisUnplannedRestart unplanned = 3;
+
+  // Description missing in models
+  ActionProtocolIsisPlannedRestart planned = 4;
 }
 
 // Initiates IS-IS Unplanned Graceful Restart process for the selected IS-IS routers.
@@ -14158,6 +14409,36 @@ message ActionProtocolIsisUnplannedRestart {
   // not started i.e. RR bit is cleared and hold_timer is reset to normal.
   // default = 10
   optional uint32 restart_after = 2;
+}
+
+// Initiates IS-IS Planned Graceful Restart process for the selected IS-IS routers.
+// If no name is specified then Graceful Restart will be sent to all configured IS-IS
+// routers. When an emulated IS-IS router is in the planned Restarting mode, it sends
+// an IIH PDU containing a Restart TLV with the PR (Planned Restart Request) bit set
+// and sets the Remaining Time with the restart_time greater than the expected control-plane
+// restart time that is the maximum time within which this router or routers will complete
+// the graceful restart. It waits for PA (Planned Restart Acknowledge) in an IIH PDU
+// from Neighbor(s). The use of the PR bit provides a means to safely support restart
+// periods that are significantly longer than standard Holding Times. The PR bit SHOULD
+// remain set in IIHs until the restart is initiated. Reference: https://datatracker.ietf.org/doc/html/rfc8706#section-3.2.3.
+// Once the Restarting Router receives the Restart Tlv with PA bit is set, it intiates
+// the Restart Request with the RR bit is set. The holding_time is set as the Remaining
+// Time as received in Restart Tlv or by the remaining time of restart_time that was
+// sent in the Planned Restart Request Tlv. This is left to the choice of the implementation.
+message ActionProtocolIsisPlannedRestart {
+
+  // This is the estimated duration (in seconds) it will take for the IS-IS session to
+  // be re-established after a Planned Restart Request. The Remaining Time is set with
+  // the restart_time in the Restarting Tlv.
+  // default = 30
+  optional uint32 restart_time = 1;
+
+  // Once it receives Restarting TLV having PA bit set in a IIH PDU from a neighbor, the
+  // time (in seconds), after which IIH PDU, having Restart Tlv with RA & RR bits unset,
+  // will be sent. This should result in IIH to be transmitted indicating restart is Completed,
+  // and hold_timer is reset to normal.
+  // default = 10
+  optional uint32 restart_after = 3;
 }
 
 // Request to traffic generator for metrics of choice.
@@ -19483,8 +19764,8 @@ message IsisIIHRestartFlags {
   optional bool pa_bit = 5;
 }
 
-// The capture result request to the traffic generator. Stops the port capture on the
-// port_name and returns the capture.
+// The capture result request to the traffic generator.
+// Stops the port capture on the port_name and returns the capture.
 message CaptureRequest {
 
   // The name of a port a capture is started on.
@@ -19494,6 +19775,69 @@ message CaptureRequest {
   // 
   // required = true
   optional string port_name = 1;
+
+  // Specification of the packets to be returned in the capture result from  the set of
+  // captured packets as per capture configuration.
+  CaptureRequestPackets packets = 2;
+}
+
+// Packets to be returned in the capture result from  the set of captured packets as
+// per capture configuration.
+message CaptureRequestPackets {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      all = 1;
+      slice = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.all
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  CaptureRequestCaptureSlice slice = 2;
+}
+
+// Packets to be returned as part of the capture result from the set of captured packets
+// as per
+// capture configuration and specification of capture slice.
+// To be noted,
+// - definition of capture slice works in conjunction with capture filter parameters
+// in set_config.
+// - if 'initial' set of packets is desired to be returned in the capture result, 'overwrite'
+// attribute in 'captures'
+// settings of set_config should be disabled.
+message CaptureRequestCaptureSlice {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      initial = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.initial
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  CaptureRequestCaptureSliceInitial initial = 2;
+}
+
+// Specification of capture slice to retrieve captured packets from begining of captured
+// packet sequence.
+message CaptureRequestCaptureSliceInitial {
+
+  // Position of the packet (Nth) in the captured packet sequence starting from which
+  // packets would be returned as part of the capture result.
+  // default = 1
+  optional uint64 start = 1;
+
+  // Maximum number of packets to be returned as part of the capture result starting from
+  // the position of 'start' packet.
+  // default = 100
+  optional uint64 count = 2;
 }
 
 // mac counter pattern
@@ -32251,6 +32595,1805 @@ message PatternFlowRSVPPathObjectsCustomType {
 
   // Description missing in models
   PatternFlowRSVPPathObjectsCustomTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpVersionCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The LACP version number.
+message PatternFlowLacpVersion {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpVersionCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpVersionCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorTypeCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// TLV Type for Actor Information. The value 0x01 identifies this TLV as containing
+// information about the sending device (the Actor).
+message PatternFlowLacpduActorType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorLengthCounter {
+
+  // Description missing in models
+  // default = 20
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The length of the Actor Information TLV payload in bytes.
+message PatternFlowLacpduActorLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 20
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [20]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorLengthCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorSystemPriorityCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The priority assigned to the Actor's system for use in aggregation. A lower numerical
+// value indicates a higher priority. Used to select the active System ID when forming
+// an aggregator.
+message PatternFlowLacpduActorSystemPriority {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorSystemPriorityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorSystemPriorityCounter decrement = 6;
+}
+
+// mac counter pattern
+message PatternFlowLacpduActorSystemIdCounter {
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:01
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The Actor's System ID, which is a globally unique MAC address assigned to the system
+// containing the Actor.
+message PatternFlowLacpduActorSystemId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['00:00:00:00:00:00']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorSystemIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorSystemIdCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorKeyCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The operational Key value assigned to the Actor's port. The key is generated based
+// on port configuration (e.g., speed, duplex, trunk ID) and is used to identify potential
+// aggregation groups. Only links with the same key can be aggregated together.
+message PatternFlowLacpduActorKey {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorKeyCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorKeyCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorPortPriorityCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The priority assigned to the Actor's port. A lower numerical value indicates a higher
+// priority. Used to prioritize ports for inclusion in a Link Aggregation Group (LAG)
+// when the group is full.
+message PatternFlowLacpduActorPortPriority {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorPortPriorityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorPortPriorityCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorPortNumberCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The port number assigned to the Actor's port. It is a unique identifier for the port
+// within the system.
+message PatternFlowLacpduActorPortNumber {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorPortNumberCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorPortNumberCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorReservedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Reserved field for future use in the Actor TLV. Should be set to all zeros.
+message PatternFlowLacpduActorReserved {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorReservedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorReservedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerTypeCounter {
+
+  // Description missing in models
+  // default = 2
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// TLV Type for Partner Information. The value 0x02 identifies this TLV as containing
+// information about the remote device (the Partner), as understood by the Actor.
+message PatternFlowLacpduPartnerType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 2
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [2]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerLengthCounter {
+
+  // Description missing in models
+  // default = 20
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The length of the Partner Information TLV payload in bytes.
+message PatternFlowLacpduPartnerLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 20
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [20]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerLengthCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerSystemPriorityCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The priority of the Partner's system, as received by the Actor.
+message PatternFlowLacpduPartnerSystemPriority {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerSystemPriorityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerSystemPriorityCounter decrement = 6;
+}
+
+// mac counter pattern
+message PatternFlowLacpduPartnerSystemIdCounter {
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:01
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The Partner's System ID (MAC address), as received by the Actor.
+message PatternFlowLacpduPartnerSystemId {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['00:00:00:00:00:00']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerSystemIdCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerSystemIdCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerKeyCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The operational Key value of the Partner's port, as received by the Actor.
+message PatternFlowLacpduPartnerKey {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerKeyCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerKeyCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerPortPriorityCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The priority of the Partner's port, as received by the Actor.
+message PatternFlowLacpduPartnerPortPriority {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerPortPriorityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerPortPriorityCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerPortNumberCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The port number of the Partner's port, as received by the Actor.
+message PatternFlowLacpduPartnerPortNumber {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerPortNumberCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerPortNumberCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerReservedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Reserved field for future use in the Partner TLV. Should be set to all zeros.
+message PatternFlowLacpduPartnerReserved {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerReservedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerReservedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduCollectorTypeCounter {
+
+  // Description missing in models
+  // default = 3
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// TLV Type for Collector Information. The value 0x03 identifies this TLV.
+message PatternFlowLacpduCollectorType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 3
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [3]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduCollectorTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduCollectorTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduCollectorLengthCounter {
+
+  // Description missing in models
+  // default = 16
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The length of the Collector Information TLV payload in bytes. The value must be 16
+// (0x10).
+message PatternFlowLacpduCollectorLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 16
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [16]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduCollectorLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduCollectorLengthCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduCollectorMaxDelayCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Indicates the maximum delay, in units of 10 microseconds, that the transmitting system's
+// aggregator will take to buffer frames from its collector before emitting a frame.
+message PatternFlowLacpduCollectorMaxDelay {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduCollectorMaxDelayCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduCollectorMaxDelayCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduTerminatorTypeCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// TLV Type for Terminator Information. The value 0x00 indicates the end of the TLV
+// list.
+message PatternFlowLacpduTerminatorType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduTerminatorTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduTerminatorTypeCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduTerminatorLengthCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// The length of the Terminator TLV payload. The value must be 0.
+message PatternFlowLacpduTerminatorLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduTerminatorLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduTerminatorLengthCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorStateActivityCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// LACP Activity (1=Active, 0=Passive)
+message PatternFlowLacpduActorStateActivity {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateActivityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateActivityCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorStateTimeoutCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// LACP Timeout (1=Fast timeout, 0=Slow timeout)
+message PatternFlowLacpduActorStateTimeout {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateTimeoutCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateTimeoutCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorStateAggregationCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Aggregation (1=Aggregatable, 0=Individual)
+message PatternFlowLacpduActorStateAggregation {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateAggregationCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateAggregationCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorStateSynchronizationCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Synchronization (1=In Sync, 0=Out of Sync)
+message PatternFlowLacpduActorStateSynchronization {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateSynchronizationCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateSynchronizationCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorStateCollectingCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Collecting (1=Enabled, 0=Disabled)
+message PatternFlowLacpduActorStateCollecting {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateCollectingCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateCollectingCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorStateDistributingCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Distributing (1=Enabled, 0=Disabled)
+message PatternFlowLacpduActorStateDistributing {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateDistributingCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateDistributingCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorStateDefaultedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Defaulted (1=Using defaulted partner info, 0=Using received partner info)
+message PatternFlowLacpduActorStateDefaulted {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateDefaultedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateDefaultedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduActorStateExpiredCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Expired (1=Expired, 0=Not Expired)
+message PatternFlowLacpduActorStateExpired {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateExpiredCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduActorStateExpiredCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerStateActivityCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// LACP Activity (1=Active, 0=Passive)
+message PatternFlowLacpduPartnerStateActivity {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateActivityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateActivityCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerStateTimeoutCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// LACP Timeout (1=Fast timeout, 0=Slow timeout)
+message PatternFlowLacpduPartnerStateTimeout {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateTimeoutCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateTimeoutCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerStateAggregationCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Aggregation (1=Aggregatable, 0=Individual)
+message PatternFlowLacpduPartnerStateAggregation {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateAggregationCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateAggregationCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerStateSynchronizationCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Synchronization (1=In Sync, 0=Out of Sync)
+message PatternFlowLacpduPartnerStateSynchronization {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateSynchronizationCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateSynchronizationCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerStateCollectingCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Collecting (1=Enabled, 0=Disabled)
+message PatternFlowLacpduPartnerStateCollecting {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateCollectingCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateCollectingCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerStateDistributingCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Distributing (1=Enabled, 0=Disabled)
+message PatternFlowLacpduPartnerStateDistributing {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateDistributingCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateDistributingCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerStateDefaultedCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Defaulted (1=Using defaulted partner info, 0=Using received partner info)
+message PatternFlowLacpduPartnerStateDefaulted {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateDefaultedCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateDefaultedCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowLacpduPartnerStateExpiredCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Expired (1=Expired, 0=Not Expired)
+message PatternFlowLacpduPartnerStateExpired {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateExpiredCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpduPartnerStateExpiredCounter decrement = 6;
 }
 
 // Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.31.0
+/* Open Traffic Generator API 1.32.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -31885,6 +31885,12 @@ message Failure {
   Error error = 1;
 }
 
+// Data that needs to be streamed
+message Data {
+  uint64 chunk_size = 1;
+  bytes datum = 2;
+}
+
 message SetConfigRequest {
   Config config = 1;
 }
@@ -31975,8 +31981,12 @@ service Openapi {
 
   // Sets configuration resources on the traffic generator.
   rpc SetConfig(SetConfigRequest) returns (SetConfigResponse);
+  // streaming version of the rpc SetConfig
+  rpc streamSetConfig(stream Data) returns (SetConfigResponse);
   // Description missing in models
   rpc GetConfig(google.protobuf.Empty) returns (GetConfigResponse);
+  // streaming version of the rpc GetConfig
+  rpc streamGetConfig(google.protobuf.Empty) returns (stream Data);
   // Updates specific attributes of resources configured on the traffic generator. The
   // fetched configuration shall reflect the updates applied successfully.
   // The Response.Warnings in the Success response is available for implementers to disclose
@@ -32001,14 +32011,24 @@ service Openapi {
   rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse);
   // Sets the operational state of configured resources.
   rpc SetControlState(SetControlStateRequest) returns (SetControlStateResponse);
+  // streaming version of the rpc SetControlState
+  rpc streamSetControlState(stream Data) returns (SetControlStateResponse);
   // Triggers actions against configured resources.
   rpc SetControlAction(SetControlActionRequest) returns (SetControlActionResponse);
+  // streaming version of the rpc SetControlAction
+  rpc streamSetControlAction(stream Data) returns (SetControlActionResponse);
   // Description missing in models
   rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  // streaming version of the rpc GetMetrics
+  rpc streamGetMetrics(GetMetricsRequest) returns (stream Data);
   // Description missing in models
   rpc GetStates(GetStatesRequest) returns (GetStatesResponse);
+  // streaming version of the rpc GetStates
+  rpc streamGetStates(GetStatesRequest) returns (stream Data);
   // Description missing in models
   rpc GetCapture(GetCaptureRequest) returns (GetCaptureResponse);
+  // streaming version of the rpc GetCapture
+  rpc streamGetCapture(GetCaptureRequest) returns (stream Data);
   // Description missing in models
   rpc GetVersion(google.protobuf.Empty) returns (GetVersionResponse);
 }

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.32.0
+/* Open Traffic Generator API 1.33.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -1750,6 +1750,9 @@ message DeviceIsisRouter {
 
   // Optional Segment Routing (SR).
   IsisSegmentRouting segment_routing = 10;
+
+  // Optional IS-IS Graceful Restart Configuration.
+  IsisGracefulRestart graceful_restart = 11;
 }
 
 // This container properties of an Multi-Instance-capable router (MI-RTR).
@@ -2692,6 +2695,17 @@ message IsisSRSrlb {
   // This represents the number of SIDs in a SRLB range.
   // default = 8000
   optional uint32 range = 2;
+}
+
+// Contains IS-IS Graceful configuration parameters.
+// Reference: https://datatracker.ietf.org/doc/html/rfc8706
+message IsisGracefulRestart {
+
+  // The emulated IS-IS router will acting in as the Helper for the DUT that is restarting.
+  // It acknowledges the Restart TLV sent by the DUT by sending an IIH containing a Restart
+  // TLV with the RA (Restart Acknowledgment) bit set.
+  // default = True
+  optional bool helper_mode = 1;
 }
 
 // Configuration for one or more IPv4 or IPv6 BGP peers.
@@ -7950,7 +7964,7 @@ message Ospfv2InterfaceAdvanced {
   optional uint32 dead_interval = 2;
 
   // Routing metric associated with the interface..
-  // default = 0
+  // default = 10
   optional uint32 routing_metric = 3;
 
   // The Priority for (Backup) Designated Router election.
@@ -13680,6 +13694,7 @@ message ActionProtocol {
       ipv4 = 1;
       ipv6 = 2;
       bgp = 3;
+      isis = 4;
     }
   }
   // Description missing in models
@@ -13694,6 +13709,9 @@ message ActionProtocol {
 
   // Description missing in models
   ActionProtocolBgp bgp = 4;
+
+  // Description missing in models
+  ActionProtocolIsis isis = 5;
 }
 
 // Response for actions associated with protocols on configured resources.
@@ -14063,6 +14081,83 @@ message ActionProtocolBgpGracefulRestartNotification {
 
   // Description missing in models
   DeviceBgpCustomError custom = 9;
+}
+
+// Actions associated with IS-IS on configured resources.
+message ActionProtocolIsis {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      initiate_graceful_restart = 1;
+    }
+  }
+  // Description missing in models
+  // required = true
+  optional Choice.Enum choice = 1;
+
+  // Configuration for the initiation of the IS-IS Graceful Restart.
+  ActionProtocolIsisInitiateRestart initiate_graceful_restart = 2;
+}
+
+// Timers T1 and T2 are used both by a restarting router and a starting router. Timer
+// T3 is used only by a restarting router.
+// - Timer T1 is maintained per interface and indicates the time after which an unacknowledged
+// (re)start attempt will be repeated. Its value is 3 seconds.
+// - Timer T2 is maintained for each LSP database (LSDB) for Level 1 and Level 2. Default
+// value is 90 seconds.
+// When the timer T2 expires or is canceled, indicating that synchronization of that
+// level is complete and SPF for that level is run.
+// - Timer T3 is maintained for the entire system after which the router will declare
+// that it has failed to achieve database synchronization
+// (by setting the overload bit in its own LSP). Its initial value is 65535 seconds
+// and is set to minimum of the remaining times of received IIHs
+// containing a Restart TLV with the RA set.
+message ActionProtocolIsisInitiateRestart {
+
+  // The names of device objects to control.
+  // 
+  // x-constraint:
+  // - /components/schemas/Device.IsisRouter/properties/name
+  // 
+  repeated string router_names = 1;
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      unplanned = 1;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.unplanned
+  optional Choice.Enum choice = 2;
+
+  // Description missing in models
+  ActionProtocolIsisUnplannedRestart unplanned = 3;
+}
+
+// Initiates IS-IS Unplanned Graceful Restart process for the selected IS-IS routers.
+// If no name is specified then Graceful Restart will be sent to all configured IS-IS
+// routers. When an emulated IS-IS router is in the unplanned Restarting mode, it sends
+// an IIH PDU containing a Restart TLV with the RR (Restart Request) bit set and holding_time
+// updated to as specified by user to indicate the maximum time within which this router
+// or routers will complete the graceful restart.  It waits for RA (Restart Acknowledge)
+// in an IIH PDU from Neigbhor(s).  The timer T1 is maintained per interface and indicates
+// the time after which an unacknowledged (re)start attempt will be repeated.
+message ActionProtocolIsisUnplannedRestart {
+
+  // This is the estimated duration (in seconds) it will take for the IS-IS session to
+  // be re-established after a restart. The hold-timer in the IIH PDU is updated with
+  // this time.
+  // default = 30
+  optional uint32 holding_time = 1;
+
+  // Once it receives Restarting TLV having RA bit set in a IIH PDU and CSNP PDU, time
+  // (in seconds), after which IIH PDU, having Restart Tlv with RR bit unset, will be
+  // sent. This should result in IIH to be transmitted indicating restart is Completed,
+  // not started i.e. RR bit is cleared and hold_timer is reset to normal.
+  // default = 10
+  optional uint32 restart_after = 2;
 }
 
 // Request to traffic generator for metrics of choice.
@@ -14980,6 +15075,10 @@ message IsisMetricsRequest {
       l2_csnp_received = 24;
       l2_lsp_sent = 25;
       l2_lsp_received = 26;
+      gr_initiated = 27;
+      gr_succeeded = 28;
+      neighbor_gr_initiated = 29;
+      neighbor_gr_succeeded = 30;
     }
   }
   // The list of column names that the returned result set will contain. If the list is
@@ -15071,6 +15170,24 @@ message IsisMetric {
 
   // Number of Level 2 (L2) Link State Protocol Data Units (LSPs) received.
   optional uint64 l2_lsp_received = 27;
+
+  // Number of Graceful Restarts that were initiated by this router.
+  optional uint64 gr_initiated = 28;
+
+  // Number of Graceful Restarts succeeded that were initiated by a this router. This
+  // counter is incremented if the Graceful Restart completes succesfully before the T3
+  // timer expires. Timer T3 is maintained for the entire system after which  the router
+  // will declare that it has failed to achieve database synchronization.
+  optional uint64 gr_succeeded = 29;
+
+  // Number of Graceful Restarts that were initiated by a Neighbor. This counter is incremented
+  // for Restart TLV having RR bit set in the received IIH PDU.
+  optional uint64 neighbor_gr_initiated = 30;
+
+  // Number of Graceful Restarts succeeded that were initiated by a Neighbor. This counter
+  // is incremented when Restart TLV having RR bit unset in the received IIH PDU after
+  // the Graceful Restart was initiated by a Neighbor.
+  optional uint64 neighbor_gr_succeeded = 31;
 }
 
 // The request to retrieve per LAG metrics/statistics.
@@ -16922,6 +17039,7 @@ message StatesRequest {
       dhcpv6_leases = 10;
       ospfv2_lsas = 11;
       ospfv3_lsas = 12;
+      isis_adjacencies = 13;
     }
   }
   // Description missing in models
@@ -16963,6 +17081,9 @@ message StatesRequest {
 
   // Description missing in models
   Ospfv3LsasStateRequest ospfv3_lsas = 13;
+
+  // Description missing in models
+  IsisIIHsStateRequest isis_adjacencies = 14;
 }
 
 // Response containing chosen traffic generator states
@@ -16983,6 +17104,7 @@ message StatesResponse {
       dhcpv6_leases = 10;
       ospfv2_lsas = 11;
       ospfv3_lsas = 12;
+      isis_adjacencies = 13;
     }
   }
   // Description missing in models
@@ -17024,6 +17146,9 @@ message StatesResponse {
 
   // Description missing in models
   repeated Ospfv3LsaState ospfv3_lsas = 13;
+
+  // Description missing in models
+  repeated IsisIIHsState isis_adjacencies = 14;
 }
 
 // The request to retrieve IPv4 Neighbor state (ARP cache entries) of a network interface(s).
@@ -19086,6 +19211,276 @@ message Ospfv3Link {
   // router's interface; for all other connections it represents
   // the local system's IP address.
   optional uint32 metric = 2;
+}
+
+// The request to retrieve ISIS IIH information exchanged by the ISIS routers.
+message IsisIIHsStateRequest {
+
+  // The names of ISIS routers for which learned information is requested. An empty list
+  // will return results of IIH States for all ISIS routers.
+  // 
+  // x-constraint:
+  // - /components/schemas/Device.IsisRouter/properties/name
+  // 
+  repeated string isis_router_names = 1;
+}
+
+// The result of ISIS IIH information that are exchanged.
+message IsisIIHsState {
+
+  // The name of the ISIS Router.
+  optional string isis_router_name = 1;
+
+  // Current state of adjacencies.
+  repeated IsisLocalIIHAdjacencyStates adjacency_states = 2;
+}
+
+// Information for a local adjacency.
+message IsisLocalIIHAdjacencyStates {
+
+  // System ID of a neighbor in the hex format, e.g. '650000000001'.
+  optional string neighbor_system_id = 1;
+
+  // Interface name on which adjacency is created.
+  optional string interface_name = 2;
+
+  // Local adjacency state of this ISIS router.
+  IsisLocalIIHState local_state = 3;
+
+  // A IS-IS neighbor that are learned by this ISIS router.
+  IsisNeighborIIHState neighbor_state = 4;
+}
+
+// Information for a local adjacency.
+message IsisLocalIIHState {
+
+  message LevelType {
+    enum Enum {
+      unspecified = 0;
+      level_1 = 1;
+      level_2 = 2;
+      level_1_2 = 3;
+    }
+  }
+  // This indicates whether this IS-IS router is participating in Level-1 (L1),
+  // Level-2 (L2) or both L1 and L2 domains on this interface.
+  optional LevelType.Enum level_type = 1;
+
+  // Hold timer being sent in the IIH PDU.
+  optional uint32 hold_timer = 2;
+
+  // Reference to Restarting Information.
+  IsisIIHLocalRestartStatus restarting_status = 3;
+}
+
+// Information for neighbor adjacency State.
+message IsisNeighborIIHState {
+
+  message LevelType {
+    enum Enum {
+      unspecified = 0;
+      level_1 = 1;
+      level_2 = 2;
+      level_1_2 = 3;
+    }
+  }
+  // This indicates whether Neighbor IS-IS router is participating in Level-1 (L1),
+  // Level-2 (L2) or both L1 and L2 domains on this interface.
+  optional LevelType.Enum level_type = 1;
+
+  // Hold timer received in the IIH PDU sent by the neighbor..
+  optional uint32 hold_timer = 2;
+
+  // Reference to Restarting Information.
+  IsisIIHNeighborRestartStatus restarting_status = 3;
+
+  // It refers to IIH PDU TLVs container.
+  IsisIIHNeighborTlvs tlvs = 4;
+}
+
+// This contains the Restarting/Starting/Running state of this router.
+message IsisIIHLocalRestartStatus {
+
+  message State {
+    enum Enum {
+      unspecified = 0;
+      running = 1;
+      starting = 2;
+      restarting = 3;
+    }
+  }
+  // Current State of this router.
+  // - starting: Is in Starting state when Restarting Tlv has been sent with SA bit set.
+  // - running: Is in Running state when Restarting Tlv is not present or Restarting Tlv
+  // has been sent with SA or RR bits unset.
+  // - restarting: Is in Restarting state when Restarting Tlv has been sent with RR bits
+  // set.
+  optional State.Enum state = 1;
+
+  // This container holds the information of the last Graceful Restart initiated on this
+  // router.
+  IsisIIHLocalGRLastAttemptStatus last_attempt_status = 2;
+}
+
+// This contains the Restarting/Starting/Running state of a neighbor router.
+message IsisIIHNeighborRestartStatus {
+
+  message State {
+    enum Enum {
+      unspecified = 0;
+      running = 1;
+      starting = 2;
+      restarting = 3;
+    }
+  }
+  // Current State of Neighbor router.
+  // - starting: Is in Starting state when Restarting Tlv has been received with SA bit
+  // set.
+  // - running: Is in Running state when Restarting Tlv is not present or Restarting Tlv
+  // has been received with SA or RR bits unset.
+  // - restarting: Is in Restarting state when Restarting Tlv has been received with RR
+  // bits set.
+  optional State.Enum state = 1;
+
+  // This container holds the information of the last Graceful Restart initiated  by the
+  // neighbor since the adjacency was established.
+  IsisIIHNeighborGRLastAttemptStatus last_attempt_status = 2;
+}
+
+// This object contains the status of the last attempted Graceful Restart status of
+// this router.
+// - succeeded: Choice is set if the last Graceful Status is successful.
+// - failed: The last Graceful Status is unsuccessful.
+// - inprogress: The last Graceful Restart status is in progress.
+// - unavailable: The last Graceful Restart status is not initiated.
+message IsisIIHLocalGRLastAttemptStatus {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      succeeded = 1;
+      failed = 2;
+      inprogress = 3;
+      unavailable = 4;
+    }
+  }
+  // Description missing in models
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  IsisIIHLocalGRLastAttemptSucceeded succeeded = 2;
+
+  // Description missing in models
+  IsisIIHLocalGRLastAttemptFailed failed = 3;
+}
+
+// This container contains the failure status of the last Graceful Restart initiated
+// by this router.
+message IsisIIHLocalGRLastAttemptFailed {
+
+  // Failure reason of last Graceful Restart.
+  optional string reason = 1;
+}
+
+// This container contains details about the successful status of the last Graceful
+// Restart initiated by this router.
+message IsisIIHLocalGRLastAttemptSucceeded {
+
+  // The time (in seconds) is taken to synchronize the L1 and L2 LSDB by this Restarting
+  // router.
+  // By this time, the CSNP list is cleared and all LSPs are collected by the neighbor(s).
+  optional uint32 lsdb_syncup_time = 1;
+
+  // The time (in seconds) is measured from when the Restart TLV with RR bit set is sent
+  // 
+  // in an IIH PDU upto the time when Restart TLV is sent with RR bit unset.
+  optional uint32 adjacency_bring_up_time = 3;
+}
+
+// This object contains the status of the last attempted Graceful Restart status of
+// an ISIS neighbor.
+// - succeeded: Choice is set if the last Graceful was successful.
+// - failed: The last Graceful attempt was unsuccessful.
+// - inprogress: The last Graceful Restart is in progress.
+// - unavailable: Graceful Restart has never been initiated by the neighbor.
+message IsisIIHNeighborGRLastAttemptStatus {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      succeeded = 1;
+      failed = 2;
+      inprogress = 3;
+      unavailable = 4;
+    }
+  }
+  // Description missing in models
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  IsisIIHNeighborGRLastAttemptSucceeded succeeded = 2;
+
+  // Description missing in models
+  IsisIIHNeighborGRLastAttemptFailed failed = 3;
+}
+
+// This container contains the failure status of the last Graceful Restart initiated
+// by this neighbor.
+message IsisIIHNeighborGRLastAttemptFailed {
+
+  // Failure reason of last Graceful Restart in readable string.
+  optional string reason = 1;
+}
+
+// This object contains the result of a successful graceful restart status in the last
+// attempted by a Neighbor.
+message IsisIIHNeighborGRLastAttemptSucceeded {
+
+  // The time (in second) is measured from when the Restart TLV with RR bit set in a IIH
+  // PDU is received up to the time
+  // when it receives the Restart TLV with RR bit and SA bit unset in a IIH PDU from the
+  // Neighbor Router.
+  optional uint32 adjacency_bring_up_time = 1;
+}
+
+// This contains the list of TLVs present in a IIH PDU received from a neighbor IS-IS
+// router.
+message IsisIIHNeighborTlvs {
+
+  // Restart Tlv.
+  IsisIIHRestartTlv restart_tlv = 1;
+}
+
+// Container of Restart TLV in IIH PDU. Reference: https://datatracker.ietf.org/doc/html/rfc8706#name-restart-tlv
+message IsisIIHRestartTlv {
+
+  // One octet Restart flags in the Restart TLV.
+  IsisIIHRestartFlags flags = 1;
+
+  // Remaining Holding Time (in seconds).
+  optional uint32 remaining_time = 2;
+
+  // Restarting Neighbor's System ID in hex format without 0x at the beginning. e.g. '640000000001'
+  optional string restarting_neighbor_id = 3;
+}
+
+// Restarting flags in Restarting TLV in IIH PDU.
+message IsisIIHRestartFlags {
+
+  // Restart Request bit.
+  optional bool rr_bit = 1;
+
+  // Restart Acknowledgement.
+  optional bool ra_bit = 2;
+
+  // Suppress Adjacency Advertisement.
+  optional bool sa_bit = 3;
+
+  // Restart Planned.
+  optional bool pr_bit = 4;
+
+  // Planned Pestart Acknowledgement.
+  optional bool pa_bit = 5;
 }
 
 // The capture result request to the traffic generator. Stops the port capture on the

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.30.0
+/* Open Traffic Generator API 1.31.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12645,10 +12645,8 @@ message EgressOnlyTracking {
 // These would appear as tagged metrics in corresponding egress_only_tracking metrics.
 message EgressOnlyTrackingMetricTags {
 
-  // The Name used to identify the metrics associated with the values applicable
-  // for configured Rx offset, optionally Tx offset adjustment and length inside
-  // corresponding header field. When offset of tracked metric at Tx is more than
-  // the offset at Rx, the difference should be configured as Tx offset adjustment.
+  // The name used to identify the metric tracked at configured Rx offset and of configured
+  // length. Tx offset configuration is optional.
   // required = true
   optional string name = 1;
 
@@ -12675,11 +12673,13 @@ message EgressOnlyTrackingTxOffset {
       custom = 2;
     }
   }
-  // Choose auto when Tx statistics in egress only tracking is not implemented or both
-  // Tx and Rx offset of tracked field in packet is the same. Otherwise choose custom
-  // when the offsets are different when DUT adds/ strips an encapsulation protocol header
-  // e.g. MACsec and tracked field is encapsulated in the protocol e.g. MACsec at wither
-  // Tx or Rx side.
+  // Choose auto when optional Tx statistics in egress only tracking are required while
+  // fetching egress only stats by opting tx_metric in get_metrics - egress_only_tracking
+  // - tagged_metric - metric_names.  or both Tx and Rx offset of tracked field in packet
+  // is the same. Otherwise choose custom when the Tx and Rx offsets are different due
+  // to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the
+  // egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different
+  // configuration such that the MACSec header is added/modified or removed.
   // default = Choice.Enum.auto
   optional Choice.Enum choice = 1;
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12664,8 +12664,7 @@ message EgressOnlyTrackingMetricTags {
   optional uint32 length = 4;
 }
 
-// A container of Tx offset properties. Offset in bits relative to start of the transmitted
-// packet from the transmitting port. Tx offset configuration is optional. It is relevant
+// A container of Tx offset properties. Tx offset configuration is optional. It is relevant
 // only when optional Tx statistics in egress only tracking are supported and while
 // fetching egress only stats by enabling tx_metric in get_metrics/egress_only_tracking/tagged_metric/metric_names
 message EgressOnlyTrackingTxOffset {

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12646,15 +12646,16 @@ message EgressOnlyTracking {
 message EgressOnlyTrackingMetricTags {
 
   // The name used to identify the metric tracked at configured Rx offset and of configured
-  // length. Tx offset configuration is optional.
+  // length.
   // required = true
   optional string name = 1;
 
-  // Rx Offset in bits relative to start of the packet.
+  // Offset in bits relative to start of the received packet on the receiving port.
   // required = true
   optional uint32 rx_offset = 2;
 
-  // Tx Offset in bits relative to start of the packet.
+  // Offset in bits relative to start of the transmitted packet from the transmitting
+  // port.
   EgressOnlyTrackingTxOffset tx_offset = 3;
 
   // Number of bits to track for metrics starting from configured offset
@@ -12663,7 +12664,10 @@ message EgressOnlyTrackingMetricTags {
   optional uint32 length = 4;
 }
 
-// A container of Tx offset properties.
+// A container of Tx offset properties. Offset in bits relative to start of the transmitted
+// packet from the transmitting port. Tx offset configuration is optional. It is relevant
+// only when optional Tx statistics in egress only tracking are supported and while
+// fetching egress only stats by enabling tx_metric in get_metrics/egress_only_tracking/tagged_metric/metric_names
 message EgressOnlyTrackingTxOffset {
 
   message Choice {
@@ -12673,17 +12677,15 @@ message EgressOnlyTrackingTxOffset {
       custom = 2;
     }
   }
-  // Choose auto when optional Tx statistics in egress only tracking are required while
-  // fetching egress only stats by opting tx_metric in get_metrics - egress_only_tracking
-  // - tagged_metric - metric_names.  or both Tx and Rx offset of tracked field in packet
-  // is the same. Otherwise choose custom when the Tx and Rx offsets are different due
-  // to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the
-  // egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different
-  // configuration such that the MACSec header is added/modified or removed.
+  // Choose auto when both offsets of tracked field in Tx/ Rx packets are the same. Otherwise
+  // choose custom.
   // default = Choice.Enum.auto
   optional Choice.Enum choice = 1;
 
-  // A container of custom Tx offset.
+  // A container of custom Tx offset. Choose custom when the Tx and Rx offsets are different
+  // due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when
+  // the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have
+  // different configuration such that the MACSec header is added/modified or removed.
   EgressOnlyTrackingTxOffsetCustom custom = 2;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -12665,8 +12665,8 @@ message EgressOnlyTrackingMetricTags {
 }
 
 // A container of Tx offset properties. Tx offset configuration is optional. It is relevant
-// only when optional Tx statistics in egress only tracking are supported and while
-// fetching egress only stats by enabling tx_metric in get_metrics/egress_only_tracking/tagged_metric/metric_names
+// only when optional Tx statistics in egress only tracking are supported and when fetching
+// egress only stats with tx_metric also enabled in get_metrics/egress_only_tracking/tagged_metric/metric_names.
 message EgressOnlyTrackingTxOffset {
 
   message Choice {

--- a/egress/egressonlytracking.yaml
+++ b/egress/egressonlytracking.yaml
@@ -52,19 +52,19 @@ components:
         name:
           description: |-
             The name used to identify the metric tracked at configured Rx offset and of configured
-            length. Tx offset configuration is optional.
+            length.
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
         rx_offset:
           description: |-
-            Rx Offset in bits relative to start of the packet.
+            Offset in bits relative to start of the received packet on the receiving port.
           type: integer
           format: uint32
           x-field-uid: 2
         tx_offset:
           description: |-
-            Tx Offset in bits relative to start of the packet.
+            Offset in bits relative to start of the transmitted packet from the transmitting port.
           $ref: '#/components/schemas/EgressOnlyTracking.TxOffset'
           x-field-uid: 3
         length:
@@ -79,12 +79,12 @@ components:
 
     EgressOnlyTracking.TxOffset:
       description: >-
-        A container of Tx offset properties.
+        A container of Tx offset properties. Offset in bits relative to start of the transmitted packet from the transmitting port. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and while fetching egress only stats by enabling "tx_metric" in get_metrics/egress_only_tracking/tagged_metric/metric_names
       type: object
       properties:
         choice:
           description: >-
-            Choose "auto" when optional Tx statistics in egress only tracking are required while fetching egress only stats by opting "tx_metric" in get_metrics - egress_only_tracking - tagged_metric - metric_names.  or both Tx and Rx offset of tracked field in packet is the same. Otherwise choose "custom" when the Tx and Rx offsets are different due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different configuration such that the MACSec header is added/modified or removed.
+            Choose "auto" when both offsets of tracked field in Tx/ Rx packets are the same. Otherwise choose "custom".
           type: string
           default: auto
           x-field-uid: 1
@@ -95,7 +95,7 @@ components:
               x-field-uid: 2
         custom:
           description: >-
-            A container of custom Tx offset.
+            A container of custom Tx offset. Choose "custom" when the Tx and Rx offsets are different due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different configuration such that the MACSec header is added/modified or removed.
           $ref: '#/components/schemas/EgressOnlyTracking.TxOffset.Custom'
           x-field-uid: 2
 

--- a/egress/egressonlytracking.yaml
+++ b/egress/egressonlytracking.yaml
@@ -79,7 +79,7 @@ components:
 
     EgressOnlyTracking.TxOffset:
       description: >-
-        A container of Tx offset properties. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and while fetching egress only stats by enabling "tx_metric" in get_metrics/egress_only_tracking/tagged_metric/metric_names
+        A container of Tx offset properties. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and when fetching egress only stats with "tx_metric" also enabled in get_metrics/egress_only_tracking/tagged_metric/metric_names.
       type: object
       properties:
         choice:

--- a/egress/egressonlytracking.yaml
+++ b/egress/egressonlytracking.yaml
@@ -79,7 +79,7 @@ components:
 
     EgressOnlyTracking.TxOffset:
       description: >-
-        A container of Tx offset properties. Offset in bits relative to start of the transmitted packet from the transmitting port. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and while fetching egress only stats by enabling "tx_metric" in get_metrics/egress_only_tracking/tagged_metric/metric_names
+        A container of Tx offset properties. Tx offset configuration is optional. It is relevant only when optional Tx statistics in egress only tracking are supported and while fetching egress only stats by enabling "tx_metric" in get_metrics/egress_only_tracking/tagged_metric/metric_names
       type: object
       properties:
         choice:

--- a/egress/egressonlytracking.yaml
+++ b/egress/egressonlytracking.yaml
@@ -51,10 +51,8 @@ components:
       properties:
         name:
           description: |-
-            The Name used to identify the metrics associated with the values applicable
-            for configured Rx offset, optionally Tx offset adjustment and length inside
-            corresponding header field. When offset of tracked metric at Tx is more than 
-            the offset at Rx, the difference should be configured as Tx offset adjustment.
+            The name used to identify the metric tracked at configured Rx offset and of configured
+            length. Tx offset configuration is optional.
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
@@ -86,7 +84,7 @@ components:
       properties:
         choice:
           description: >-
-            Choose "auto" when Tx statistics in egress only tracking is not implemented or both Tx and Rx offset of tracked field in packet is the same. Otherwise choose "custom" when the offsets are different when DUT adds/ strips an encapsulation protocol header e.g. MACsec and tracked field is encapsulated in the protocol e.g. MACsec at wither Tx or Rx side.
+            Choose "auto" when optional Tx statistics in egress only tracking are required while fetching egress only stats by opting "tx_metric" in get_metrics - egress_only_tracking - tagged_metric - metric_names.  or both Tx and Rx offset of tracked field in packet is the same. Otherwise choose "custom" when the Tx and Rx offsets are different due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different configuration such that the MACSec header is added/modified or removed.
           type: string
           default: auto
           x-field-uid: 1

--- a/egress/egressonlytracking.yaml
+++ b/egress/egressonlytracking.yaml
@@ -64,13 +64,10 @@ components:
           type: integer
           format: uint32
           x-field-uid: 2
-        tx_offset_adjustment:
+        tx_offset:
           description: |-
-            Tx Offset adjustment in bits. When tracked metric offset at Tx is more than the
-            offset at Rx, the differnce should be configured in bits as adjustment.
-          type: integer
-          format: uint32
-          default: 0
+            Tx Offset in bits relative to start of the packet.
+          $ref: '#/components/schemas/EgressOnlyTracking.TxOffset'
           x-field-uid: 3
         length:
           description: |-
@@ -81,6 +78,41 @@ components:
           default: 1
           minimum: 1
           x-field-uid: 4
+
+    EgressOnlyTracking.TxOffset:
+      description: >-
+        A container of Tx offset properties.
+      type: object
+      properties:
+        choice:
+          description: >-
+            Choose "auto" when Tx statistics in egress only tracking is not implemented or both Tx and Rx offset of tracked field in packet is the same. Otherwise choose "custom" when the offsets are different when DUT adds/ strips an encapsulation protocol header e.g. MACsec and tracked field is encapsulated in the protocol e.g. MACsec at wither Tx or Rx side.
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            custom:
+              x-field-uid: 2
+        custom:
+          description: >-
+            A container of custom Tx offset.
+          $ref: '#/components/schemas/EgressOnlyTracking.TxOffset.Custom'
+          x-field-uid: 2
+
+    EgressOnlyTracking.TxOffset.Custom:
+      description: >-
+        A container of custom Tx offset properties.
+      type: object
+      properties:
+        value:
+          description: >-
+            Tx Offset in bits relative to start of the packet.
+          type: integer
+          format: uint32
+          x-field-uid: 1
+
     EgressOnlyTracking.Filter:
       type: object
       properties:

--- a/egress/egressonlytracking.yaml
+++ b/egress/egressonlytracking.yaml
@@ -95,18 +95,17 @@ components:
               x-field-uid: 2
         custom:
           description: >-
-            A container of custom Tx offset. Choose "custom" when the Tx and Rx offsets are different due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different configuration such that the MACSec header is added/modified or removed.
           $ref: '#/components/schemas/EgressOnlyTracking.TxOffset.Custom'
           x-field-uid: 2
 
     EgressOnlyTracking.TxOffset.Custom:
       description: >-
-        A container of custom Tx offset properties.
+        A container of custom Tx offset properties. Choose "custom" when the Tx and Rx offsets are different due to DUT adding/ modifying or deleting encapsulation protocol header e.g. when the egress-only tracked packets are MACsec encapulated and the Tx and Rx side have different configuration such that the MACSec header is added/modified or removed.
       type: object
       properties:
         value:
           description: >-
-            Tx Offset in bits relative to start of the packet.
+            Offset in bits relative to start of the transmitted packet from the transmitting port.
           type: integer
           format: uint32
           x-field-uid: 1

--- a/egress/egressonlytracking.yaml
+++ b/egress/egressonlytracking.yaml
@@ -47,21 +47,31 @@ components:
       type: object
       required:
       - name
-      - offset
+      - rx_offset
       properties:
         name:
           description: |-
             The Name used to identify the metrics associated with the values applicable
-            for configured offset and length inside corresponding header field.
+            for configured Rx offset, optionally Tx offset adjustment and length inside
+            corresponding header field. When offset of tracked metric at Tx is more than 
+            the offset at Rx, the difference should be configured as Tx offset adjustment.
           type: string
           pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 1
-        offset:
+        rx_offset:
           description: |-
-            Offset in bits relative to start of the packet.
+            Rx Offset in bits relative to start of the packet.
           type: integer
           format: uint32
           x-field-uid: 2
+        tx_offset_adjustment:
+          description: |-
+            Tx Offset adjustment in bits. When tracked metric offset at Tx is more than the
+            offset at Rx, the differnce should be configured in bits as adjustment.
+          type: integer
+          format: uint32
+          default: 0
+          x-field-uid: 3
         length:
           description: |-
             Number of bits to track for metrics starting from configured offset
@@ -70,7 +80,7 @@ components:
           format: uint32
           default: 1
           minimum: 1
-          x-field-uid: 3
+          x-field-uid: 4
     EgressOnlyTracking.Filter:
       type: object
       properties:


### PR DESCRIPTION
PR description
============

In egress only tracking settings for implementations that support Tx statistics, support for "Tx offset" setting is added to cover cases where Rx/ Tx offsets of tracked field are not same.  This change is required to associate Tx/ Rx statistics with the same value of a tracked field in egress only tracking result. Tx offset can have three type of values:

A.	DUT does not add or strip any more header (e.g. MACsec) above tracked field in packet

        Tx (offset of IP DSCP = 31) --->DUT (does not add or strip e.g. MACsec header)---->Rx (offset of IP DSCP = 31)

        This is for a case where Tx offset of a tracked field is same as Rx (egress) side – DUT does not change offset of tracked field.

B.	DUT adds encapsulation header (e.g. MACsec) above tracked field in packet

        Tx (offset of IP DSCP = 17) --->DUT (adds e.g. MACsec header of size 14 bytes) ---->Rx (offset of IP DSCP = 31)

        This is for a case where Rx (egress) offset of a tracked field is higher than that at Tx side

C.	DUT strips encapsulation header (e.g. MACsec) above tracked field in packet

        Tx (offset of IP DSCP = 31) --->DUT (strips e.g. MACsec header of size 14 bytes) ---->Rx (offset of IP DSCP = 17)

        This is for a case where Rx (egress) offset of a tracked field is lower than that at Tx side

Redocly view
===========
https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-egress-only2/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config

set_config -> egress_only_tracking -> metric_tags -> tx_offset