### PR TITLE
Introduce option of "Capture Slice" in retrieving captured packets

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -27421,6 +27421,50 @@ components:
           x-constraint:
           - /components/schemas/Port/properties/name
           x-field-uid: 1
+        packets:
+          description: |-
+            Specification of which packets to be captured on the given port.
+          $ref: '#/components/schemas/CaptureRequest.Packets'
+          x-field-uid: 2
+    CaptureRequest.Packets:
+      type: object
+      description: |-
+        The packets to be captured on the given port.
+      properties:
+        choice:
+          type: string
+          default: all
+          x-field-uid: 1
+          x-enum:
+            all:
+              x-field-uid: 1
+            slice:
+              x-field-uid: 2
+          enum:
+          - all
+          - slice
+        slice:
+          $ref: '#/components/schemas/CaptureRequest.CaptureSlice'
+          x-field-uid: 2
+    CaptureRequest.CaptureSlice:
+      description: |-
+        Packets to be captured based on specification of capture slice through start index and packet count.
+      type: object
+      properties:
+        start:
+          description: |-
+            Index of the packet in the generated packet sequence from where capture would start.
+          type: integer
+          format: uint64
+          default: 0
+          x-field-uid: 1
+        count:
+          description: |-
+            Number of packets to be captured from the start index.
+          type: integer
+          format: uint64
+          default: 100
+          x-field-uid: 2
     Pattern.Flow.Ethernet.Dst.Counter:
       description: |-
         mac counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -19457,6 +19457,40 @@ message CaptureRequest {
   // 
   // required = true
   optional string port_name = 1;
+
+  // Specification of which packets to be captured on the given port.
+  CaptureRequestPackets packets = 2;
+}
+
+// The packets to be captured on the given port.
+message CaptureRequestPackets {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      all = 1;
+      slice = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.all
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  CaptureRequestCaptureSlice slice = 2;
+}
+
+// Packets to be captured based on specification of capture slice through start index
+// and packet count.
+message CaptureRequestCaptureSlice {
+
+  // Index of the packet in the generated packet sequence from where capture would start.
+  // default = 0
+  optional uint64 start = 1;
+
+  // Number of packets to be captured from the start index.
+  // default = 100
+  optional uint64 count = 2;
 }
 
 // mac counter pattern

--- a/result/capture.yaml
+++ b/result/capture.yaml
@@ -17,7 +17,47 @@ components:
           type: string
           x-constraint:
           - '/components/schemas/Port/properties/name'
-
-
-      
           x-field-uid: 1
+        packets:
+          description: >-
+            Specification of which packets to be captured on the given port.
+          $ref: '#/components/schemas/CaptureRequest.Packets'
+          x-field-uid: 2
+
+    CaptureRequest.Packets:
+      type: object
+      description: >-
+        The packets to be captured on the given port.
+      properties:
+        choice:
+          type: string
+          default: all
+          x-field-uid: 1
+          x-enum:
+            all:
+              x-field-uid: 1
+            slice:
+              x-field-uid: 2
+        slice:
+          $ref: '#/components/schemas/CaptureRequest.CaptureSlice'
+          x-field-uid: 2
+
+    CaptureRequest.CaptureSlice:
+      description: >-
+        Packets to be captured based on specification of capture slice through start index and packet count.
+      type: object
+      properties:
+        start:
+          description: >-
+            Index of the packet in the generated packet sequence from where capture would start.
+          type: integer
+          format: uint64
+          default: 0
+          x-field-uid: 1
+        count:
+          description: >-
+            Number of packets to be captured from the start index.
+          type: integer
+          format: uint64
+          default: 100
+          x-field-uid: 2 


### PR DESCRIPTION
Idea: 
- Default behavior: Capture all packets
- New option: Get a capture slice - get N number of packets starting from Mth packet 

ReDoc: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-cap-slice/artifacts/openapi.yaml#tag/Monitor/operation/get_capture

**Sample Code Snippet**
```
// Default behavior: capture all packets
captureRequest = gosnappi.NewCaptureRequest()
captureRequest.SetPortName("p1")

// Capture Slice
captureRequest = gosnappi.NewCaptureRequest()
captureRequest.SetPortName("p1")
captureRequest.Packets().Slice().SetStart(10).SetCount(50)
```