### PR TITLE
Support for configuring IPv4 routes to be sent/withdrawn using Traditional REACH/UN_REACH NLRI. 

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -4224,6 +4224,15 @@ components:
         learned_information_filter:
           x-field-uid: 8
           $ref: '#/components/schemas/Bgp.LearnedInformationFilter'
+        traditional_nlri_for_ipv4_routes:
+          description: "If set to true , all IPv4 routes are advertised using traditional\
+            \ or REACH_NLRI and withdrawn using UNREACH NLRI  as defined in https://datatracker.ietf.org/doc/html/rfc4271#section-4.3\
+            \ . This is applicable only for BGPv4 peers. By default (when set to false),\
+            \ all IPv4 routes are advertise using MP_REACH NLRI and withdrawn using\
+            \ MP_UNREACH NLRI  as defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3. "
+          type: boolean
+          default: false
+          x-field-uid: 16
         v4_routes:
           x-field-uid: 9
           description: |-

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -2916,6 +2916,14 @@ message BgpV4Peer {
   // Description missing in models
   BgpLearnedInformationFilter learned_information_filter = 8;
 
+  // If set to true , all IPv4 routes are advertised using traditional or REACH_NLRI and
+  // withdrawn using UNREACH NLRI  as defined in https://datatracker.ietf.org/doc/html/rfc4271#section-4.3
+  // . This is applicable only for BGPv4 peers. By default (when set to false), all IPv4
+  // routes are advertise using MP_REACH NLRI and withdrawn using MP_UNREACH NLRI  as
+  // defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3.
+  // default = False
+  optional bool traditional_nlri_for_ipv4_routes = 16;
+
   // Emulated BGPv4 route ranges.
   repeated BgpV4RouteRange v4_routes = 9;
 

--- a/device/bgp/bgpv4.yaml
+++ b/device/bgp/bgpv4.yaml
@@ -51,6 +51,15 @@ components:
         learned_information_filter:
           x-include: ./bgp.yaml#/components/schemas/Device.Bgp/properties/learned_information_filter
           x-field-uid: 8
+        traditional_nlri_for_ipv4_routes:
+          description: >-
+            If set to true , all IPv4 routes are advertised using traditional or REACH_NLRI and withdrawn using UNREACH NLRI 
+            as defined in https://datatracker.ietf.org/doc/html/rfc4271#section-4.3 . This is applicable only for BGPv4 peers.
+            By default (when set to false), all IPv4 routes are advertise using MP_REACH NLRI and withdrawn using MP_UNREACH NLRI 
+            as defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3. 
+          type: boolean
+          default: false
+          x-field-uid: 16
         v4_routes:
           x-include: ./bgp.yaml#/components/schemas/Device.Bgp/properties/v4_routes
           x-field-uid: 9


### PR DESCRIPTION
Current model does not provide this control so implementations are expected to always send IPv4 routes in MP_REACH and withdraw routes using MP_UNREACH. 
This PR allows user to optionally allow IPv4 routes only for IPv4 BGP peers to be configured to be advertised or withdrawn using Traditional REACH/UN_REACH methods . 