### PR TITLE
Support for LACP header

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -15651,9 +15651,6 @@ components:
         terminator_information:
           $ref: '#/components/schemas/Flow.Lacp.TerminatorInformation'
           x-field-uid: 6
-        fcs:
-          x-field-uid: 7
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.Fcs'
     Flow.Lacp.ActorInformation:
       description: |-
         Information about the local (actor) system.
@@ -46110,68 +46107,6 @@ components:
           x-field-uid: 7
       x-constants:
         v1: 1
-    Pattern.Flow.Lacp.Fcs.Counter:
-      description: |-
-        integer counter pattern
-      type: object
-      properties:
-        start:
-          type: integer
-          x-field-uid: 1
-          default: 0
-          format: uint32
-        step:
-          type: integer
-          x-field-uid: 2
-          default: 1
-          format: uint32
-        count:
-          type: integer
-          x-field-uid: 3
-          default: 1
-          format: uint32
-    Pattern.Flow.Lacp.Fcs:
-      description: |-
-        Frame Check Sequence. A 32-bit CRC value used to check for errors in frame transmission. It is calculated over the entire Ethernet frame.
-      type: object
-      properties:
-        choice:
-          type: string
-          x-enum:
-            value:
-              x-field-uid: 2
-            values:
-              x-field-uid: 3
-            increment:
-              x-field-uid: 4
-            decrement:
-              x-field-uid: 5
-          default: value
-          x-field-uid: 1
-          enum:
-          - value
-          - values
-          - increment
-          - decrement
-        value:
-          type: integer
-          x-field-uid: 2
-          default: 0
-          format: uint32
-        values:
-          type: array
-          items:
-            type: integer
-            format: uint32
-          x-field-uid: 3
-          default:
-          - 0
-        increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.Fcs.Counter'
-          x-field-uid: 5
-        decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.Fcs.Counter'
-          x-field-uid: 6
     Pattern.Flow.Lacp.ActorInformation.Type.Counter:
       description: |-
         integer counter pattern

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -13244,6 +13244,8 @@ components:
               x-field-uid: 21
             macsec:
               x-field-uid: 22
+            lacp:
+              x-field-uid: 23
           enum:
           - custom
           - ethernet
@@ -13267,6 +13269,7 @@ components:
           - snmpv2c
           - rsvp
           - macsec
+          - lacp
         custom:
           $ref: '#/components/schemas/Flow.Custom'
           x-field-uid: 2
@@ -13333,6 +13336,9 @@ components:
         macsec:
           $ref: '#/components/schemas/Flow.Macsec'
           x-field-uid: 23
+        lacp:
+          $ref: '#/components/schemas/Flow.Lacp'
+          x-field-uid: 24
     Flow.Custom:
       type: object
       description: |-
@@ -15617,6 +15623,118 @@ components:
               x-field-uid: 1
           enum:
           - auto
+    Flow.Lacp:
+      description: |-
+        Defines the fields of a Link Aggregation Control Protocol (LACP) Data Unit (PDU) as specified by IEEE 802.3ad. LACP is a Slow Protocol (EtherType 0x8809) used for dynamic link aggregation.
+      type: object
+      properties:
+        destination_address:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.DestinationAddress'
+        source_address:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.SourceAddress'
+        length_type:
+          x-field-uid: 3
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.LengthType'
+        sub_type:
+          x-field-uid: 4
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.SubType'
+        version:
+          x-field-uid: 5
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Version'
+        actor_tlv_type:
+          x-field-uid: 6
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorTlvType'
+        actor_tlv_length:
+          x-field-uid: 7
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorTlvLength'
+        actor_system_priority:
+          x-field-uid: 8
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorSystemPriority'
+        actor_system:
+          x-field-uid: 9
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorSystem'
+        actor_key:
+          x-field-uid: 10
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorKey'
+        actor_port_priority:
+          x-field-uid: 11
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorPortPriority'
+        actor_port:
+          x-field-uid: 12
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorPort'
+        actor_state:
+          x-field-uid: 13
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorState'
+        actor_reserved:
+          description: |-
+            Reserved field for future use in the Actor TLV. Should be set to all zeros.
+          type: string
+          format: hex
+          default: '000000'
+          x-field-uid: 14
+        partner_tlv_type:
+          x-field-uid: 15
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerTlvType'
+        partner_tlv_length:
+          x-field-uid: 16
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerTlvLength'
+        partner_system_priority:
+          x-field-uid: 17
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerSystemPriority'
+        partner_system:
+          x-field-uid: 18
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerSystem'
+        partner_key:
+          x-field-uid: 19
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerKey'
+        partner_port_priority:
+          x-field-uid: 20
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerPortPriority'
+        partner_port:
+          x-field-uid: 21
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerPort'
+        partner_state:
+          x-field-uid: 22
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerState'
+        partner_reserved:
+          description: |-
+            Reserved field for future use in the Partner TLV. Should be set to all zeros.
+          type: string
+          format: hex
+          default: '000000'
+          x-field-uid: 23
+        collector_tlv_type:
+          x-field-uid: 24
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorTlvType'
+        collector_tlv_length:
+          x-field-uid: 25
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorTlvLength'
+        collector_max_delay:
+          x-field-uid: 26
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorMaxDelay'
+        collector_reserved:
+          description: |-
+            Reserved field for future use in the Collector TLV. 12 bytes long and should be set to all zeros.
+          type: string
+          default: '000000000000000000000000'
+          x-field-uid: 27
+        terminator_tlv_type:
+          x-field-uid: 28
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorTlvType'
+        terminator_tlv_length:
+          x-field-uid: 29
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorTlvLength'
+        final_reserved:
+          description: |-
+            Final block of reserved bytes to pad the PDU. It is 50 bytes long, set to all zeros, and ignored on receipt.
+          type: string
+          default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+          x-field-uid: 30
+        fcs:
+          x-field-uid: 31
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Fcs'
     Flow.Size:
       description: |-
         The frame size which overrides the total length of the packet
@@ -45747,6 +45865,2780 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.RSVP.PathObjectsCustom.Type.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Lacp.DestinationAddress.Counter:
+      description: |-
+        mac counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 01:80:C2:00:00:02
+          format: mac
+        step:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:01
+          format: mac
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Lacp.DestinationAddress.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 47
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 48
+          minimum: 1
+          maximum: 48
+          x-field-uid: 3
+    Pattern.Flow.Lacp.DestinationAddress:
+      description: |-
+        The destination MAC address. For LACP, this is the special multicast address 01-80-C2-00-00-02 used for Slow Protocols.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 01:80:C2:00:00:02
+          format: mac
+        values:
+          type: array
+          items:
+            type: string
+            format: mac
+          x-field-uid: 3
+          default:
+          - 01:80:C2:00:00:02
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.DestinationAddress.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.DestinationAddress.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.DestinationAddress.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.SourceAddress.Counter:
+      description: |-
+        mac counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 00:00:00:00:00:00
+          format: mac
+        step:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:01
+          format: mac
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Lacp.SourceAddress.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 47
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 48
+          minimum: 1
+          maximum: 48
+          x-field-uid: 3
+    Pattern.Flow.Lacp.SourceAddress:
+      description: |-
+        The source MAC address of the physical port through which the LACPDU is transmitted.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:00
+          format: mac
+        values:
+          type: array
+          items:
+            type: string
+            format: mac
+          x-field-uid: 3
+          default:
+          - 00:00:00:00:00:00
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.SourceAddress.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.SourceAddress.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.SourceAddress.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.LengthType.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 34825
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+      x-constants:
+        slow_protocols: 34825
+    Pattern.Flow.Lacp.LengthType.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.LengthType:
+      description: |-
+        Ethernet Type field. It must be set to 0x8809 to indicate a Slow Protocol like LACP.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 34825
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 34825
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.LengthType.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.LengthType.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.LengthType.MetricTag'
+          x-field-uid: 7
+      x-constants:
+        slow_protocols: 34825
+    Pattern.Flow.Lacp.SubType.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+      x-constants:
+        lacp: 1
+    Pattern.Flow.Lacp.SubType.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.SubType:
+      description: |-
+        Indicates the specific Slow Protocol subtype. It must be set to 0x01 for LACPDUs.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.SubType.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.SubType.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.SubType.MetricTag'
+          x-field-uid: 7
+      x-constants:
+        lacp: 1
+    Pattern.Flow.Lacp.Version.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+      x-constants:
+        v1: 1
+    Pattern.Flow.Lacp.Version.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.Version:
+      description: |-
+        The LACP version number. It must be set to 0x01.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Version.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Version.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Version.MetricTag'
+          x-field-uid: 7
+      x-constants:
+        v1: 1
+    Pattern.Flow.Lacp.ActorTlvType.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 1
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+      x-constants:
+        actor_information: 1
+    Pattern.Flow.Lacp.ActorTlvType.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.ActorTlvType:
+      description: |-
+        TLV Type for Actor Information. The value 0x01 identifies this TLV as containing information about the sending device (the Actor).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 1
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorTlvType.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorTlvType.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorTlvType.MetricTag'
+          x-field-uid: 7
+      x-constants:
+        actor_information: 1
+    Pattern.Flow.Lacp.ActorTlvLength.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 20
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacp.ActorTlvLength.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.ActorTlvLength:
+      description: |-
+        The length of the Actor Information TLV payload in bytes. The value must be 20 (0x14).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 20
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 20
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorTlvLength.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorTlvLength.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorTlvLength.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.ActorSystemPriority.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 32768
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.ActorSystemPriority.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.ActorSystemPriority:
+      description: |-
+        The priority assigned to the Actor's system for use in aggregation. A lower numerical value indicates a higher priority. Used to select the active System ID when forming an aggregator. The default value is 32768 (0x8000).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 32768
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 32768
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorSystemPriority.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorSystemPriority.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorSystemPriority.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.ActorSystem.Counter:
+      description: |-
+        mac counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 00:00:00:00:00:00
+          format: mac
+        step:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:01
+          format: mac
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Lacp.ActorSystem.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 47
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 48
+          minimum: 1
+          maximum: 48
+          x-field-uid: 3
+    Pattern.Flow.Lacp.ActorSystem:
+      description: |-
+        The Actor's System ID, which is a globally unique MAC address assigned to the system containing the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:00
+          format: mac
+        values:
+          type: array
+          items:
+            type: string
+            format: mac
+          x-field-uid: 3
+          default:
+          - 00:00:00:00:00:00
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorSystem.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorSystem.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorSystem.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.ActorKey.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.ActorKey.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.ActorKey:
+      description: |-
+        The operational Key value assigned to the Actor's port. The key is generated based on port configuration (e.g., speed, duplex, trunk ID) and is used to identify potential aggregation groups. Only links with the same key can be aggregated together.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorKey.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorKey.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorKey.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.ActorPortPriority.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 32768
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.ActorPortPriority.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.ActorPortPriority:
+      description: |-
+        The priority assigned to the Actor's port. A lower numerical value indicates a higher priority. Used to prioritize ports for inclusion in a Link Aggregation Group (LAG) when the group is full. The default value is 32768 (0x8000).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 32768
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 32768
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorPortPriority.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorPortPriority.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorPortPriority.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.ActorPort.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.ActorPort.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.ActorPort:
+      description: |-
+        The port number assigned to the Actor's port. It is a unique identifier for the port within the system.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorPort.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorPort.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorPort.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.ActorState.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacp.ActorState.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.ActorState:
+      description: |-
+        A 1-byte bitmask indicating the Actor's state. Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) Bit 2: Aggregation (1=Aggregatable, 0=Individual) Bit 3: Synchronization (1=In Sync, 0=Out of Sync) Bit 4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing (1=Enabled, 0=Disabled) Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received partner info) Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorState.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorState.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorState.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.PartnerTlvType.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 2
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+      x-constants:
+        partner_information: 2
+    Pattern.Flow.Lacp.PartnerTlvType.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.PartnerTlvType:
+      description: |-
+        TLV Type for Partner Information. The value 0x02 identifies this TLV as containing information about the remote device (the Partner), as understood by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 2
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 2
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerTlvType.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerTlvType.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerTlvType.MetricTag'
+          x-field-uid: 7
+      x-constants:
+        partner_information: 2
+    Pattern.Flow.Lacp.PartnerTlvLength.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 20
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacp.PartnerTlvLength.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.PartnerTlvLength:
+      description: |-
+        The length of the Partner Information TLV payload in bytes. The value must be 20 (0x14).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 20
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 20
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerTlvLength.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerTlvLength.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerTlvLength.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.PartnerSystemPriority.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.PartnerSystemPriority.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.PartnerSystemPriority:
+      description: |-
+        The priority of the Partner's system, as received by the Actor. If no LACPDU has been received from the partner, this is set to zero.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerSystemPriority.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerSystemPriority.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerSystemPriority.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.PartnerSystem.Counter:
+      description: |-
+        mac counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 00:00:00:00:00:00
+          format: mac
+        step:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:01
+          format: mac
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Lacp.PartnerSystem.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 47
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 48
+          minimum: 1
+          maximum: 48
+          x-field-uid: 3
+    Pattern.Flow.Lacp.PartnerSystem:
+      description: |-
+        The Partner's System ID (MAC address), as received by the Actor. If no LACPDU has been received from the partner, this is set to all zeros.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 00:00:00:00:00:00
+          format: mac
+        values:
+          type: array
+          items:
+            type: string
+            format: mac
+          x-field-uid: 3
+          default:
+          - 00:00:00:00:00:00
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerSystem.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerSystem.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerSystem.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.PartnerKey.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.PartnerKey.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.PartnerKey:
+      description: |-
+        The operational Key value of the Partner's port, as received by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerKey.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerKey.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerKey.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.PartnerPortPriority.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.PartnerPortPriority.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.PartnerPortPriority:
+      description: |-
+        The priority of the Partner's port, as received by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerPortPriority.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerPortPriority.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerPortPriority.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.PartnerPort.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.PartnerPort.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.PartnerPort:
+      description: |-
+        The port number of the Partner's port, as received by the Actor.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerPort.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerPort.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerPort.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.PartnerState.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacp.PartnerState.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.PartnerState:
+      description: |-
+        A 1-byte bitmask indicating the Partner's state, as received by the Actor. Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) Bit 2: Aggregation (1=Aggregatable, 0=Individual) Bit 3: Synchronization (1=In Sync, 0=Out of Sync) Bit 4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing (1=Enabled, 0=Disabled) Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received partner info) Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerState.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerState.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerState.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.CollectorTlvType.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 3
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+      x-constants:
+        collector_information: 3
+    Pattern.Flow.Lacp.CollectorTlvType.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.CollectorTlvType:
+      description: |-
+        TLV Type for Collector Information. The value 0x03 identifies this TLV.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 3
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 3
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorTlvType.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorTlvType.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorTlvType.MetricTag'
+          x-field-uid: 7
+      x-constants:
+        collector_information: 3
+    Pattern.Flow.Lacp.CollectorTlvLength.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 16
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacp.CollectorTlvLength.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.CollectorTlvLength:
+      description: |-
+        The length of the Collector Information TLV payload in bytes. The value must be 16 (0x10).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 16
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 16
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorTlvLength.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorTlvLength.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorTlvLength.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.CollectorMaxDelay.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 65535
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 65535
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 65535
+    Pattern.Flow.Lacp.CollectorMaxDelay.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 15
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 16
+          minimum: 1
+          maximum: 16
+          x-field-uid: 3
+    Pattern.Flow.Lacp.CollectorMaxDelay:
+      description: |-
+        Indicates the maximum delay, in units of 10 microseconds, that the transmitting system's aggregator will take to buffer frames from its collector before emitting a frame.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 65535
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 65535
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorMaxDelay.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorMaxDelay.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorMaxDelay.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.TerminatorTlvType.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+      x-constants:
+        terminator: 0
+    Pattern.Flow.Lacp.TerminatorTlvType.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.TerminatorTlvType:
+      description: |-
+        TLV Type for Terminator Information. The value 0x00 indicates the end of the TLV list.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorTlvType.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorTlvType.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorTlvType.MetricTag'
+          x-field-uid: 7
+      x-constants:
+        terminator: 0
+    Pattern.Flow.Lacp.TerminatorTlvLength.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 255
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 255
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 255
+    Pattern.Flow.Lacp.TerminatorTlvLength.MetricTag:
+      description: |-
+        Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          description: |-
+            Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field
+          type: string
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
+          x-field-uid: 1
+        offset:
+          description: |-
+            Offset in bits relative to start of corresponding header field
+          type: integer
+          format: uint32
+          default: 0
+          maximum: 7
+          x-field-uid: 2
+        length:
+          description: |-
+            Number of bits to track for metrics starting from configured offset of corresponding header field
+          type: integer
+          format: uint32
+          default: 8
+          minimum: 1
+          maximum: 8
+          x-field-uid: 3
+    Pattern.Flow.Lacp.TerminatorTlvLength:
+      description: |-
+        The length of the Terminator TLV payload. The value must be 0.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 255
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 255
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorTlvLength.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorTlvLength.Counter'
+          x-field-uid: 6
+        metric_tags:
+          description: |-
+            One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorTlvLength.MetricTag'
+          x-field-uid: 7
+    Pattern.Flow.Lacp.Fcs.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Lacp.Fcs:
+      description: |-
+        Frame Check Sequence. A 32-bit CRC value used to check for errors in frame transmission. It is calculated over the entire Ethernet frame.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Fcs.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Fcs.Counter'
           x-field-uid: 6
     Version:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -15627,11 +15627,6 @@ components:
       description: |-
         Defines the fields of a Link Aggregation Control Protocol (LACP) Data Unit (PDU) as specified by IEEE 802.3ad.
       type: object
-      required:
-      - actor_information
-      - partner_information
-      - collection_information
-      - terminator_information
       properties:
         sub_type:
           x-field-uid: 1
@@ -15639,125 +15634,127 @@ components:
         version:
           x-field-uid: 2
           $ref: '#/components/schemas/Pattern.Flow.Lacp.Version'
-        actor_information:
-          $ref: '#/components/schemas/Flow.Lacp.ActorInformation'
+        actor:
+          $ref: '#/components/schemas/Flow.Lacp.Actor'
           x-field-uid: 3
-        partner_information:
-          $ref: '#/components/schemas/Flow.Lacp.PartnerInformation'
+        partner:
+          $ref: '#/components/schemas/Flow.Lacp.Partner'
           x-field-uid: 4
-        collection_information:
-          $ref: '#/components/schemas/Flow.Lacp.CollectorInformation'
+        collector:
+          $ref: '#/components/schemas/Flow.Lacp.Collector'
           x-field-uid: 5
-        terminator_information:
-          $ref: '#/components/schemas/Flow.Lacp.TerminatorInformation'
+        terminator:
+          $ref: '#/components/schemas/Flow.Lacp.Terminator'
           x-field-uid: 6
-    Flow.Lacp.ActorInformation:
+    Flow.Lacp.Actor:
       description: |-
         Information about the local (actor) system.
       type: object
       properties:
         type:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Type'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Type'
         length:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Length'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Length'
         system_priority:
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.SystemPriority'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.SystemPriority'
         system_id:
           x-field-uid: 4
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.SystemId'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.SystemId'
         key:
           x-field-uid: 5
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Key'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Key'
         port_priority:
           x-field-uid: 6
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.PortPriority'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.PortPriority'
         port_number:
           x-field-uid: 7
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.PortNumber'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.PortNumber'
         actor_state:
           x-field-uid: 8
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.ActorState'
-        actor_reserved:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.ActorState'
+        reserved:
           description: |-
             Reserved field for future use in the Actor TLV. Should be set to all zeros.
           type: string
           format: hex
           default: '000000'
           x-field-uid: 9
-    Flow.Lacp.PartnerInformation:
+    Flow.Lacp.Partner:
       description: |-
         Information about the remote (partner) system.
       type: object
       properties:
         type:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Type'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Type'
         length:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Length'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Length'
         system_priority:
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.SystemPriority'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.SystemPriority'
         system_id:
           x-field-uid: 4
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.SystemId'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.SystemId'
         key:
           x-field-uid: 5
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Key'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Key'
         port_priority:
           x-field-uid: 6
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PortPriority'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PortPriority'
         port_number:
           x-field-uid: 7
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PortNumber'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PortNumber'
         partner_state:
           x-field-uid: 8
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PartnerState'
-        partner_reserved:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PartnerState'
+        reserved:
           description: |-
             Reserved field for future use in the Partner TLV. Should be set to all zeros.
           type: string
           format: hex
           default: '000000'
           x-field-uid: 9
-    Flow.Lacp.CollectorInformation:
+    Flow.Lacp.Collector:
       description: |-
         Information about frame collection parameters.
       type: object
       properties:
         type:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.Type'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.Type'
         length:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.Length'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.Length'
         max_delay:
           x-field-uid: 3
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.MaxDelay'
-        collector_reserved:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.MaxDelay'
+        reserved:
           description: |-
             Reserved field for future use in the Collector TLV. 12 bytes long and should be set to all zeros.
           type: string
+          format: hex
           default: '000000000000000000000000'
           x-field-uid: 4
-    Flow.Lacp.TerminatorInformation:
+    Flow.Lacp.Terminator:
       description: |-
         Marks the end of the LACPDU message.
       type: object
       properties:
         type:
           x-field-uid: 1
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorInformation.Type'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Terminator.Type'
         length:
           x-field-uid: 2
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorInformation.Length'
-        final_reserved:
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Terminator.Length'
+        reserved:
           description: |-
             Final block of reserved bytes to pad the PDU. It is 50 bytes long.
           type: string
+          format: hex
           default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
           x-field-uid: 3
     Flow.Size:
@@ -46107,7 +46104,7 @@ components:
           x-field-uid: 7
       x-constants:
         v1: 1
-    Pattern.Flow.Lacp.ActorInformation.Type.Counter:
+    Pattern.Flow.Lacp.Actor.Type.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -46131,8 +46128,8 @@ components:
           format: uint32
           maximum: 255
       x-constants:
-        actor_information: 1
-    Pattern.Flow.Lacp.ActorInformation.Type.MetricTag:
+        actor: 1
+    Pattern.Flow.Lacp.Actor.Type.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46162,7 +46159,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.ActorInformation.Type:
+    Pattern.Flow.Lacp.Actor.Type:
       description: |-
         TLV Type for Actor Information. The value 0x01 identifies this TLV as containing information about the sending device (the Actor).
       type: object
@@ -46201,21 +46198,21 @@ components:
           default:
           - 1
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Type.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Type.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Type.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Type.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Type.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Type.MetricTag'
           x-field-uid: 7
       x-constants:
-        actor_information: 1
-    Pattern.Flow.Lacp.ActorInformation.Length.Counter:
+        actor: 1
+    Pattern.Flow.Lacp.Actor.Length.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -46238,7 +46235,7 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.Lacp.ActorInformation.Length.MetricTag:
+    Pattern.Flow.Lacp.Actor.Length.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46268,7 +46265,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.ActorInformation.Length:
+    Pattern.Flow.Lacp.Actor.Length:
       description: |-
         The length of the Actor Information TLV payload in bytes.
       type: object
@@ -46307,19 +46304,19 @@ components:
           default:
           - 20
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Length.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Length.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Length.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Length.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.ActorInformation.SystemPriority.Counter:
+    Pattern.Flow.Lacp.Actor.SystemPriority.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -46327,7 +46324,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 32768
+          default: 0
           format: uint32
           maximum: 65535
         step:
@@ -46342,7 +46339,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.ActorInformation.SystemPriority.MetricTag:
+    Pattern.Flow.Lacp.Actor.SystemPriority.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46372,7 +46369,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.ActorInformation.SystemPriority:
+    Pattern.Flow.Lacp.Actor.SystemPriority:
       description: |-
         The priority assigned to the Actor's system for use in aggregation. A lower numerical value indicates a higher priority. Used to select the active System ID when forming an aggregator.
       type: object
@@ -46398,7 +46395,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 32768
+          default: 0
           format: uint32
           maximum: 65535
         values:
@@ -46409,21 +46406,21 @@ components:
             maximum: 65535
           x-field-uid: 3
           default:
-          - 32768
+          - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.SystemPriority.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.SystemPriority.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.SystemPriority.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.SystemPriority.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.SystemPriority.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.SystemPriority.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.ActorInformation.SystemId.Counter:
+    Pattern.Flow.Lacp.Actor.SystemId.Counter:
       description: |-
         mac counter pattern
       type: object
@@ -46443,7 +46440,7 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.Lacp.ActorInformation.SystemId.MetricTag:
+    Pattern.Flow.Lacp.Actor.SystemId.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46473,7 +46470,7 @@ components:
           minimum: 1
           maximum: 48
           x-field-uid: 3
-    Pattern.Flow.Lacp.ActorInformation.SystemId:
+    Pattern.Flow.Lacp.Actor.SystemId:
       description: |-
         The Actor's System ID, which is a globally unique MAC address assigned to the system containing the Actor.
       type: object
@@ -46510,19 +46507,19 @@ components:
           default:
           - 00:00:00:00:00:00
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.SystemId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.SystemId.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.SystemId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.SystemId.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.SystemId.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.SystemId.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.ActorInformation.Key.Counter:
+    Pattern.Flow.Lacp.Actor.Key.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -46545,7 +46542,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.ActorInformation.Key.MetricTag:
+    Pattern.Flow.Lacp.Actor.Key.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46575,7 +46572,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.ActorInformation.Key:
+    Pattern.Flow.Lacp.Actor.Key:
       description: |-
         The operational Key value assigned to the Actor's port. The key is generated based on port configuration (e.g., speed, duplex, trunk ID) and is used to identify potential aggregation groups. Only links with the same key can be aggregated together.
       type: object
@@ -46614,19 +46611,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Key.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Key.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Key.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Key.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.Key.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.Key.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.ActorInformation.PortPriority.Counter:
+    Pattern.Flow.Lacp.Actor.PortPriority.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -46634,7 +46631,7 @@ components:
         start:
           type: integer
           x-field-uid: 1
-          default: 32768
+          default: 0
           format: uint32
           maximum: 65535
         step:
@@ -46649,7 +46646,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.ActorInformation.PortPriority.MetricTag:
+    Pattern.Flow.Lacp.Actor.PortPriority.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46679,7 +46676,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.ActorInformation.PortPriority:
+    Pattern.Flow.Lacp.Actor.PortPriority:
       description: |-
         The priority assigned to the Actor's port. A lower numerical value indicates a higher priority. Used to prioritize ports for inclusion in a Link Aggregation Group (LAG) when the group is full.
       type: object
@@ -46705,7 +46702,7 @@ components:
         value:
           type: integer
           x-field-uid: 2
-          default: 32768
+          default: 0
           format: uint32
           maximum: 65535
         values:
@@ -46716,21 +46713,21 @@ components:
             maximum: 65535
           x-field-uid: 3
           default:
-          - 32768
+          - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.PortPriority.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.PortPriority.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.PortPriority.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.PortPriority.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.PortPriority.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.PortPriority.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.ActorInformation.PortNumber.Counter:
+    Pattern.Flow.Lacp.Actor.PortNumber.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -46753,7 +46750,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.ActorInformation.PortNumber.MetricTag:
+    Pattern.Flow.Lacp.Actor.PortNumber.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46783,7 +46780,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.ActorInformation.PortNumber:
+    Pattern.Flow.Lacp.Actor.PortNumber:
       description: |-
         The port number assigned to the Actor's port. It is a unique identifier for the port within the system.
       type: object
@@ -46822,19 +46819,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.PortNumber.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.PortNumber.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.PortNumber.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.PortNumber.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.PortNumber.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.PortNumber.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.ActorInformation.ActorState.Counter:
+    Pattern.Flow.Lacp.Actor.ActorState.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -46857,7 +46854,7 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.Lacp.ActorInformation.ActorState.MetricTag:
+    Pattern.Flow.Lacp.Actor.ActorState.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46887,7 +46884,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.ActorInformation.ActorState:
+    Pattern.Flow.Lacp.Actor.ActorState:
       description: |-
         A 1-byte bitmask indicating the Actor's state. Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) Bit 2: Aggregation (1=Aggregatable, 0=Individual) Bit 3: Synchronization (1=In Sync, 0=Out of Sync) Bit 4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing (1=Enabled, 0=Disabled) Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received partner info) Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)
       type: object
@@ -46926,19 +46923,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.ActorState.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.ActorState.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.ActorState.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.ActorState.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.ActorInformation.ActorState.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Actor.ActorState.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.PartnerInformation.Type.Counter:
+    Pattern.Flow.Lacp.Partner.Type.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -46962,8 +46959,8 @@ components:
           format: uint32
           maximum: 255
       x-constants:
-        partner_information: 2
-    Pattern.Flow.Lacp.PartnerInformation.Type.MetricTag:
+        partner: 2
+    Pattern.Flow.Lacp.Partner.Type.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -46993,7 +46990,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.PartnerInformation.Type:
+    Pattern.Flow.Lacp.Partner.Type:
       description: |-
         TLV Type for Partner Information. The value 0x02 identifies this TLV as containing information about the remote device (the Partner), as understood by the Actor.
       type: object
@@ -47032,21 +47029,21 @@ components:
           default:
           - 2
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Type.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Type.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Type.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Type.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Type.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Type.MetricTag'
           x-field-uid: 7
       x-constants:
-        partner_information: 2
-    Pattern.Flow.Lacp.PartnerInformation.Length.Counter:
+        partner: 2
+    Pattern.Flow.Lacp.Partner.Length.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -47069,7 +47066,7 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.Lacp.PartnerInformation.Length.MetricTag:
+    Pattern.Flow.Lacp.Partner.Length.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47099,7 +47096,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.PartnerInformation.Length:
+    Pattern.Flow.Lacp.Partner.Length:
       description: |-
         The length of the Partner Information TLV payload in bytes.
       type: object
@@ -47138,19 +47135,19 @@ components:
           default:
           - 20
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Length.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Length.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Length.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Length.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.PartnerInformation.SystemPriority.Counter:
+    Pattern.Flow.Lacp.Partner.SystemPriority.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -47173,7 +47170,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.PartnerInformation.SystemPriority.MetricTag:
+    Pattern.Flow.Lacp.Partner.SystemPriority.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47203,7 +47200,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.PartnerInformation.SystemPriority:
+    Pattern.Flow.Lacp.Partner.SystemPriority:
       description: |-
         The priority of the Partner's system, as received by the Actor.
       type: object
@@ -47242,19 +47239,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.SystemPriority.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.SystemPriority.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.SystemPriority.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.SystemPriority.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.SystemPriority.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.SystemPriority.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.PartnerInformation.SystemId.Counter:
+    Pattern.Flow.Lacp.Partner.SystemId.Counter:
       description: |-
         mac counter pattern
       type: object
@@ -47274,7 +47271,7 @@ components:
           x-field-uid: 3
           default: 1
           format: uint32
-    Pattern.Flow.Lacp.PartnerInformation.SystemId.MetricTag:
+    Pattern.Flow.Lacp.Partner.SystemId.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47304,7 +47301,7 @@ components:
           minimum: 1
           maximum: 48
           x-field-uid: 3
-    Pattern.Flow.Lacp.PartnerInformation.SystemId:
+    Pattern.Flow.Lacp.Partner.SystemId:
       description: |-
         The Partner's System ID (MAC address), as received by the Actor.
       type: object
@@ -47341,19 +47338,19 @@ components:
           default:
           - 00:00:00:00:00:00
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.SystemId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.SystemId.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.SystemId.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.SystemId.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.SystemId.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.SystemId.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.PartnerInformation.Key.Counter:
+    Pattern.Flow.Lacp.Partner.Key.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -47376,7 +47373,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.PartnerInformation.Key.MetricTag:
+    Pattern.Flow.Lacp.Partner.Key.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47406,7 +47403,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.PartnerInformation.Key:
+    Pattern.Flow.Lacp.Partner.Key:
       description: |-
         The operational Key value of the Partner's port, as received by the Actor.
       type: object
@@ -47445,19 +47442,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Key.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Key.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Key.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Key.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.Key.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.Key.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.PartnerInformation.PortPriority.Counter:
+    Pattern.Flow.Lacp.Partner.PortPriority.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -47480,7 +47477,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.PartnerInformation.PortPriority.MetricTag:
+    Pattern.Flow.Lacp.Partner.PortPriority.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47510,7 +47507,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.PartnerInformation.PortPriority:
+    Pattern.Flow.Lacp.Partner.PortPriority:
       description: |-
         The priority of the Partner's port, as received by the Actor.
       type: object
@@ -47549,19 +47546,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PortPriority.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PortPriority.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PortPriority.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PortPriority.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PortPriority.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PortPriority.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.PartnerInformation.PortNumber.Counter:
+    Pattern.Flow.Lacp.Partner.PortNumber.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -47584,7 +47581,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.PartnerInformation.PortNumber.MetricTag:
+    Pattern.Flow.Lacp.Partner.PortNumber.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47614,7 +47611,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.PartnerInformation.PortNumber:
+    Pattern.Flow.Lacp.Partner.PortNumber:
       description: |-
         The port number of the Partner's port, as received by the Actor.
       type: object
@@ -47653,19 +47650,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PortNumber.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PortNumber.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PortNumber.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PortNumber.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PortNumber.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PortNumber.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.PartnerInformation.PartnerState.Counter:
+    Pattern.Flow.Lacp.Partner.PartnerState.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -47688,7 +47685,7 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.Lacp.PartnerInformation.PartnerState.MetricTag:
+    Pattern.Flow.Lacp.Partner.PartnerState.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47718,7 +47715,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.PartnerInformation.PartnerState:
+    Pattern.Flow.Lacp.Partner.PartnerState:
       description: |-
         A 1-byte bitmask indicating the Partner's state, as received by the Actor. Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) Bit 2: Aggregation (1=Aggregatable, 0=Individual) Bit 3: Synchronization (1=In Sync, 0=Out of Sync) Bit 4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing (1=Enabled, 0=Disabled) Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received partner info) Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)
       type: object
@@ -47757,19 +47754,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PartnerState.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PartnerState.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PartnerState.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PartnerState.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.PartnerInformation.PartnerState.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Partner.PartnerState.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.CollectorInformation.Type.Counter:
+    Pattern.Flow.Lacp.Collector.Type.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -47793,8 +47790,8 @@ components:
           format: uint32
           maximum: 255
       x-constants:
-        collector_information: 3
-    Pattern.Flow.Lacp.CollectorInformation.Type.MetricTag:
+        collector: 3
+    Pattern.Flow.Lacp.Collector.Type.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47824,7 +47821,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.CollectorInformation.Type:
+    Pattern.Flow.Lacp.Collector.Type:
       description: |-
         TLV Type for Collector Information. The value 0x03 identifies this TLV.
       type: object
@@ -47863,21 +47860,21 @@ components:
           default:
           - 3
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.Type.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.Type.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.Type.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.Type.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.Type.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.Type.MetricTag'
           x-field-uid: 7
       x-constants:
-        collector_information: 3
-    Pattern.Flow.Lacp.CollectorInformation.Length.Counter:
+        collector: 3
+    Pattern.Flow.Lacp.Collector.Length.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -47900,7 +47897,7 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.Lacp.CollectorInformation.Length.MetricTag:
+    Pattern.Flow.Lacp.Collector.Length.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -47930,7 +47927,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.CollectorInformation.Length:
+    Pattern.Flow.Lacp.Collector.Length:
       description: |-
         The length of the Collector Information TLV payload in bytes. The value must be 16 (0x10).
       type: object
@@ -47969,19 +47966,19 @@ components:
           default:
           - 16
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.Length.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.Length.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.Length.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.Length.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.CollectorInformation.MaxDelay.Counter:
+    Pattern.Flow.Lacp.Collector.MaxDelay.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -48004,7 +48001,7 @@ components:
           default: 1
           format: uint32
           maximum: 65535
-    Pattern.Flow.Lacp.CollectorInformation.MaxDelay.MetricTag:
+    Pattern.Flow.Lacp.Collector.MaxDelay.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -48034,7 +48031,7 @@ components:
           minimum: 1
           maximum: 16
           x-field-uid: 3
-    Pattern.Flow.Lacp.CollectorInformation.MaxDelay:
+    Pattern.Flow.Lacp.Collector.MaxDelay:
       description: |-
         Indicates the maximum delay, in units of 10 microseconds, that the transmitting system's aggregator will take to buffer frames from its collector before emitting a frame.
       type: object
@@ -48073,19 +48070,19 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.MaxDelay.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.MaxDelay.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.MaxDelay.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.MaxDelay.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.CollectorInformation.MaxDelay.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Collector.MaxDelay.MetricTag'
           x-field-uid: 7
-    Pattern.Flow.Lacp.TerminatorInformation.Type.Counter:
+    Pattern.Flow.Lacp.Terminator.Type.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -48110,7 +48107,7 @@ components:
           maximum: 255
       x-constants:
         terminator: 0
-    Pattern.Flow.Lacp.TerminatorInformation.Type.MetricTag:
+    Pattern.Flow.Lacp.Terminator.Type.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -48140,7 +48137,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.TerminatorInformation.Type:
+    Pattern.Flow.Lacp.Terminator.Type:
       description: |-
         TLV Type for Terminator Information. The value 0x00 indicates the end of the TLV list.
       type: object
@@ -48179,21 +48176,21 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorInformation.Type.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Terminator.Type.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorInformation.Type.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Terminator.Type.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorInformation.Type.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Terminator.Type.MetricTag'
           x-field-uid: 7
       x-constants:
         terminator: 0
-    Pattern.Flow.Lacp.TerminatorInformation.Length.Counter:
+    Pattern.Flow.Lacp.Terminator.Length.Counter:
       description: |-
         integer counter pattern
       type: object
@@ -48216,7 +48213,7 @@ components:
           default: 1
           format: uint32
           maximum: 255
-    Pattern.Flow.Lacp.TerminatorInformation.Length.MetricTag:
+    Pattern.Flow.Lacp.Terminator.Length.MetricTag:
       description: |-
         Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
       type: object
@@ -48246,7 +48243,7 @@ components:
           minimum: 1
           maximum: 8
           x-field-uid: 3
-    Pattern.Flow.Lacp.TerminatorInformation.Length:
+    Pattern.Flow.Lacp.Terminator.Length:
       description: |-
         The length of the Terminator TLV payload. The value must be 0.
       type: object
@@ -48285,17 +48282,17 @@ components:
           default:
           - 0
         increment:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorInformation.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Terminator.Length.Counter'
           x-field-uid: 5
         decrement:
-          $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorInformation.Length.Counter'
+          $ref: '#/components/schemas/Pattern.Flow.Lacp.Terminator.Length.Counter'
           x-field-uid: 6
         metric_tags:
           description: |-
             One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.
           type: array
           items:
-            $ref: '#/components/schemas/Pattern.Flow.Lacp.TerminatorInformation.Length.MetricTag'
+            $ref: '#/components/schemas/Pattern.Flow.Lacp.Terminator.Length.MetricTag'
           x-field-uid: 7
     Version:
       description: |-

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -11729,116 +11729,112 @@ message FlowLacp {
   PatternFlowLacpVersion version = 2;
 
   // Description missing in models
-  // required = true
-  FlowLacpActorInformation actor_information = 3;
+  FlowLacpActor actor = 3;
 
   // Description missing in models
-  // required = true
-  FlowLacpPartnerInformation partner_information = 4;
+  FlowLacpPartner partner = 4;
 
   // Description missing in models
-  // required = true
-  FlowLacpCollectorInformation collection_information = 5;
+  FlowLacpCollector collector = 5;
 
   // Description missing in models
-  // required = true
-  FlowLacpTerminatorInformation terminator_information = 6;
+  FlowLacpTerminator terminator = 6;
 }
 
 // Information about the local (actor) system.
-message FlowLacpActorInformation {
+message FlowLacpActor {
 
   // Description missing in models
-  PatternFlowLacpActorInformationType type = 1;
+  PatternFlowLacpActorType type = 1;
 
   // Description missing in models
-  PatternFlowLacpActorInformationLength length = 2;
+  PatternFlowLacpActorLength length = 2;
 
   // Description missing in models
-  PatternFlowLacpActorInformationSystemPriority system_priority = 3;
+  PatternFlowLacpActorSystemPriority system_priority = 3;
 
   // Description missing in models
-  PatternFlowLacpActorInformationSystemId system_id = 4;
+  PatternFlowLacpActorSystemId system_id = 4;
 
   // Description missing in models
-  PatternFlowLacpActorInformationKey key = 5;
+  PatternFlowLacpActorKey key = 5;
 
   // Description missing in models
-  PatternFlowLacpActorInformationPortPriority port_priority = 6;
+  PatternFlowLacpActorPortPriority port_priority = 6;
 
   // Description missing in models
-  PatternFlowLacpActorInformationPortNumber port_number = 7;
+  PatternFlowLacpActorPortNumber port_number = 7;
 
   // Description missing in models
-  PatternFlowLacpActorInformationActorState actor_state = 8;
+  PatternFlowLacpActorActorState actor_state = 8;
 
   // Reserved field for future use in the Actor TLV. Should be set to all zeros.
   // default = 000000
-  optional string actor_reserved = 9;
+  optional string reserved = 9;
 }
 
 // Information about the remote (partner) system.
-message FlowLacpPartnerInformation {
+message FlowLacpPartner {
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationType type = 1;
+  PatternFlowLacpPartnerType type = 1;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationLength length = 2;
+  PatternFlowLacpPartnerLength length = 2;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationSystemPriority system_priority = 3;
+  PatternFlowLacpPartnerSystemPriority system_priority = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationSystemId system_id = 4;
+  PatternFlowLacpPartnerSystemId system_id = 4;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationKey key = 5;
+  PatternFlowLacpPartnerKey key = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPortPriority port_priority = 6;
+  PatternFlowLacpPartnerPortPriority port_priority = 6;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPortNumber port_number = 7;
+  PatternFlowLacpPartnerPortNumber port_number = 7;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPartnerState partner_state = 8;
+  PatternFlowLacpPartnerPartnerState partner_state = 8;
 
   // Reserved field for future use in the Partner TLV. Should be set to all zeros.
   // default = 000000
-  optional string partner_reserved = 9;
+  optional string reserved = 9;
 }
 
 // Information about frame collection parameters.
-message FlowLacpCollectorInformation {
+message FlowLacpCollector {
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationType type = 1;
+  PatternFlowLacpCollectorType type = 1;
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationLength length = 2;
+  PatternFlowLacpCollectorLength length = 2;
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationMaxDelay max_delay = 3;
+  PatternFlowLacpCollectorMaxDelay max_delay = 3;
 
   // Reserved field for future use in the Collector TLV. 12 bytes long and should be set
   // to all zeros.
   // default = 000000000000000000000000
-  optional string collector_reserved = 4;
+  optional string reserved = 4;
 }
 
 // Marks the end of the LACPDU message.
-message FlowLacpTerminatorInformation {
+message FlowLacpTerminator {
 
   // Description missing in models
-  PatternFlowLacpTerminatorInformationType type = 1;
+  PatternFlowLacpTerminatorType type = 1;
 
   // Description missing in models
-  PatternFlowLacpTerminatorInformationLength length = 2;
+  PatternFlowLacpTerminatorLength length = 2;
 
   // Final block of reserved bytes to pad the PDU. It is 50 bytes long.
   // default = 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-  optional string final_reserved = 3;
+  optional string reserved = 3;
 }
 
 // The frame size which overrides the total length of the packet
@@ -32488,7 +32484,7 @@ message PatternFlowLacpVersion {
 }
 
 // integer counter pattern
-message PatternFlowLacpActorInformationTypeCounter {
+message PatternFlowLacpActorTypeCounter {
 
   // Description missing in models
   // default = 1
@@ -32506,7 +32502,7 @@ message PatternFlowLacpActorInformationTypeCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpActorInformationTypeMetricTag {
+message PatternFlowLacpActorTypeMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -32525,7 +32521,7 @@ message PatternFlowLacpActorInformationTypeMetricTag {
 
 // TLV Type for Actor Information. The value 0x01 identifies this TLV as containing
 // information about the sending device (the Actor).
-message PatternFlowLacpActorInformationType {
+message PatternFlowLacpActorType {
 
   message Choice {
     enum Enum {
@@ -32549,19 +32545,19 @@ message PatternFlowLacpActorInformationType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpActorInformationTypeCounter increment = 5;
+  PatternFlowLacpActorTypeCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpActorInformationTypeCounter decrement = 6;
+  PatternFlowLacpActorTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpActorInformationTypeMetricTag metric_tags = 7;
+  repeated PatternFlowLacpActorTypeMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpActorInformationLengthCounter {
+message PatternFlowLacpActorLengthCounter {
 
   // Description missing in models
   // default = 20
@@ -32579,7 +32575,7 @@ message PatternFlowLacpActorInformationLengthCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpActorInformationLengthMetricTag {
+message PatternFlowLacpActorLengthMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -32597,7 +32593,7 @@ message PatternFlowLacpActorInformationLengthMetricTag {
 }
 
 // The length of the Actor Information TLV payload in bytes.
-message PatternFlowLacpActorInformationLength {
+message PatternFlowLacpActorLength {
 
   message Choice {
     enum Enum {
@@ -32621,22 +32617,22 @@ message PatternFlowLacpActorInformationLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpActorInformationLengthCounter increment = 5;
+  PatternFlowLacpActorLengthCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpActorInformationLengthCounter decrement = 6;
+  PatternFlowLacpActorLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpActorInformationLengthMetricTag metric_tags = 7;
+  repeated PatternFlowLacpActorLengthMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpActorInformationSystemPriorityCounter {
+message PatternFlowLacpActorSystemPriorityCounter {
 
   // Description missing in models
-  // default = 32768
+  // default = 0
   optional uint32 start = 1;
 
   // Description missing in models
@@ -32651,7 +32647,7 @@ message PatternFlowLacpActorInformationSystemPriorityCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpActorInformationSystemPriorityMetricTag {
+message PatternFlowLacpActorSystemPriorityMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -32671,7 +32667,7 @@ message PatternFlowLacpActorInformationSystemPriorityMetricTag {
 // The priority assigned to the Actor's system for use in aggregation. A lower numerical
 // value indicates a higher priority. Used to select the active System ID when forming
 // an aggregator.
-message PatternFlowLacpActorInformationSystemPriority {
+message PatternFlowLacpActorSystemPriority {
 
   message Choice {
     enum Enum {
@@ -32687,27 +32683,27 @@ message PatternFlowLacpActorInformationSystemPriority {
   optional Choice.Enum choice = 1;
 
   // Description missing in models
-  // default = 32768
+  // default = 0
   optional uint32 value = 2;
 
   // Description missing in models
-  // default = [32768]
+  // default = [0]
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpActorInformationSystemPriorityCounter increment = 5;
+  PatternFlowLacpActorSystemPriorityCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpActorInformationSystemPriorityCounter decrement = 6;
+  PatternFlowLacpActorSystemPriorityCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpActorInformationSystemPriorityMetricTag metric_tags = 7;
+  repeated PatternFlowLacpActorSystemPriorityMetricTag metric_tags = 7;
 }
 
 // mac counter pattern
-message PatternFlowLacpActorInformationSystemIdCounter {
+message PatternFlowLacpActorSystemIdCounter {
 
   // Description missing in models
   // default = 00:00:00:00:00:00
@@ -32725,7 +32721,7 @@ message PatternFlowLacpActorInformationSystemIdCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpActorInformationSystemIdMetricTag {
+message PatternFlowLacpActorSystemIdMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -32744,7 +32740,7 @@ message PatternFlowLacpActorInformationSystemIdMetricTag {
 
 // The Actor's System ID, which is a globally unique MAC address assigned to the system
 // containing the Actor.
-message PatternFlowLacpActorInformationSystemId {
+message PatternFlowLacpActorSystemId {
 
   message Choice {
     enum Enum {
@@ -32768,19 +32764,19 @@ message PatternFlowLacpActorInformationSystemId {
   repeated string values = 3;
 
   // Description missing in models
-  PatternFlowLacpActorInformationSystemIdCounter increment = 5;
+  PatternFlowLacpActorSystemIdCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpActorInformationSystemIdCounter decrement = 6;
+  PatternFlowLacpActorSystemIdCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpActorInformationSystemIdMetricTag metric_tags = 7;
+  repeated PatternFlowLacpActorSystemIdMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpActorInformationKeyCounter {
+message PatternFlowLacpActorKeyCounter {
 
   // Description missing in models
   // default = 0
@@ -32798,7 +32794,7 @@ message PatternFlowLacpActorInformationKeyCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpActorInformationKeyMetricTag {
+message PatternFlowLacpActorKeyMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -32818,7 +32814,7 @@ message PatternFlowLacpActorInformationKeyMetricTag {
 // The operational Key value assigned to the Actor's port. The key is generated based
 // on port configuration (e.g., speed, duplex, trunk ID) and is used to identify potential
 // aggregation groups. Only links with the same key can be aggregated together.
-message PatternFlowLacpActorInformationKey {
+message PatternFlowLacpActorKey {
 
   message Choice {
     enum Enum {
@@ -32842,22 +32838,22 @@ message PatternFlowLacpActorInformationKey {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpActorInformationKeyCounter increment = 5;
+  PatternFlowLacpActorKeyCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpActorInformationKeyCounter decrement = 6;
+  PatternFlowLacpActorKeyCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpActorInformationKeyMetricTag metric_tags = 7;
+  repeated PatternFlowLacpActorKeyMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpActorInformationPortPriorityCounter {
+message PatternFlowLacpActorPortPriorityCounter {
 
   // Description missing in models
-  // default = 32768
+  // default = 0
   optional uint32 start = 1;
 
   // Description missing in models
@@ -32872,7 +32868,7 @@ message PatternFlowLacpActorInformationPortPriorityCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpActorInformationPortPriorityMetricTag {
+message PatternFlowLacpActorPortPriorityMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -32892,80 +32888,7 @@ message PatternFlowLacpActorInformationPortPriorityMetricTag {
 // The priority assigned to the Actor's port. A lower numerical value indicates a higher
 // priority. Used to prioritize ports for inclusion in a Link Aggregation Group (LAG)
 // when the group is full.
-message PatternFlowLacpActorInformationPortPriority {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 32768
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [32768]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowLacpActorInformationPortPriorityCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowLacpActorInformationPortPriorityCounter decrement = 6;
-
-  // One or more metric tags can be used to enable tracking portion of or all bits in
-  // a corresponding header field for metrics per each applicable value. These would appear
-  // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpActorInformationPortPriorityMetricTag metric_tags = 7;
-}
-
-// integer counter pattern
-message PatternFlowLacpActorInformationPortNumberCounter {
-
-  // Description missing in models
-  // default = 0
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Metric tag can be used to enable tracking portion of or all bits in a corresponding
-// header field for metrics per each applicable value. These would appear as tagged
-// metrics in corresponding flow metrics.
-message PatternFlowLacpActorInformationPortNumberMetricTag {
-
-  // Name used to identify the metrics associated with the values applicable for configured
-  // offset and length inside corresponding header field
-  // required = true
-  optional string name = 1;
-
-  // Offset in bits relative to start of corresponding header field
-  // default = 0
-  optional uint32 offset = 2;
-
-  // Number of bits to track for metrics starting from configured offset of corresponding
-  // header field
-  // default = 16
-  optional uint32 length = 3;
-}
-
-// The port number assigned to the Actor's port. It is a unique identifier for the port
-// within the system.
-message PatternFlowLacpActorInformationPortNumber {
+message PatternFlowLacpActorPortPriority {
 
   message Choice {
     enum Enum {
@@ -32989,19 +32912,19 @@ message PatternFlowLacpActorInformationPortNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpActorInformationPortNumberCounter increment = 5;
+  PatternFlowLacpActorPortPriorityCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpActorInformationPortNumberCounter decrement = 6;
+  PatternFlowLacpActorPortPriorityCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpActorInformationPortNumberMetricTag metric_tags = 7;
+  repeated PatternFlowLacpActorPortPriorityMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpActorInformationActorStateCounter {
+message PatternFlowLacpActorPortNumberCounter {
 
   // Description missing in models
   // default = 0
@@ -33019,7 +32942,80 @@ message PatternFlowLacpActorInformationActorStateCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpActorInformationActorStateMetricTag {
+message PatternFlowLacpActorPortNumberMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The port number assigned to the Actor's port. It is a unique identifier for the port
+// within the system.
+message PatternFlowLacpActorPortNumber {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorPortNumberCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorPortNumberCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorPortNumberMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpActorActorStateCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorActorStateMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33042,7 +33038,7 @@ message PatternFlowLacpActorInformationActorStateMetricTag {
 // Bit 4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing (1=Enabled, 0=Disabled)
 // Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received partner info)
 // Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)
-message PatternFlowLacpActorInformationActorState {
+message PatternFlowLacpActorActorState {
 
   message Choice {
     enum Enum {
@@ -33066,19 +33062,19 @@ message PatternFlowLacpActorInformationActorState {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpActorInformationActorStateCounter increment = 5;
+  PatternFlowLacpActorActorStateCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpActorInformationActorStateCounter decrement = 6;
+  PatternFlowLacpActorActorStateCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpActorInformationActorStateMetricTag metric_tags = 7;
+  repeated PatternFlowLacpActorActorStateMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpPartnerInformationTypeCounter {
+message PatternFlowLacpPartnerTypeCounter {
 
   // Description missing in models
   // default = 2
@@ -33096,7 +33092,7 @@ message PatternFlowLacpPartnerInformationTypeCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpPartnerInformationTypeMetricTag {
+message PatternFlowLacpPartnerTypeMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33115,7 +33111,7 @@ message PatternFlowLacpPartnerInformationTypeMetricTag {
 
 // TLV Type for Partner Information. The value 0x02 identifies this TLV as containing
 // information about the remote device (the Partner), as understood by the Actor.
-message PatternFlowLacpPartnerInformationType {
+message PatternFlowLacpPartnerType {
 
   message Choice {
     enum Enum {
@@ -33139,19 +33135,19 @@ message PatternFlowLacpPartnerInformationType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationTypeCounter increment = 5;
+  PatternFlowLacpPartnerTypeCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationTypeCounter decrement = 6;
+  PatternFlowLacpPartnerTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpPartnerInformationTypeMetricTag metric_tags = 7;
+  repeated PatternFlowLacpPartnerTypeMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpPartnerInformationLengthCounter {
+message PatternFlowLacpPartnerLengthCounter {
 
   // Description missing in models
   // default = 20
@@ -33169,7 +33165,7 @@ message PatternFlowLacpPartnerInformationLengthCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpPartnerInformationLengthMetricTag {
+message PatternFlowLacpPartnerLengthMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33187,7 +33183,7 @@ message PatternFlowLacpPartnerInformationLengthMetricTag {
 }
 
 // The length of the Partner Information TLV payload in bytes.
-message PatternFlowLacpPartnerInformationLength {
+message PatternFlowLacpPartnerLength {
 
   message Choice {
     enum Enum {
@@ -33211,19 +33207,19 @@ message PatternFlowLacpPartnerInformationLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationLengthCounter increment = 5;
+  PatternFlowLacpPartnerLengthCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationLengthCounter decrement = 6;
+  PatternFlowLacpPartnerLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpPartnerInformationLengthMetricTag metric_tags = 7;
+  repeated PatternFlowLacpPartnerLengthMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpPartnerInformationSystemPriorityCounter {
+message PatternFlowLacpPartnerSystemPriorityCounter {
 
   // Description missing in models
   // default = 0
@@ -33241,7 +33237,7 @@ message PatternFlowLacpPartnerInformationSystemPriorityCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpPartnerInformationSystemPriorityMetricTag {
+message PatternFlowLacpPartnerSystemPriorityMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33259,7 +33255,7 @@ message PatternFlowLacpPartnerInformationSystemPriorityMetricTag {
 }
 
 // The priority of the Partner's system, as received by the Actor.
-message PatternFlowLacpPartnerInformationSystemPriority {
+message PatternFlowLacpPartnerSystemPriority {
 
   message Choice {
     enum Enum {
@@ -33283,19 +33279,19 @@ message PatternFlowLacpPartnerInformationSystemPriority {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationSystemPriorityCounter increment = 5;
+  PatternFlowLacpPartnerSystemPriorityCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationSystemPriorityCounter decrement = 6;
+  PatternFlowLacpPartnerSystemPriorityCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpPartnerInformationSystemPriorityMetricTag metric_tags = 7;
+  repeated PatternFlowLacpPartnerSystemPriorityMetricTag metric_tags = 7;
 }
 
 // mac counter pattern
-message PatternFlowLacpPartnerInformationSystemIdCounter {
+message PatternFlowLacpPartnerSystemIdCounter {
 
   // Description missing in models
   // default = 00:00:00:00:00:00
@@ -33313,7 +33309,7 @@ message PatternFlowLacpPartnerInformationSystemIdCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpPartnerInformationSystemIdMetricTag {
+message PatternFlowLacpPartnerSystemIdMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33331,7 +33327,7 @@ message PatternFlowLacpPartnerInformationSystemIdMetricTag {
 }
 
 // The Partner's System ID (MAC address), as received by the Actor.
-message PatternFlowLacpPartnerInformationSystemId {
+message PatternFlowLacpPartnerSystemId {
 
   message Choice {
     enum Enum {
@@ -33355,19 +33351,19 @@ message PatternFlowLacpPartnerInformationSystemId {
   repeated string values = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationSystemIdCounter increment = 5;
+  PatternFlowLacpPartnerSystemIdCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationSystemIdCounter decrement = 6;
+  PatternFlowLacpPartnerSystemIdCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpPartnerInformationSystemIdMetricTag metric_tags = 7;
+  repeated PatternFlowLacpPartnerSystemIdMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpPartnerInformationKeyCounter {
+message PatternFlowLacpPartnerKeyCounter {
 
   // Description missing in models
   // default = 0
@@ -33385,7 +33381,7 @@ message PatternFlowLacpPartnerInformationKeyCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpPartnerInformationKeyMetricTag {
+message PatternFlowLacpPartnerKeyMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33403,7 +33399,7 @@ message PatternFlowLacpPartnerInformationKeyMetricTag {
 }
 
 // The operational Key value of the Partner's port, as received by the Actor.
-message PatternFlowLacpPartnerInformationKey {
+message PatternFlowLacpPartnerKey {
 
   message Choice {
     enum Enum {
@@ -33427,19 +33423,19 @@ message PatternFlowLacpPartnerInformationKey {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationKeyCounter increment = 5;
+  PatternFlowLacpPartnerKeyCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationKeyCounter decrement = 6;
+  PatternFlowLacpPartnerKeyCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpPartnerInformationKeyMetricTag metric_tags = 7;
+  repeated PatternFlowLacpPartnerKeyMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpPartnerInformationPortPriorityCounter {
+message PatternFlowLacpPartnerPortPriorityCounter {
 
   // Description missing in models
   // default = 0
@@ -33457,7 +33453,7 @@ message PatternFlowLacpPartnerInformationPortPriorityCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpPartnerInformationPortPriorityMetricTag {
+message PatternFlowLacpPartnerPortPriorityMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33475,7 +33471,7 @@ message PatternFlowLacpPartnerInformationPortPriorityMetricTag {
 }
 
 // The priority of the Partner's port, as received by the Actor.
-message PatternFlowLacpPartnerInformationPortPriority {
+message PatternFlowLacpPartnerPortPriority {
 
   message Choice {
     enum Enum {
@@ -33499,19 +33495,19 @@ message PatternFlowLacpPartnerInformationPortPriority {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPortPriorityCounter increment = 5;
+  PatternFlowLacpPartnerPortPriorityCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPortPriorityCounter decrement = 6;
+  PatternFlowLacpPartnerPortPriorityCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpPartnerInformationPortPriorityMetricTag metric_tags = 7;
+  repeated PatternFlowLacpPartnerPortPriorityMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpPartnerInformationPortNumberCounter {
+message PatternFlowLacpPartnerPortNumberCounter {
 
   // Description missing in models
   // default = 0
@@ -33529,7 +33525,7 @@ message PatternFlowLacpPartnerInformationPortNumberCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpPartnerInformationPortNumberMetricTag {
+message PatternFlowLacpPartnerPortNumberMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33547,7 +33543,7 @@ message PatternFlowLacpPartnerInformationPortNumberMetricTag {
 }
 
 // The port number of the Partner's port, as received by the Actor.
-message PatternFlowLacpPartnerInformationPortNumber {
+message PatternFlowLacpPartnerPortNumber {
 
   message Choice {
     enum Enum {
@@ -33571,19 +33567,19 @@ message PatternFlowLacpPartnerInformationPortNumber {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPortNumberCounter increment = 5;
+  PatternFlowLacpPartnerPortNumberCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPortNumberCounter decrement = 6;
+  PatternFlowLacpPartnerPortNumberCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpPartnerInformationPortNumberMetricTag metric_tags = 7;
+  repeated PatternFlowLacpPartnerPortNumberMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpPartnerInformationPartnerStateCounter {
+message PatternFlowLacpPartnerPartnerStateCounter {
 
   // Description missing in models
   // default = 0
@@ -33601,7 +33597,7 @@ message PatternFlowLacpPartnerInformationPartnerStateCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpPartnerInformationPartnerStateMetricTag {
+message PatternFlowLacpPartnerPartnerStateMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33624,7 +33620,7 @@ message PatternFlowLacpPartnerInformationPartnerStateMetricTag {
 // (1=In Sync, 0=Out of Sync) Bit 4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing
 // (1=Enabled, 0=Disabled) Bit 6: Defaulted (1=Using defaulted partner info, 0=Using
 // received partner info) Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)
-message PatternFlowLacpPartnerInformationPartnerState {
+message PatternFlowLacpPartnerPartnerState {
 
   message Choice {
     enum Enum {
@@ -33648,19 +33644,19 @@ message PatternFlowLacpPartnerInformationPartnerState {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPartnerStateCounter increment = 5;
+  PatternFlowLacpPartnerPartnerStateCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpPartnerInformationPartnerStateCounter decrement = 6;
+  PatternFlowLacpPartnerPartnerStateCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpPartnerInformationPartnerStateMetricTag metric_tags = 7;
+  repeated PatternFlowLacpPartnerPartnerStateMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpCollectorInformationTypeCounter {
+message PatternFlowLacpCollectorTypeCounter {
 
   // Description missing in models
   // default = 3
@@ -33678,7 +33674,7 @@ message PatternFlowLacpCollectorInformationTypeCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpCollectorInformationTypeMetricTag {
+message PatternFlowLacpCollectorTypeMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33696,7 +33692,7 @@ message PatternFlowLacpCollectorInformationTypeMetricTag {
 }
 
 // TLV Type for Collector Information. The value 0x03 identifies this TLV.
-message PatternFlowLacpCollectorInformationType {
+message PatternFlowLacpCollectorType {
 
   message Choice {
     enum Enum {
@@ -33720,19 +33716,19 @@ message PatternFlowLacpCollectorInformationType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationTypeCounter increment = 5;
+  PatternFlowLacpCollectorTypeCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationTypeCounter decrement = 6;
+  PatternFlowLacpCollectorTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpCollectorInformationTypeMetricTag metric_tags = 7;
+  repeated PatternFlowLacpCollectorTypeMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpCollectorInformationLengthCounter {
+message PatternFlowLacpCollectorLengthCounter {
 
   // Description missing in models
   // default = 16
@@ -33750,7 +33746,7 @@ message PatternFlowLacpCollectorInformationLengthCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpCollectorInformationLengthMetricTag {
+message PatternFlowLacpCollectorLengthMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33769,7 +33765,7 @@ message PatternFlowLacpCollectorInformationLengthMetricTag {
 
 // The length of the Collector Information TLV payload in bytes. The value must be 16
 // (0x10).
-message PatternFlowLacpCollectorInformationLength {
+message PatternFlowLacpCollectorLength {
 
   message Choice {
     enum Enum {
@@ -33793,19 +33789,19 @@ message PatternFlowLacpCollectorInformationLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationLengthCounter increment = 5;
+  PatternFlowLacpCollectorLengthCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationLengthCounter decrement = 6;
+  PatternFlowLacpCollectorLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpCollectorInformationLengthMetricTag metric_tags = 7;
+  repeated PatternFlowLacpCollectorLengthMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpCollectorInformationMaxDelayCounter {
+message PatternFlowLacpCollectorMaxDelayCounter {
 
   // Description missing in models
   // default = 0
@@ -33823,7 +33819,7 @@ message PatternFlowLacpCollectorInformationMaxDelayCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpCollectorInformationMaxDelayMetricTag {
+message PatternFlowLacpCollectorMaxDelayMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33842,7 +33838,7 @@ message PatternFlowLacpCollectorInformationMaxDelayMetricTag {
 
 // Indicates the maximum delay, in units of 10 microseconds, that the transmitting system's
 // aggregator will take to buffer frames from its collector before emitting a frame.
-message PatternFlowLacpCollectorInformationMaxDelay {
+message PatternFlowLacpCollectorMaxDelay {
 
   message Choice {
     enum Enum {
@@ -33866,19 +33862,19 @@ message PatternFlowLacpCollectorInformationMaxDelay {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationMaxDelayCounter increment = 5;
+  PatternFlowLacpCollectorMaxDelayCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpCollectorInformationMaxDelayCounter decrement = 6;
+  PatternFlowLacpCollectorMaxDelayCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpCollectorInformationMaxDelayMetricTag metric_tags = 7;
+  repeated PatternFlowLacpCollectorMaxDelayMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpTerminatorInformationTypeCounter {
+message PatternFlowLacpTerminatorTypeCounter {
 
   // Description missing in models
   // default = 0
@@ -33896,7 +33892,7 @@ message PatternFlowLacpTerminatorInformationTypeCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpTerminatorInformationTypeMetricTag {
+message PatternFlowLacpTerminatorTypeMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33915,7 +33911,7 @@ message PatternFlowLacpTerminatorInformationTypeMetricTag {
 
 // TLV Type for Terminator Information. The value 0x00 indicates the end of the TLV
 // list.
-message PatternFlowLacpTerminatorInformationType {
+message PatternFlowLacpTerminatorType {
 
   message Choice {
     enum Enum {
@@ -33939,19 +33935,19 @@ message PatternFlowLacpTerminatorInformationType {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpTerminatorInformationTypeCounter increment = 5;
+  PatternFlowLacpTerminatorTypeCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpTerminatorInformationTypeCounter decrement = 6;
+  PatternFlowLacpTerminatorTypeCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpTerminatorInformationTypeMetricTag metric_tags = 7;
+  repeated PatternFlowLacpTerminatorTypeMetricTag metric_tags = 7;
 }
 
 // integer counter pattern
-message PatternFlowLacpTerminatorInformationLengthCounter {
+message PatternFlowLacpTerminatorLengthCounter {
 
   // Description missing in models
   // default = 0
@@ -33969,7 +33965,7 @@ message PatternFlowLacpTerminatorInformationLengthCounter {
 // Metric tag can be used to enable tracking portion of or all bits in a corresponding
 // header field for metrics per each applicable value. These would appear as tagged
 // metrics in corresponding flow metrics.
-message PatternFlowLacpTerminatorInformationLengthMetricTag {
+message PatternFlowLacpTerminatorLengthMetricTag {
 
   // Name used to identify the metrics associated with the values applicable for configured
   // offset and length inside corresponding header field
@@ -33987,7 +33983,7 @@ message PatternFlowLacpTerminatorInformationLengthMetricTag {
 }
 
 // The length of the Terminator TLV payload. The value must be 0.
-message PatternFlowLacpTerminatorInformationLength {
+message PatternFlowLacpTerminatorLength {
 
   message Choice {
     enum Enum {
@@ -34011,15 +34007,15 @@ message PatternFlowLacpTerminatorInformationLength {
   repeated uint32 values = 3;
 
   // Description missing in models
-  PatternFlowLacpTerminatorInformationLengthCounter increment = 5;
+  PatternFlowLacpTerminatorLengthCounter increment = 5;
 
   // Description missing in models
-  PatternFlowLacpTerminatorInformationLengthCounter decrement = 6;
+  PatternFlowLacpTerminatorLengthCounter decrement = 6;
 
   // One or more metric tags can be used to enable tracking portion of or all bits in
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
-  repeated PatternFlowLacpTerminatorInformationLengthMetricTag metric_tags = 7;
+  repeated PatternFlowLacpTerminatorLengthMetricTag metric_tags = 7;
 }
 
 // Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -9665,6 +9665,7 @@ message FlowHeader {
       snmpv2c = 20;
       rsvp = 21;
       macsec = 22;
+      lacp = 23;
     }
   }
   // The available types of flow headers. If one is not provided the
@@ -9737,6 +9738,9 @@ message FlowHeader {
 
   // Description missing in models
   FlowMacsec macsec = 23;
+
+  // Description missing in models
+  FlowLacp lacp = 24;
 }
 
 // Custom packet header
@@ -11712,6 +11716,111 @@ message FlowMacsec {
   // type of traffic with MACSec header fields explicitly specified by the user.
   // default = Choice.Enum.auto
   optional Choice.Enum choice = 1;
+}
+
+// Defines the fields of a Link Aggregation Control Protocol (LACP) Data Unit (PDU)
+// as specified by IEEE 802.3ad. LACP is a Slow Protocol (EtherType 0x8809) used for
+// dynamic link aggregation.
+message FlowLacp {
+
+  // Description missing in models
+  PatternFlowLacpDestinationAddress destination_address = 1;
+
+  // Description missing in models
+  PatternFlowLacpSourceAddress source_address = 2;
+
+  // Description missing in models
+  PatternFlowLacpLengthType length_type = 3;
+
+  // Description missing in models
+  PatternFlowLacpSubType sub_type = 4;
+
+  // Description missing in models
+  PatternFlowLacpVersion version = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorTlvType actor_tlv_type = 6;
+
+  // Description missing in models
+  PatternFlowLacpActorTlvLength actor_tlv_length = 7;
+
+  // Description missing in models
+  PatternFlowLacpActorSystemPriority actor_system_priority = 8;
+
+  // Description missing in models
+  PatternFlowLacpActorSystem actor_system = 9;
+
+  // Description missing in models
+  PatternFlowLacpActorKey actor_key = 10;
+
+  // Description missing in models
+  PatternFlowLacpActorPortPriority actor_port_priority = 11;
+
+  // Description missing in models
+  PatternFlowLacpActorPort actor_port = 12;
+
+  // Description missing in models
+  PatternFlowLacpActorState actor_state = 13;
+
+  // Reserved field for future use in the Actor TLV. Should be set to all zeros.
+  // default = 000000
+  optional string actor_reserved = 14;
+
+  // Description missing in models
+  PatternFlowLacpPartnerTlvType partner_tlv_type = 15;
+
+  // Description missing in models
+  PatternFlowLacpPartnerTlvLength partner_tlv_length = 16;
+
+  // Description missing in models
+  PatternFlowLacpPartnerSystemPriority partner_system_priority = 17;
+
+  // Description missing in models
+  PatternFlowLacpPartnerSystem partner_system = 18;
+
+  // Description missing in models
+  PatternFlowLacpPartnerKey partner_key = 19;
+
+  // Description missing in models
+  PatternFlowLacpPartnerPortPriority partner_port_priority = 20;
+
+  // Description missing in models
+  PatternFlowLacpPartnerPort partner_port = 21;
+
+  // Description missing in models
+  PatternFlowLacpPartnerState partner_state = 22;
+
+  // Reserved field for future use in the Partner TLV. Should be set to all zeros.
+  // default = 000000
+  optional string partner_reserved = 23;
+
+  // Description missing in models
+  PatternFlowLacpCollectorTlvType collector_tlv_type = 24;
+
+  // Description missing in models
+  PatternFlowLacpCollectorTlvLength collector_tlv_length = 25;
+
+  // Description missing in models
+  PatternFlowLacpCollectorMaxDelay collector_max_delay = 26;
+
+  // Reserved field for future use in the Collector TLV. 12 bytes long and should be set
+  // to all zeros.
+  // default = 000000000000000000000000
+  optional string collector_reserved = 27;
+
+  // Description missing in models
+  PatternFlowLacpTerminatorTlvType terminator_tlv_type = 28;
+
+  // Description missing in models
+  PatternFlowLacpTerminatorTlvLength terminator_tlv_length = 29;
+
+  // Final block of reserved bytes to pad the PDU. It is 50 bytes long, set to all zeros,
+  // and ignored on receipt.
+  // default = 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  optional string final_reserved = 30;
+
+  // Description missing in models
+  PatternFlowLacpFcs fcs = 31;
 }
 
 // The frame size which overrides the total length of the packet
@@ -32214,6 +32323,1953 @@ message PatternFlowRSVPPathObjectsCustomType {
 
   // Description missing in models
   PatternFlowRSVPPathObjectsCustomTypeCounter decrement = 6;
+}
+
+// mac counter pattern
+message PatternFlowLacpDestinationAddressCounter {
+
+  // Description missing in models
+  // default = 01:80:C2:00:00:02
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:01
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpDestinationAddressMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 48
+  optional uint32 length = 3;
+}
+
+// The destination MAC address. For LACP, this is the special multicast address 01-80-C2-00-00-02
+// used for Slow Protocols.
+message PatternFlowLacpDestinationAddress {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 01:80:C2:00:00:02
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['01:80:C2:00:00:02']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowLacpDestinationAddressCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpDestinationAddressCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpDestinationAddressMetricTag metric_tags = 7;
+}
+
+// mac counter pattern
+message PatternFlowLacpSourceAddressCounter {
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:01
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpSourceAddressMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 48
+  optional uint32 length = 3;
+}
+
+// The source MAC address of the physical port through which the LACPDU is transmitted.
+message PatternFlowLacpSourceAddress {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['00:00:00:00:00:00']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowLacpSourceAddressCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpSourceAddressCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpSourceAddressMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpLengthTypeCounter {
+
+  // Description missing in models
+  // default = 34825
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpLengthTypeMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// Ethernet Type field. It must be set to 0x8809 to indicate a Slow Protocol like LACP.
+message PatternFlowLacpLengthType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 34825
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [34825]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpLengthTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpLengthTypeCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpLengthTypeMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpSubTypeCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpSubTypeMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// Indicates the specific Slow Protocol subtype. It must be set to 0x01 for LACPDUs.
+message PatternFlowLacpSubType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpSubTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpSubTypeCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpSubTypeMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpVersionCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpVersionMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// The LACP version number. It must be set to 0x01.
+message PatternFlowLacpVersion {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpVersionCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpVersionCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpVersionMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpActorTlvTypeCounter {
+
+  // Description missing in models
+  // default = 1
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorTlvTypeMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// TLV Type for Actor Information. The value 0x01 identifies this TLV as containing
+// information about the sending device (the Actor).
+message PatternFlowLacpActorTlvType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [1]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorTlvTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorTlvTypeCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorTlvTypeMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpActorTlvLengthCounter {
+
+  // Description missing in models
+  // default = 20
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorTlvLengthMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// The length of the Actor Information TLV payload in bytes. The value must be 20 (0x14).
+message PatternFlowLacpActorTlvLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 20
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [20]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorTlvLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorTlvLengthCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorTlvLengthMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpActorSystemPriorityCounter {
+
+  // Description missing in models
+  // default = 32768
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorSystemPriorityMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The priority assigned to the Actor's system for use in aggregation. A lower numerical
+// value indicates a higher priority. Used to select the active System ID when forming
+// an aggregator. The default value is 32768 (0x8000).
+message PatternFlowLacpActorSystemPriority {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 32768
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [32768]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorSystemPriorityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorSystemPriorityCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorSystemPriorityMetricTag metric_tags = 7;
+}
+
+// mac counter pattern
+message PatternFlowLacpActorSystemCounter {
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:01
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorSystemMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 48
+  optional uint32 length = 3;
+}
+
+// The Actor's System ID, which is a globally unique MAC address assigned to the system
+// containing the Actor.
+message PatternFlowLacpActorSystem {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['00:00:00:00:00:00']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorSystemCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorSystemCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorSystemMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpActorKeyCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorKeyMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The operational Key value assigned to the Actor's port. The key is generated based
+// on port configuration (e.g., speed, duplex, trunk ID) and is used to identify potential
+// aggregation groups. Only links with the same key can be aggregated together.
+message PatternFlowLacpActorKey {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorKeyCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorKeyCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorKeyMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpActorPortPriorityCounter {
+
+  // Description missing in models
+  // default = 32768
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorPortPriorityMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The priority assigned to the Actor's port. A lower numerical value indicates a higher
+// priority. Used to prioritize ports for inclusion in a Link Aggregation Group (LAG)
+// when the group is full. The default value is 32768 (0x8000).
+message PatternFlowLacpActorPortPriority {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 32768
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [32768]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorPortPriorityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorPortPriorityCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorPortPriorityMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpActorPortCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorPortMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The port number assigned to the Actor's port. It is a unique identifier for the port
+// within the system.
+message PatternFlowLacpActorPort {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorPortCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorPortCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorPortMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpActorStateCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpActorStateMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// A 1-byte bitmask indicating the Actor's state. Bit 0 (LSB): LACP_Activity (1=Active,
+// 0=Passive) Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) Bit 2: Aggregation
+// (1=Aggregatable, 0=Individual) Bit 3: Synchronization (1=In Sync, 0=Out of Sync)
+// Bit 4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing (1=Enabled, 0=Disabled)
+// Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received partner info)
+// Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)
+message PatternFlowLacpActorState {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpActorStateCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpActorStateCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpActorStateMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpPartnerTlvTypeCounter {
+
+  // Description missing in models
+  // default = 2
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpPartnerTlvTypeMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// TLV Type for Partner Information. The value 0x02 identifies this TLV as containing
+// information about the remote device (the Partner), as understood by the Actor.
+message PatternFlowLacpPartnerTlvType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 2
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [2]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpPartnerTlvTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpPartnerTlvTypeCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpPartnerTlvTypeMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpPartnerTlvLengthCounter {
+
+  // Description missing in models
+  // default = 20
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpPartnerTlvLengthMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// The length of the Partner Information TLV payload in bytes. The value must be 20
+// (0x14).
+message PatternFlowLacpPartnerTlvLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 20
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [20]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpPartnerTlvLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpPartnerTlvLengthCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpPartnerTlvLengthMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpPartnerSystemPriorityCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpPartnerSystemPriorityMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The priority of the Partner's system, as received by the Actor. If no LACPDU has
+// been received from the partner, this is set to zero.
+message PatternFlowLacpPartnerSystemPriority {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpPartnerSystemPriorityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpPartnerSystemPriorityCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpPartnerSystemPriorityMetricTag metric_tags = 7;
+}
+
+// mac counter pattern
+message PatternFlowLacpPartnerSystemCounter {
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:01
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpPartnerSystemMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 48
+  optional uint32 length = 3;
+}
+
+// The Partner's System ID (MAC address), as received by the Actor. If no LACPDU has
+// been received from the partner, this is set to all zeros.
+message PatternFlowLacpPartnerSystem {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 00:00:00:00:00:00
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['00:00:00:00:00:00']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowLacpPartnerSystemCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpPartnerSystemCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpPartnerSystemMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpPartnerKeyCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpPartnerKeyMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The operational Key value of the Partner's port, as received by the Actor.
+message PatternFlowLacpPartnerKey {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpPartnerKeyCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpPartnerKeyCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpPartnerKeyMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpPartnerPortPriorityCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpPartnerPortPriorityMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The priority of the Partner's port, as received by the Actor.
+message PatternFlowLacpPartnerPortPriority {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpPartnerPortPriorityCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpPartnerPortPriorityCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpPartnerPortPriorityMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpPartnerPortCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpPartnerPortMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// The port number of the Partner's port, as received by the Actor.
+message PatternFlowLacpPartnerPort {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpPartnerPortCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpPartnerPortCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpPartnerPortMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpPartnerStateCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpPartnerStateMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// A 1-byte bitmask indicating the Partner's state, as received by the Actor. Bit 0
+// (LSB): LACP_Activity (1=Active, 0=Passive) Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow
+// timeout) Bit 2: Aggregation (1=Aggregatable, 0=Individual) Bit 3: Synchronization
+// (1=In Sync, 0=Out of Sync) Bit 4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing
+// (1=Enabled, 0=Disabled) Bit 6: Defaulted (1=Using defaulted partner info, 0=Using
+// received partner info) Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)
+message PatternFlowLacpPartnerState {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpPartnerStateCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpPartnerStateCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpPartnerStateMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpCollectorTlvTypeCounter {
+
+  // Description missing in models
+  // default = 3
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpCollectorTlvTypeMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// TLV Type for Collector Information. The value 0x03 identifies this TLV.
+message PatternFlowLacpCollectorTlvType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 3
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [3]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpCollectorTlvTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpCollectorTlvTypeCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpCollectorTlvTypeMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpCollectorTlvLengthCounter {
+
+  // Description missing in models
+  // default = 16
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpCollectorTlvLengthMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// The length of the Collector Information TLV payload in bytes. The value must be 16
+// (0x10).
+message PatternFlowLacpCollectorTlvLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 16
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [16]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpCollectorTlvLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpCollectorTlvLengthCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpCollectorTlvLengthMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpCollectorMaxDelayCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpCollectorMaxDelayMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 16
+  optional uint32 length = 3;
+}
+
+// Indicates the maximum delay, in units of 10 microseconds, that the transmitting system's
+// aggregator will take to buffer frames from its collector before emitting a frame.
+message PatternFlowLacpCollectorMaxDelay {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpCollectorMaxDelayCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpCollectorMaxDelayCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpCollectorMaxDelayMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpTerminatorTlvTypeCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpTerminatorTlvTypeMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// TLV Type for Terminator Information. The value 0x00 indicates the end of the TLV
+// list.
+message PatternFlowLacpTerminatorTlvType {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpTerminatorTlvTypeCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpTerminatorTlvTypeCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpTerminatorTlvTypeMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpTerminatorTlvLengthCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Metric tag can be used to enable tracking portion of or all bits in a corresponding
+// header field for metrics per each applicable value. These would appear as tagged
+// metrics in corresponding flow metrics.
+message PatternFlowLacpTerminatorTlvLengthMetricTag {
+
+  // Name used to identify the metrics associated with the values applicable for configured
+  // offset and length inside corresponding header field
+  // required = true
+  optional string name = 1;
+
+  // Offset in bits relative to start of corresponding header field
+  // default = 0
+  optional uint32 offset = 2;
+
+  // Number of bits to track for metrics starting from configured offset of corresponding
+  // header field
+  // default = 8
+  optional uint32 length = 3;
+}
+
+// The length of the Terminator TLV payload. The value must be 0.
+message PatternFlowLacpTerminatorTlvLength {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpTerminatorTlvLengthCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpTerminatorTlvLengthCounter decrement = 6;
+
+  // One or more metric tags can be used to enable tracking portion of or all bits in
+  // a corresponding header field for metrics per each applicable value. These would appear
+  // as tagged metrics in corresponding flow metrics.
+  repeated PatternFlowLacpTerminatorTlvLengthMetricTag metric_tags = 7;
+}
+
+// integer counter pattern
+message PatternFlowLacpFcsCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// Frame Check Sequence. A 32-bit CRC value used to check for errors in frame transmission.
+// It is calculated over the entire Ethernet frame.
+message PatternFlowLacpFcs {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowLacpFcsCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowLacpFcsCounter decrement = 6;
 }
 
 // Version details

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -11743,9 +11743,6 @@ message FlowLacp {
   // Description missing in models
   // required = true
   FlowLacpTerminatorInformation terminator_information = 6;
-
-  // Description missing in models
-  PatternFlowLacpFcs fcs = 7;
 }
 
 // Information about the local (actor) system.
@@ -32488,54 +32485,6 @@ message PatternFlowLacpVersion {
   // a corresponding header field for metrics per each applicable value. These would appear
   // as tagged metrics in corresponding flow metrics.
   repeated PatternFlowLacpVersionMetricTag metric_tags = 7;
-}
-
-// integer counter pattern
-message PatternFlowLacpFcsCounter {
-
-  // Description missing in models
-  // default = 0
-  optional uint32 start = 1;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 step = 2;
-
-  // Description missing in models
-  // default = 1
-  optional uint32 count = 3;
-}
-
-// Frame Check Sequence. A 32-bit CRC value used to check for errors in frame transmission.
-// It is calculated over the entire Ethernet frame.
-message PatternFlowLacpFcs {
-
-  message Choice {
-    enum Enum {
-      unspecified = 0;
-      value = 2;
-      values = 3;
-      increment = 4;
-      decrement = 5;
-    }
-  }
-  // Description missing in models
-  // default = Choice.Enum.value
-  optional Choice.Enum choice = 1;
-
-  // Description missing in models
-  // default = 0
-  optional uint32 value = 2;
-
-  // Description missing in models
-  // default = [0]
-  repeated uint32 values = 3;
-
-  // Description missing in models
-  PatternFlowLacpFcsCounter increment = 5;
-
-  // Description missing in models
-  PatternFlowLacpFcsCounter decrement = 6;
 }
 
 // integer counter pattern

--- a/flow/packet-headers/header.yaml
+++ b/flow/packet-headers/header.yaml
@@ -57,6 +57,8 @@ components:
               x-field-uid: 21
             macsec:
               x-field-uid: 22
+            lacp:
+              x-field-uid: 23
         custom:
           $ref: './custom.yaml#/components/schemas/Flow.Custom'
           x-field-uid: 2
@@ -123,3 +125,6 @@ components:
         macsec:
           $ref: './macsec.yaml#/components/schemas/Flow.Macsec'
           x-field-uid: 23
+        lacp:
+          $ref: './lacp.yaml#/components/schemas/Flow.Lacp'
+          x-field-uid: 24

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -4,11 +4,6 @@ components:
       description: Defines the fields of a Link Aggregation Control Protocol (LACP)
         Data Unit (PDU) as specified by IEEE 802.3ad.
       type: object
-      required:
-        - actor_information
-        - partner_information
-        - collection_information
-        - terminator_information
       properties:
         sub_type:
           x-field-pattern:
@@ -34,19 +29,19 @@ components:
               - count
               - metric_tags
           x-field-uid: 2
-        actor_information:
-          $ref: '#/components/schemas/Flow.Lacp.ActorInformation'
+        actor:
+          $ref: '#/components/schemas/Flow.Lacp.Actor'
           x-field-uid: 3
-        partner_information:
-          $ref: '#/components/schemas/Flow.Lacp.PartnerInformation'
+        partner:
+          $ref: '#/components/schemas/Flow.Lacp.Partner'
           x-field-uid: 4
-        collection_information:
-          $ref: '#/components/schemas/Flow.Lacp.CollectorInformation'
+        collector:
+          $ref: '#/components/schemas/Flow.Lacp.Collector'
           x-field-uid: 5
-        terminator_information:
-          $ref: '#/components/schemas/Flow.Lacp.TerminatorInformation'
+        terminator:
+          $ref: '#/components/schemas/Flow.Lacp.Terminator'
           x-field-uid: 6
-    Flow.Lacp.ActorInformation:
+    Flow.Lacp.Actor:
       description: |-
         Information about the local (actor) system.
       type: object
@@ -54,7 +49,7 @@ components:
         type:
           x-field-pattern:
             x-constants:
-              actor_information: 1
+              actor: 1
             description: TLV Type for Actor Information. The value 0x01 identifies
               this TLV as containing information about the sending device (the Actor).
             format: integer
@@ -81,7 +76,7 @@ components:
               the active System ID when forming an aggregator.
             format: integer
             length: 16
-            default: 32768
+            default: 0
             features:
               - count
               - metric_tags
@@ -116,7 +111,7 @@ components:
               in a Link Aggregation Group (LAG) when the group is full.
             format: integer
             length: 16
-            default: 32768
+            default: 0
             features:
               - count
               - metric_tags
@@ -150,14 +145,14 @@ components:
               - count
               - metric_tags
           x-field-uid: 8
-        actor_reserved:
+        reserved:
           description: Reserved field for future use in the Actor TLV. Should be
             set to all zeros.
           type: string
           format: hex
           default: '000000'
           x-field-uid: 9
-    Flow.Lacp.PartnerInformation:
+    Flow.Lacp.Partner:
       description: |-
         Information about the remote (partner) system.
       type: object
@@ -165,7 +160,7 @@ components:
         type:
           x-field-pattern:
             x-constants:
-              partner_information: 2
+              partner: 2
             description: TLV Type for Partner Information. The value 0x02 identifies
               this TLV as containing information about the remote device (the Partner),
               as understood by the Actor.
@@ -258,14 +253,14 @@ components:
               - count
               - metric_tags
           x-field-uid: 8
-        partner_reserved:
+        reserved:
           description: Reserved field for future use in the Partner TLV. Should
             be set to all zeros.
           type: string
           format: hex
           default: '000000'
           x-field-uid: 9
-    Flow.Lacp.CollectorInformation:
+    Flow.Lacp.Collector:
       description: |-
         Information about frame collection parameters.
       type: object
@@ -273,7 +268,7 @@ components:
         type:
           x-field-pattern:
             x-constants:
-              collector_information: 3
+              collector: 3
             description: TLV Type for Collector Information. The value 0x03 identifies
               this TLV.
             format: integer
@@ -306,13 +301,14 @@ components:
               - count
               - metric_tags
           x-field-uid: 3
-        collector_reserved:
+        reserved:
           description: Reserved field for future use in the Collector TLV. 12 bytes
             long and should be set to all zeros.
           type: string
+          format: hex
           default: '000000000000000000000000'
           x-field-uid: 4
-    Flow.Lacp.TerminatorInformation:
+    Flow.Lacp.Terminator:
       description: |-
         Marks the end of the LACPDU message.
       type: object
@@ -341,9 +337,10 @@ components:
               - count
               - metric_tags
           x-field-uid: 2
-        final_reserved:
+        reserved:
           description: Final block of reserved bytes to pad the PDU. It is 50 bytes
             long.
           type: string
+          format: hex
           default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
           x-field-uid: 3

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -4,6 +4,8 @@ components:
       description: Defines the fields of a Link Aggregation Control Protocol (LACP)
         Data Unit (PDU) as specified by IEEE 802.3ad.
       type: object
+      required:
+        - actor_information      
       properties:
         sub_type:
           x-field-pattern:
@@ -16,7 +18,7 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 4
+          x-field-uid: 1
         version:
           x-field-pattern:
             x-constants:
@@ -28,8 +30,36 @@ components:
             features:
               - count
               - metric_tags
+          x-field-uid: 2
+        actor_information:
+          $ref: '#/components/schemas/Flow.Lacp.ActorInformation'
+          x-field-uid: 3
+        partner_information:
+          $ref: '#/components/schemas/Flow.Lacp.PartnerInformation'
+          x-field-uid: 4
+        collection_information:
+          $ref: '#/components/schemas/Flow.Lacp.CollectorInformation'
           x-field-uid: 5
-        actor_tlv_type:
+        terminator_information:
+          $ref: '#/components/schemas/Flow.Lacp.TerminatorInformation'
+          x-field-uid: 6                              
+        fcs:
+          x-field-pattern:
+            description: Frame Check Sequence. A 32-bit CRC value used to check for
+              errors in frame transmission. It is calculated over the entire Ethernet
+              frame.
+            format: integer
+            length: 32
+            default: 0
+            features:
+              - count
+          x-field-uid: 7
+    Flow.Lacp.ActorInformation:
+      description: |-
+        Information about the local (actor) system.
+      type: object
+      properties:                       
+        type:
           x-field-pattern:
             x-constants:
               actor_information: 1
@@ -41,8 +71,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 6
-        actor_tlv_length:
+          x-field-uid: 1
+        length:
           x-field-pattern:
             description: The length of the Actor Information TLV payload in bytes.
             format: integer
@@ -51,21 +81,20 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 7
-        actor_system_priority:
+          x-field-uid: 2
+        system_priority:
           x-field-pattern:
             description: The priority assigned to the Actor's system for use in aggregation.
               A lower numerical value indicates a higher priority. Used to select
-              the active System ID when forming an aggregator. The default value is
-              32768 (0x8000).
+              the active System ID when forming an aggregator.
             format: integer
             length: 16
             default: 32768
             features:
               - count
               - metric_tags
-          x-field-uid: 8
-        actor_system:
+          x-field-uid: 3
+        system_id:
           x-field-pattern:
             description: The Actor's System ID, which is a globally unique MAC address
               assigned to the system containing the Actor.
@@ -74,8 +103,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 9
-        actor_key:
+          x-field-uid: 4
+        key:
           x-field-pattern:
             description: The operational Key value assigned to the Actor's port. The
               key is generated based on port configuration (e.g., speed, duplex, trunk
@@ -87,21 +116,20 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 10
-        actor_port_priority:
+          x-field-uid: 5
+        port_priority:
           x-field-pattern:
             description: The priority assigned to the Actor's port. A lower numerical
               value indicates a higher priority. Used to prioritize ports for inclusion
-              in a Link Aggregation Group (LAG) when the group is full. The default
-              value is 32768 (0x8000).
+              in a Link Aggregation Group (LAG) when the group is full.
             format: integer
             length: 16
             default: 32768
             features:
               - count
               - metric_tags
-          x-field-uid: 11
-        actor_port:
+          x-field-uid: 6
+        port_number:
           x-field-pattern:
             description: The port number assigned to the Actor's port. It is a unique
               identifier for the port within the system.
@@ -111,7 +139,7 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 12
+          x-field-uid: 7
         actor_state:
           x-field-pattern:
             description: 'A 1-byte bitmask indicating the Actor''s state.
@@ -129,15 +157,20 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 13
+          x-field-uid: 8
         actor_reserved:
           description: Reserved field for future use in the Actor TLV. Should be
             set to all zeros.
           type: string
           format: hex
           default: '000000'
-          x-field-uid: 14
-        partner_tlv_type:
+          x-field-uid: 9
+    Flow.Lacp.PartnerInformation:
+      description: |-
+        Information about the remote (partner) system.
+      type: object
+      properties:          
+        type:
           x-field-pattern:
             x-constants:
               partner_information: 2
@@ -150,8 +183,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 15
-        partner_tlv_length:
+          x-field-uid: 1
+        length:
           x-field-pattern:
             description: The length of the Partner Information TLV payload in bytes.
             format: integer
@@ -160,8 +193,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 16
-        partner_system_priority:
+          x-field-uid: 2
+        system_priority:
           x-field-pattern:
             description: The priority of the Partner's system, as received by the
               Actor.
@@ -171,8 +204,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 17
-        partner_system:
+          x-field-uid: 3
+        system_id:
           x-field-pattern:
             description: The Partner's System ID (MAC address), as received by the
               Actor.
@@ -181,8 +214,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 18
-        partner_key:
+          x-field-uid: 4
+        key:
           x-field-pattern:
             description: The operational Key value of the Partner's port, as received
               by the Actor.
@@ -192,8 +225,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 19
-        partner_port_priority:
+          x-field-uid: 5
+        port_priority:
           x-field-pattern:
             description: The priority of the Partner's port, as received by the Actor.
             format: integer
@@ -202,8 +235,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 20
-        partner_port:
+          x-field-uid: 6
+        port_number:
           x-field-pattern:
             description: The port number of the Partner's port, as received by the
               Actor.
@@ -213,7 +246,7 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 21
+          x-field-uid: 7
         partner_state:
           x-field-pattern:
             description: 'A 1-byte bitmask indicating the Partner''s state, as received
@@ -232,15 +265,20 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 22
+          x-field-uid: 8
         partner_reserved:
           description: Reserved field for future use in the Partner TLV. Should
             be set to all zeros.
           type: string
           format: hex
           default: '000000'
-          x-field-uid: 23
-        collector_tlv_type:
+          x-field-uid: 9
+    Flow.Lacp.CollectorInformation:
+      description: |-
+        Information about frame collection parameters.
+      type: object
+      properties:
+        type:
           x-field-pattern:
             x-constants:
               collector_information: 3
@@ -252,8 +290,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 24
-        collector_tlv_length:
+          x-field-uid: 1
+        length:
           x-field-pattern:
             description: The length of the Collector Information TLV payload in bytes.
               The value must be 16 (0x10).
@@ -263,8 +301,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 25
-        collector_max_delay:
+          x-field-uid: 2
+        max_delay:
           x-field-pattern:
             description: Indicates the maximum delay, in units of 10 microseconds,
               that the transmitting system's aggregator will take to buffer frames
@@ -275,14 +313,19 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 26
+          x-field-uid: 3
         collector_reserved:
           description: Reserved field for future use in the Collector TLV. 12 bytes
             long and should be set to all zeros.
           type: string
           default: '000000000000000000000000'
-          x-field-uid: 27
-        terminator_tlv_type:
+          x-field-uid: 4
+    Flow.Lacp.TerminatorInformation:
+      description: |-
+        Marks the end of the LACPDU message.
+      type: object
+      properties:          
+        type:
           x-field-pattern:
             x-constants:
               terminator: 0
@@ -294,8 +337,8 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 28
-        terminator_tlv_length:
+          x-field-uid: 1
+        length:
           x-field-pattern:
             description: The length of the Terminator TLV payload. The value must
               be 0.
@@ -305,22 +348,10 @@ components:
             features:
               - count
               - metric_tags
-          x-field-uid: 29
+          x-field-uid: 2
         final_reserved:
           description: Final block of reserved bytes to pad the PDU. It is 50 bytes
             long.
           type: string
           default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-
-          x-field-uid: 30
-        fcs:
-          x-field-pattern:
-            description: Frame Check Sequence. A 32-bit CRC value used to check for
-              errors in frame transmission. It is calculated over the entire Ethernet
-              frame.
-            format: integer
-            length: 32
-            default: 0
-            features:
-              - count
-          x-field-uid: 31
+          x-field-uid: 3

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -45,18 +45,7 @@ components:
           x-field-uid: 5
         terminator_information:
           $ref: '#/components/schemas/Flow.Lacp.TerminatorInformation'
-          x-field-uid: 6                              
-        fcs:
-          x-field-pattern:
-            description: Frame Check Sequence. A 32-bit CRC value used to check for
-              errors in frame transmission. It is calculated over the entire Ethernet
-              frame.
-            format: integer
-            length: 32
-            default: 0
-            features:
-              - count
-          x-field-uid: 7
+          x-field-uid: 6
     Flow.Lacp.ActorInformation:
       description: |-
         Information about the local (actor) system.

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -114,7 +114,7 @@ components:
           x-field-uid: 12
         actor_state:
           x-field-pattern:
-            description: 'A 1-byte bitmask indicating the Actor''s state. 
+            description: 'A 1-byte bitmask indicating the Actor''s state.\n 
               Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) 
               Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) 
               Bit 2: Aggregation (1=Aggregatable, 0=Individual) 

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -5,7 +5,10 @@ components:
         Data Unit (PDU) as specified by IEEE 802.3ad.
       type: object
       required:
-        - actor_information      
+        - actor_information
+        - partner_information
+        - collection_information
+        - terminator_information
       properties:
         sub_type:
           x-field-pattern:

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -1,0 +1,353 @@
+components:
+  schemas:
+    Flow.Lacp:
+      description: Defines the fields of a Link Aggregation Control Protocol (LACP)
+        Data Unit (PDU) as specified by IEEE 802.3ad. LACP is a Slow Protocol (EtherType
+        0x8809) used for dynamic link aggregation.
+      type: object
+      properties:
+        subtype:
+          x-field-uid: 1
+          x-field-pattern:
+            description: Identifies the specific Slow Protocol. For LACP, this value
+              is always 1.
+            format: integer
+            length: 8
+            default: 1
+            features:
+            - count
+            - metric_tags
+        version:
+          x-field-uid: 2
+          x-field-pattern:
+            description: The version of the LACP protocol being used. For the standard
+              defined in IEEE 802.3ad, this value is always 1.
+            format: integer
+            length: 8
+            default: 1
+            features:
+            - count
+            - metric_tags
+        actor:
+          x-field-uid: 3
+          description: A block of fields containing information about the Actor, which
+            is the local device transmitting the LACPDU.
+          type: object
+          properties:
+            tlv_type:
+              x-field-uid: 4
+              x-field-pattern:
+                description: The Type-Length-Value (TLV) type identifier for Actor
+                  information. This is fixed to 1.
+                format: integer
+                length: 8
+                default: 1
+                features:
+                - count
+                - metric_tags
+            tlv_length:
+              x-field-uid: 5
+              x-field-pattern:
+                description: The length of the Actor information block, in bytes.
+                  This is fixed to 20 (0x14).
+                format: integer
+                length: 8
+                default: 20
+                features:
+                - count
+                - metric_tags
+            system_priority:
+              x-field-uid: 6
+              x-field-pattern:
+                description: The priority assigned to the Actor's system. Used in
+                  conjunction with the system MAC address to form the System ID and
+                  determine which system is the master. A lower numerical value indicates
+                  a higher priority. The default value is 32768.
+                format: integer
+                length: 16
+                default: 32768
+                features:
+                - count
+                - metric_tags
+            system:
+              x-field-uid: 7
+              x-field-pattern:
+                description: The MAC address of the Actor system. This globally unique
+                  value is a key component of the System Identifier.
+                format: mac
+                length: 48
+                default: 00:00:00:00:00:00
+                features:
+                - count
+                - metric_tags
+            key:
+              x-field-uid: 8
+              x-field-pattern:
+                description: An operational key value assigned to the Actor's port.
+                  Ports with the same key are considered part of the same potential
+                  Link Aggregation Group (LAG). The value is determined by port characteristics
+                  like speed and duplex mode.
+                format: integer
+                length: 16
+                default: 0
+                features:
+                - count
+                - metric_tags
+            port_priority:
+              x-field-uid: 9
+              x-field-pattern:
+                description: The priority assigned to the Actor's port within its
+                  system. This value is used to decide which ports will become active
+                  in a LAG if there are more eligible ports than the configured limit.
+                  A lower numerical value indicates a higher priority. The default
+                  value is 32768.
+                format: integer
+                length: 16
+                default: 32768
+                features:
+                - count
+                - metric_tags
+            port:
+              x-field-uid: 10
+              x-field-pattern:
+                description: The unique port number assigned to the Actor's port.
+                format: integer
+                length: 16
+                default: 0
+                features:
+                - count
+                - metric_tags
+            state:
+              x-field-uid: 11
+              x-field-pattern:
+                description: 'An 8-bit mask describing the state of the Actor''s port.
+                  Bit 0 (LSB): LACP Activity (1=Active, 0=Passive). Bit 1: LACP Timeout
+                  (1=Fast/1s, 0=Slow/30s). Bit 2: Aggregation (1=Aggregatable, 0=Individual).
+                  Bit 3: Synchronization (1=In Sync, 0=Out of Sync). Bit 4: Collecting
+                  (1=Enabled, 0=Disabled). Bit 5: Distributing (1=Enabled, 0=Disabled).
+                  Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received
+                  partner info). Bit 7: Expired (1=LACPDU receiver is expired, 0=Normal).'
+                format: integer
+                length: 8
+                default: 0
+                features:
+                - count
+                - metric_tags
+            reserved:
+              x-field-uid: 12
+              x-field-pattern:
+                description: Reserved for future use. Must be set to all zeros.
+                format: hex
+                length: 24
+                default: '000000'
+                features:
+                - count
+                - metric_tags
+        partner:
+          x-field-uid: 13
+          description: A block of fields containing information about the Partner,
+            which is the remote device as perceived by the Actor.
+          type: object
+          properties:
+            tlv_type:
+              x-field-uid: 14
+              x-field-pattern:
+                description: The Type-Length-Value (TLV) type identifier for Partner
+                  information. This is fixed to 2.
+                format: integer
+                length: 8
+                default: 2
+                features:
+                - count
+                - metric_tags
+            tlv_length:
+              x-field-uid: 15
+              x-field-pattern:
+                description: The length of the Partner information block, in bytes.
+                  This is fixed to 20 (0x14).
+                format: integer
+                length: 8
+                default: 20
+                features:
+                - count
+                - metric_tags
+            system_priority:
+              x-field-uid: 16
+              x-field-pattern:
+                description: The system priority of the Partner, as received in a
+                  previous LACPDU. If no information has been received, this is set
+                  to zero.
+                format: integer
+                length: 16
+                default: 0
+                features:
+                - count
+                - metric_tags
+            system:
+              x-field-uid: 17
+              x-field-pattern:
+                description: The MAC address of the Partner system, as received in
+                  a previous LACPDU. If no information has been received, this is
+                  set to all zeros.
+                format: mac
+                length: 48
+                default: 00:00:00:00:00:00
+                features:
+                - count
+                - metric_tags
+            key:
+              x-field-uid: 18
+              x-field-pattern:
+                description: The operational key value of the Partner's port, as received
+                  in a previous LACPDU.
+                format: integer
+                length: 16
+                default: 0
+                features:
+                - count
+                - metric_tags
+            port_priority:
+              x-field-uid: 19
+              x-field-pattern:
+                description: The priority of the Partner's port, as received in a
+                  previous LACPDU.
+                format: integer
+                length: 16
+                default: 0
+                features:
+                - count
+                - metric_tags
+            port:
+              x-field-uid: 20
+              x-field-pattern:
+                description: The port number of the Partner's port, as received in
+                  a previous LACPDU.
+                format: integer
+                length: 16
+                default: 0
+                features:
+                - count
+                - metric_tags
+            state:
+              x-field-uid: 21
+              x-field-pattern:
+                description: An 8-bit mask describing the state of the Partner's port,
+                  as received in a previous LACPDU. The bit definitions are identical
+                  to the Actor state.
+                format: integer
+                length: 8
+                default: 0
+                features:
+                - count
+                - metric_tags
+            reserved:
+              x-field-uid: 22
+              x-field-pattern:
+                description: Reserved for future use. Must be set to all zeros.
+                format: hex
+                length: 24
+                default: '000000'
+                features:
+                - count
+                - metric_tags
+        collector:
+          x-field-uid: 23
+          description: A block of fields containing information related to the frame
+            collector.
+          type: object
+          properties:
+            tlv_type:
+              x-field-uid: 24
+              x-field-pattern:
+                description: The Type-Length-Value (TLV) type identifier for Collector
+                  information. This is fixed to 3.
+                format: integer
+                length: 8
+                default: 3
+                features:
+                - count
+                - metric_tags
+            tlv_length:
+              x-field-uid: 25
+              x-field-pattern:
+                description: The length of the Collector information block, in bytes.
+                  This is fixed to 16 (0x10).
+                format: integer
+                length: 8
+                default: 16
+                features:
+                - count
+                - metric_tags
+            max_delay:
+              x-field-uid: 26
+              x-field-pattern:
+                description: The maximum delay, in units of 10 microseconds, that
+                  the Actor asserts for the aggregation. This informs the partner
+                  of the maximum time it may need to buffer frames.
+                format: integer
+                length: 16
+                default: 0
+                features:
+                - count
+                - metric_tags
+            reserved:
+              x-field-uid: 27
+              x-field-pattern:
+                description: Reserved for future use. Must be set to all zeros.
+                format: hex
+                length: 96
+                default: '000000000000000000000000'
+                features:
+                - count
+                - metric_tags
+        terminator:
+          x-field-uid: 28
+          description: A block of fields that marks the end of the meaningful LACP
+            information in the PDU.
+          type: object
+          properties:
+            tlv_type:
+              x-field-uid: 29
+              x-field-pattern:
+                description: The Type-Length-Value (TLV) type identifier for the Terminator.
+                  This is fixed to 0.
+                format: integer
+                length: 8
+                default: 0
+                features:
+                - count
+                - metric_tags
+            tlv_length:
+              x-field-uid: 30
+              x-field-pattern:
+                description: The length of the Terminator information block, in bytes.
+                  This is fixed to 0.
+                format: integer
+                length: 8
+                default: 0
+                features:
+                - count
+                - metric_tags
+            reserved:
+              x-field-uid: 31
+              x-field-pattern:
+                description: Reserved padding to meet the minimum Ethernet frame size.
+                  This field is 50 bytes long and must be set to all zeros.
+                format: hex
+                length: 400
+                default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                features:
+                - count
+                - metric_tags
+        fcs:
+          x-field-uid: 32
+          x-field-pattern:
+            description: Frame Check Sequence. A 32-bit Cyclic Redundancy Check (CRC)
+              value used to detect accidental alterations of data during transmission.
+              This is typically calculated and checked by hardware.
+            format: integer
+            length: 32
+            default: 0
+            features:
+            - count
+            - metric_tags

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -114,7 +114,7 @@ components:
           x-field-uid: 12
         actor_state:
           x-field-pattern:
-            description: 'A 1-byte bitmask indicating the Actor''s state.\n 
+            description: 'A 1-byte bitmask indicating the Actor''s state.
               Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) 
               Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) 
               Bit 2: Aggregation (1=Aggregatable, 0=Individual) 

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -2,49 +2,14 @@ components:
   schemas:
     Flow.Lacp:
       description: Defines the fields of a Link Aggregation Control Protocol (LACP)
-        Data Unit (PDU) as specified by IEEE 802.3ad. LACP is a Slow Protocol (EtherType
-        0x8809) used for dynamic link aggregation.
+        Data Unit (PDU) as specified by IEEE 802.3ad.
       type: object
       properties:
-        destination_address:
-          x-field-pattern:
-            description: The destination MAC address. For LACP, this is the special
-              multicast address 01-80-C2-00-00-02 used for Slow Protocols.
-            format: mac
-            default: 01:80:C2:00:00:02
-            features:
-              - count
-              - metric_tags
-          x-field-uid: 1
-        source_address:
-          x-field-pattern:
-            description: The source MAC address of the physical port through which
-              the LACPDU is transmitted.
-            format: mac
-            default: 00:00:00:00:00:00
-            features:
-              - count
-              - metric_tags
-          x-field-uid: 2
-        length_type:
-          x-field-pattern:
-            x-constants:
-              slow_protocols: 34825
-            description: Ethernet Type field. It must be set to 0x8809 to indicate
-              a Slow Protocol like LACP.
-            format: integer
-            length: 16
-            default: 34825
-            features:
-              - count
-              - metric_tags
-          x-field-uid: 3
         sub_type:
           x-field-pattern:
             x-constants:
               lacp: 1
-            description: Indicates the specific Slow Protocol subtype. It must be
-              set to 0x01 for LACPDUs.
+            description: Indicates the specific Slow Protocol subtype.
             format: integer
             length: 8
             default: 1
@@ -56,7 +21,7 @@ components:
           x-field-pattern:
             x-constants:
               v1: 1
-            description: The LACP version number. It must be set to 0x01.
+            description: The LACP version number.
             format: integer
             length: 8
             default: 1
@@ -80,7 +45,6 @@ components:
         actor_tlv_length:
           x-field-pattern:
             description: The length of the Actor Information TLV payload in bytes.
-              The value must be 20 (0x14).
             format: integer
             length: 8
             default: 20
@@ -150,13 +114,15 @@ components:
           x-field-uid: 12
         actor_state:
           x-field-pattern:
-            description: 'A 1-byte bitmask indicating the Actor''s state. Bit 0 (LSB):
-                  LACP_Activity (1=Active, 0=Passive) Bit 1: LACP_Timeout (1=Fast timeout,
-                  0=Slow timeout) Bit 2: Aggregation (1=Aggregatable, 0=Individual) Bit
-                  3: Synchronization (1=In Sync, 0=Out of Sync) Bit 4: Collecting (1=Enabled,
-                  0=Disabled) Bit 5: Distributing (1=Enabled, 0=Disabled) Bit 6: Defaulted
-                  (1=Using defaulted partner info, 0=Using received partner info) Bit
-                  7 (MSB): Expired (1=Expired, 0=Not Expired)'
+            description: 'A 1-byte bitmask indicating the Actor''s state. 
+              Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) 
+              Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) 
+              Bit 2: Aggregation (1=Aggregatable, 0=Individual) 
+              Bit 3: Synchronization (1=In Sync, 0=Out of Sync) 
+              Bit 4: Collecting (1=Enabled, 0=Disabled) 
+              Bit 5: Distributing (1=Enabled, 0=Disabled) 
+              Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received partner info) 
+              Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)'
             format: integer
             length: 8
             default: 0
@@ -188,7 +154,6 @@ components:
         partner_tlv_length:
           x-field-pattern:
             description: The length of the Partner Information TLV payload in bytes.
-              The value must be 20 (0x14).
             format: integer
             length: 8
             default: 20
@@ -199,8 +164,7 @@ components:
         partner_system_priority:
           x-field-pattern:
             description: The priority of the Partner's system, as received by the
-              Actor. If no LACPDU has been received from the partner, this is set
-              to zero.
+              Actor.
             format: integer
             length: 16
             default: 0
@@ -211,8 +175,7 @@ components:
         partner_system:
           x-field-pattern:
             description: The Partner's System ID (MAC address), as received by the
-              Actor. If no LACPDU has been received from the partner, this is set
-              to all zeros.
+              Actor.
             format: mac
             default: 00:00:00:00:00:00
             features:
@@ -254,12 +217,15 @@ components:
         partner_state:
           x-field-pattern:
             description: 'A 1-byte bitmask indicating the Partner''s state, as received
-                  by the Actor. Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) Bit 1:
-                  LACP_Timeout (1=Fast timeout, 0=Slow timeout) Bit 2: Aggregation (1=Aggregatable,
-                  0=Individual) Bit 3: Synchronization (1=In Sync, 0=Out of Sync) Bit
-                  4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing (1=Enabled,
-                  0=Disabled) Bit 6: Defaulted (1=Using defaulted partner info, 0=Using
-                  received partner info) Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)'
+                  by the Actor. 
+                  Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) 
+                  Bit 1: LACP_Timeout (1=Fast timeout, 0=Slow timeout) 
+                  Bit 2: Aggregation (1=Aggregatable, 0=Individual) 
+                  Bit 3: Synchronization (1=In Sync, 0=Out of Sync) 
+                  Bit 4: Collecting (1=Enabled, 0=Disabled) 
+                  Bit 5: Distributing (1=Enabled, 0=Disabled) 
+                  Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received partner info) 
+                  Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)'
             format: integer
             length: 8
             default: 0
@@ -342,7 +308,7 @@ components:
           x-field-uid: 29
         final_reserved:
           description: Final block of reserved bytes to pad the PDU. It is 50 bytes
-            long, set to all zeros, and ignored on receipt.
+            long.
           type: string
           default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
 

--- a/flow/packet-headers/lacp.yaml
+++ b/flow/packet-headers/lacp.yaml
@@ -6,348 +6,355 @@ components:
         0x8809) used for dynamic link aggregation.
       type: object
       properties:
-        subtype:
+        destination_address:
+          x-field-pattern:
+            description: The destination MAC address. For LACP, this is the special
+              multicast address 01-80-C2-00-00-02 used for Slow Protocols.
+            format: mac
+            default: 01:80:C2:00:00:02
+            features:
+              - count
+              - metric_tags
           x-field-uid: 1
+        source_address:
           x-field-pattern:
-            description: Identifies the specific Slow Protocol. For LACP, this value
-              is always 1.
-            format: integer
-            length: 8
-            default: 1
+            description: The source MAC address of the physical port through which
+              the LACPDU is transmitted.
+            format: mac
+            default: 00:00:00:00:00:00
             features:
-            - count
-            - metric_tags
-        version:
+              - count
+              - metric_tags
           x-field-uid: 2
+        length_type:
           x-field-pattern:
-            description: The version of the LACP protocol being used. For the standard
-              defined in IEEE 802.3ad, this value is always 1.
+            x-constants:
+              slow_protocols: 34825
+            description: Ethernet Type field. It must be set to 0x8809 to indicate
+              a Slow Protocol like LACP.
+            format: integer
+            length: 16
+            default: 34825
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 3
+        sub_type:
+          x-field-pattern:
+            x-constants:
+              lacp: 1
+            description: Indicates the specific Slow Protocol subtype. It must be
+              set to 0x01 for LACPDUs.
             format: integer
             length: 8
             default: 1
             features:
-            - count
-            - metric_tags
-        actor:
-          x-field-uid: 3
-          description: A block of fields containing information about the Actor, which
-            is the local device transmitting the LACPDU.
-          type: object
-          properties:
-            tlv_type:
-              x-field-uid: 4
-              x-field-pattern:
-                description: The Type-Length-Value (TLV) type identifier for Actor
-                  information. This is fixed to 1.
-                format: integer
-                length: 8
-                default: 1
-                features:
-                - count
-                - metric_tags
-            tlv_length:
-              x-field-uid: 5
-              x-field-pattern:
-                description: The length of the Actor information block, in bytes.
-                  This is fixed to 20 (0x14).
-                format: integer
-                length: 8
-                default: 20
-                features:
-                - count
-                - metric_tags
-            system_priority:
-              x-field-uid: 6
-              x-field-pattern:
-                description: The priority assigned to the Actor's system. Used in
-                  conjunction with the system MAC address to form the System ID and
-                  determine which system is the master. A lower numerical value indicates
-                  a higher priority. The default value is 32768.
-                format: integer
-                length: 16
-                default: 32768
-                features:
-                - count
-                - metric_tags
-            system:
-              x-field-uid: 7
-              x-field-pattern:
-                description: The MAC address of the Actor system. This globally unique
-                  value is a key component of the System Identifier.
-                format: mac
-                length: 48
-                default: 00:00:00:00:00:00
-                features:
-                - count
-                - metric_tags
-            key:
-              x-field-uid: 8
-              x-field-pattern:
-                description: An operational key value assigned to the Actor's port.
-                  Ports with the same key are considered part of the same potential
-                  Link Aggregation Group (LAG). The value is determined by port characteristics
-                  like speed and duplex mode.
-                format: integer
-                length: 16
-                default: 0
-                features:
-                - count
-                - metric_tags
-            port_priority:
-              x-field-uid: 9
-              x-field-pattern:
-                description: The priority assigned to the Actor's port within its
-                  system. This value is used to decide which ports will become active
-                  in a LAG if there are more eligible ports than the configured limit.
-                  A lower numerical value indicates a higher priority. The default
-                  value is 32768.
-                format: integer
-                length: 16
-                default: 32768
-                features:
-                - count
-                - metric_tags
-            port:
-              x-field-uid: 10
-              x-field-pattern:
-                description: The unique port number assigned to the Actor's port.
-                format: integer
-                length: 16
-                default: 0
-                features:
-                - count
-                - metric_tags
-            state:
-              x-field-uid: 11
-              x-field-pattern:
-                description: 'An 8-bit mask describing the state of the Actor''s port.
-                  Bit 0 (LSB): LACP Activity (1=Active, 0=Passive). Bit 1: LACP Timeout
-                  (1=Fast/1s, 0=Slow/30s). Bit 2: Aggregation (1=Aggregatable, 0=Individual).
-                  Bit 3: Synchronization (1=In Sync, 0=Out of Sync). Bit 4: Collecting
-                  (1=Enabled, 0=Disabled). Bit 5: Distributing (1=Enabled, 0=Disabled).
-                  Bit 6: Defaulted (1=Using defaulted partner info, 0=Using received
-                  partner info). Bit 7: Expired (1=LACPDU receiver is expired, 0=Normal).'
-                format: integer
-                length: 8
-                default: 0
-                features:
-                - count
-                - metric_tags
-            reserved:
-              x-field-uid: 12
-              x-field-pattern:
-                description: Reserved for future use. Must be set to all zeros.
-                format: hex
-                length: 24
-                default: '000000'
-                features:
-                - count
-                - metric_tags
-        partner:
-          x-field-uid: 13
-          description: A block of fields containing information about the Partner,
-            which is the remote device as perceived by the Actor.
-          type: object
-          properties:
-            tlv_type:
-              x-field-uid: 14
-              x-field-pattern:
-                description: The Type-Length-Value (TLV) type identifier for Partner
-                  information. This is fixed to 2.
-                format: integer
-                length: 8
-                default: 2
-                features:
-                - count
-                - metric_tags
-            tlv_length:
-              x-field-uid: 15
-              x-field-pattern:
-                description: The length of the Partner information block, in bytes.
-                  This is fixed to 20 (0x14).
-                format: integer
-                length: 8
-                default: 20
-                features:
-                - count
-                - metric_tags
-            system_priority:
-              x-field-uid: 16
-              x-field-pattern:
-                description: The system priority of the Partner, as received in a
-                  previous LACPDU. If no information has been received, this is set
-                  to zero.
-                format: integer
-                length: 16
-                default: 0
-                features:
-                - count
-                - metric_tags
-            system:
-              x-field-uid: 17
-              x-field-pattern:
-                description: The MAC address of the Partner system, as received in
-                  a previous LACPDU. If no information has been received, this is
-                  set to all zeros.
-                format: mac
-                length: 48
-                default: 00:00:00:00:00:00
-                features:
-                - count
-                - metric_tags
-            key:
-              x-field-uid: 18
-              x-field-pattern:
-                description: The operational key value of the Partner's port, as received
-                  in a previous LACPDU.
-                format: integer
-                length: 16
-                default: 0
-                features:
-                - count
-                - metric_tags
-            port_priority:
-              x-field-uid: 19
-              x-field-pattern:
-                description: The priority of the Partner's port, as received in a
-                  previous LACPDU.
-                format: integer
-                length: 16
-                default: 0
-                features:
-                - count
-                - metric_tags
-            port:
-              x-field-uid: 20
-              x-field-pattern:
-                description: The port number of the Partner's port, as received in
-                  a previous LACPDU.
-                format: integer
-                length: 16
-                default: 0
-                features:
-                - count
-                - metric_tags
-            state:
-              x-field-uid: 21
-              x-field-pattern:
-                description: An 8-bit mask describing the state of the Partner's port,
-                  as received in a previous LACPDU. The bit definitions are identical
-                  to the Actor state.
-                format: integer
-                length: 8
-                default: 0
-                features:
-                - count
-                - metric_tags
-            reserved:
-              x-field-uid: 22
-              x-field-pattern:
-                description: Reserved for future use. Must be set to all zeros.
-                format: hex
-                length: 24
-                default: '000000'
-                features:
-                - count
-                - metric_tags
-        collector:
-          x-field-uid: 23
-          description: A block of fields containing information related to the frame
-            collector.
-          type: object
-          properties:
-            tlv_type:
-              x-field-uid: 24
-              x-field-pattern:
-                description: The Type-Length-Value (TLV) type identifier for Collector
-                  information. This is fixed to 3.
-                format: integer
-                length: 8
-                default: 3
-                features:
-                - count
-                - metric_tags
-            tlv_length:
-              x-field-uid: 25
-              x-field-pattern:
-                description: The length of the Collector information block, in bytes.
-                  This is fixed to 16 (0x10).
-                format: integer
-                length: 8
-                default: 16
-                features:
-                - count
-                - metric_tags
-            max_delay:
-              x-field-uid: 26
-              x-field-pattern:
-                description: The maximum delay, in units of 10 microseconds, that
-                  the Actor asserts for the aggregation. This informs the partner
-                  of the maximum time it may need to buffer frames.
-                format: integer
-                length: 16
-                default: 0
-                features:
-                - count
-                - metric_tags
-            reserved:
-              x-field-uid: 27
-              x-field-pattern:
-                description: Reserved for future use. Must be set to all zeros.
-                format: hex
-                length: 96
-                default: '000000000000000000000000'
-                features:
-                - count
-                - metric_tags
-        terminator:
-          x-field-uid: 28
-          description: A block of fields that marks the end of the meaningful LACP
-            information in the PDU.
-          type: object
-          properties:
-            tlv_type:
-              x-field-uid: 29
-              x-field-pattern:
-                description: The Type-Length-Value (TLV) type identifier for the Terminator.
-                  This is fixed to 0.
-                format: integer
-                length: 8
-                default: 0
-                features:
-                - count
-                - metric_tags
-            tlv_length:
-              x-field-uid: 30
-              x-field-pattern:
-                description: The length of the Terminator information block, in bytes.
-                  This is fixed to 0.
-                format: integer
-                length: 8
-                default: 0
-                features:
-                - count
-                - metric_tags
-            reserved:
-              x-field-uid: 31
-              x-field-pattern:
-                description: Reserved padding to meet the minimum Ethernet frame size.
-                  This field is 50 bytes long and must be set to all zeros.
-                format: hex
-                length: 400
-                default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                features:
-                - count
-                - metric_tags
-        fcs:
-          x-field-uid: 32
+              - count
+              - metric_tags
+          x-field-uid: 4
+        version:
           x-field-pattern:
-            description: Frame Check Sequence. A 32-bit Cyclic Redundancy Check (CRC)
-              value used to detect accidental alterations of data during transmission.
-              This is typically calculated and checked by hardware.
+            x-constants:
+              v1: 1
+            description: The LACP version number. It must be set to 0x01.
+            format: integer
+            length: 8
+            default: 1
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 5
+        actor_tlv_type:
+          x-field-pattern:
+            x-constants:
+              actor_information: 1
+            description: TLV Type for Actor Information. The value 0x01 identifies
+              this TLV as containing information about the sending device (the Actor).
+            format: integer
+            length: 8
+            default: 1
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 6
+        actor_tlv_length:
+          x-field-pattern:
+            description: The length of the Actor Information TLV payload in bytes.
+              The value must be 20 (0x14).
+            format: integer
+            length: 8
+            default: 20
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 7
+        actor_system_priority:
+          x-field-pattern:
+            description: The priority assigned to the Actor's system for use in aggregation.
+              A lower numerical value indicates a higher priority. Used to select
+              the active System ID when forming an aggregator. The default value is
+              32768 (0x8000).
+            format: integer
+            length: 16
+            default: 32768
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 8
+        actor_system:
+          x-field-pattern:
+            description: The Actor's System ID, which is a globally unique MAC address
+              assigned to the system containing the Actor.
+            format: mac
+            default: 00:00:00:00:00:00
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 9
+        actor_key:
+          x-field-pattern:
+            description: The operational Key value assigned to the Actor's port. The
+              key is generated based on port configuration (e.g., speed, duplex, trunk
+              ID) and is used to identify potential aggregation groups. Only links
+              with the same key can be aggregated together.
+            format: integer
+            length: 16
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 10
+        actor_port_priority:
+          x-field-pattern:
+            description: The priority assigned to the Actor's port. A lower numerical
+              value indicates a higher priority. Used to prioritize ports for inclusion
+              in a Link Aggregation Group (LAG) when the group is full. The default
+              value is 32768 (0x8000).
+            format: integer
+            length: 16
+            default: 32768
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 11
+        actor_port:
+          x-field-pattern:
+            description: The port number assigned to the Actor's port. It is a unique
+              identifier for the port within the system.
+            format: integer
+            length: 16
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 12
+        actor_state:
+          x-field-pattern:
+            description: 'A 1-byte bitmask indicating the Actor''s state. Bit 0 (LSB):
+                  LACP_Activity (1=Active, 0=Passive) Bit 1: LACP_Timeout (1=Fast timeout,
+                  0=Slow timeout) Bit 2: Aggregation (1=Aggregatable, 0=Individual) Bit
+                  3: Synchronization (1=In Sync, 0=Out of Sync) Bit 4: Collecting (1=Enabled,
+                  0=Disabled) Bit 5: Distributing (1=Enabled, 0=Disabled) Bit 6: Defaulted
+                  (1=Using defaulted partner info, 0=Using received partner info) Bit
+                  7 (MSB): Expired (1=Expired, 0=Not Expired)'
+            format: integer
+            length: 8
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 13
+        actor_reserved:
+          description: Reserved field for future use in the Actor TLV. Should be
+            set to all zeros.
+          type: string
+          format: hex
+          default: '000000'
+          x-field-uid: 14
+        partner_tlv_type:
+          x-field-pattern:
+            x-constants:
+              partner_information: 2
+            description: TLV Type for Partner Information. The value 0x02 identifies
+              this TLV as containing information about the remote device (the Partner),
+              as understood by the Actor.
+            format: integer
+            length: 8
+            default: 2
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 15
+        partner_tlv_length:
+          x-field-pattern:
+            description: The length of the Partner Information TLV payload in bytes.
+              The value must be 20 (0x14).
+            format: integer
+            length: 8
+            default: 20
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 16
+        partner_system_priority:
+          x-field-pattern:
+            description: The priority of the Partner's system, as received by the
+              Actor. If no LACPDU has been received from the partner, this is set
+              to zero.
+            format: integer
+            length: 16
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 17
+        partner_system:
+          x-field-pattern:
+            description: The Partner's System ID (MAC address), as received by the
+              Actor. If no LACPDU has been received from the partner, this is set
+              to all zeros.
+            format: mac
+            default: 00:00:00:00:00:00
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 18
+        partner_key:
+          x-field-pattern:
+            description: The operational Key value of the Partner's port, as received
+              by the Actor.
+            format: integer
+            length: 16
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 19
+        partner_port_priority:
+          x-field-pattern:
+            description: The priority of the Partner's port, as received by the Actor.
+            format: integer
+            length: 16
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 20
+        partner_port:
+          x-field-pattern:
+            description: The port number of the Partner's port, as received by the
+              Actor.
+            format: integer
+            length: 16
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 21
+        partner_state:
+          x-field-pattern:
+            description: 'A 1-byte bitmask indicating the Partner''s state, as received
+                  by the Actor. Bit 0 (LSB): LACP_Activity (1=Active, 0=Passive) Bit 1:
+                  LACP_Timeout (1=Fast timeout, 0=Slow timeout) Bit 2: Aggregation (1=Aggregatable,
+                  0=Individual) Bit 3: Synchronization (1=In Sync, 0=Out of Sync) Bit
+                  4: Collecting (1=Enabled, 0=Disabled) Bit 5: Distributing (1=Enabled,
+                  0=Disabled) Bit 6: Defaulted (1=Using defaulted partner info, 0=Using
+                  received partner info) Bit 7 (MSB): Expired (1=Expired, 0=Not Expired)'
+            format: integer
+            length: 8
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 22
+        partner_reserved:
+          description: Reserved field for future use in the Partner TLV. Should
+            be set to all zeros.
+          type: string
+          format: hex
+          default: '000000'
+          x-field-uid: 23
+        collector_tlv_type:
+          x-field-pattern:
+            x-constants:
+              collector_information: 3
+            description: TLV Type for Collector Information. The value 0x03 identifies
+              this TLV.
+            format: integer
+            length: 8
+            default: 3
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 24
+        collector_tlv_length:
+          x-field-pattern:
+            description: The length of the Collector Information TLV payload in bytes.
+              The value must be 16 (0x10).
+            format: integer
+            length: 8
+            default: 16
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 25
+        collector_max_delay:
+          x-field-pattern:
+            description: Indicates the maximum delay, in units of 10 microseconds,
+              that the transmitting system's aggregator will take to buffer frames
+              from its collector before emitting a frame.
+            format: integer
+            length: 16
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 26
+        collector_reserved:
+          description: Reserved field for future use in the Collector TLV. 12 bytes
+            long and should be set to all zeros.
+          type: string
+          default: '000000000000000000000000'
+          x-field-uid: 27
+        terminator_tlv_type:
+          x-field-pattern:
+            x-constants:
+              terminator: 0
+            description: TLV Type for Terminator Information. The value 0x00 indicates
+              the end of the TLV list.
+            format: integer
+            length: 8
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 28
+        terminator_tlv_length:
+          x-field-pattern:
+            description: The length of the Terminator TLV payload. The value must
+              be 0.
+            format: integer
+            length: 8
+            default: 0
+            features:
+              - count
+              - metric_tags
+          x-field-uid: 29
+        final_reserved:
+          description: Final block of reserved bytes to pad the PDU. It is 50 bytes
+            long, set to all zeros, and ignored on receipt.
+          type: string
+          default: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+
+          x-field-uid: 30
+        fcs:
+          x-field-pattern:
+            description: Frame Check Sequence. A 32-bit CRC value used to check for
+              errors in frame transmission. It is calculated over the entire Ethernet
+              frame.
             format: integer
             length: 32
             default: 0
             features:
-            - count
-            - metric_tags
+              - count
+          x-field-uid: 31


### PR DESCRIPTION
**LACP Header Support**

[Redocly view of proposed model](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/lacp_header_modi/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config)

Proposal is for LACP header (without Ethernet). Since this is a port endpoint support (and not device), user has to config Ethernet destination address explicitly (auto support can not be provided).

```
...
f1Eth := flow.Packet().Add().Ethernet()
f1Eth.Src().SetValue("00:00:00:00:00:AA")
f1Eth.Dst().SetValue("00:00:00:00:00:BB")

f1Lacp := flow.Packet().Add().Lacp()
f1Lacp.SubType().SetValue(1)

f1LacpActor := f1Lacp.Actor()
f1LacpActor.SystemPriority().SetValue(32768)
f1LacpActor.SystemId().SetValue("00:00:00:00:00:AA")
f1LacpActor.Key().SetValue(13)
f1LacpActor.PortPriority().SetValue(32768)
f1LacpActor.PortNumber().SetValue(25)
f1LacpActor.ActorState().SetValue(54)

f1LacpPartner := f1Lacp.Partner()
f1LacpPartner.SystemPriority().SetValue(32768)
f1LacpPartner.SystemId().SetValue("00:0c:29:1e:a2:6d")
f1LacpPartner.Key().SetValue(1)
f1LacpPartner.PortPriority().SetValue(32768)
f1LacpPartner.PortNumber().SetValue(1)
f1LacpPartner.PartnerState().SetValue(61)
```