### PR TITLE
[OSPFv2 ]Fix default/max of ospfv2/interface/advanced/routing_metric

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -10720,7 +10720,8 @@ components:
             Routing metric associated with the interface..
           type: integer
           format: uint32
-          default: 0
+          maximum: 65535
+          default: 10
           x-field-uid: 3
         priority:
           description: "The Priority for (Backup) Designated Router election.    \

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -7964,7 +7964,7 @@ message Ospfv2InterfaceAdvanced {
   optional uint32 dead_interval = 2;
 
   // Routing metric associated with the interface..
-  // default = 0
+  // default = 10
   optional uint32 routing_metric = 3;
 
   // The Priority for (Backup) Designated Router election.

--- a/device/ospfv2/interface/interface.yaml
+++ b/device/ospfv2/interface/interface.yaml
@@ -161,7 +161,8 @@ components:
             Routing metric associated with the interface..
           type: integer
           format: uint32
-          default: 0
+          maximum: 65535
+          default: 10
           x-field-uid: 3
         priority:
           description: |-


### PR DESCRIPTION
Following fixes in ospfv2/interface/advanced/routing_metric are done for in this PR,
- introduce max value of 65535
  - As in RFC, length of router-LSA (Type-1) is 16-bit

- change default value from 0 to 10
  - It should have non-zero value reflecting cost of metric as default.