### PR TITLE
Support for get_capabilities api to probe included/excluded paths in the model.

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -235,3 +235,30 @@ paths:
         default:
           $ref: '../result/request.yaml#/components/responses/Failure'
           x-field-uid: 2
+  /capabilities/capabilities:
+    description: >-
+      Capabilities API
+    post:
+      tags: ['Capabilities']
+      operationId: get_capabilities
+      x-stream: server
+      requestBody:
+        description: >-
+          Capabilities request to the traffic generator.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../result/capabilities.yaml#/components/schemas/Capabilities.Request'      
+      responses:
+        '200':
+          description: >-
+            Capabilites response from the traffic generator
+          content:
+            application/json:
+              schema:
+                $ref: '../result/states.yaml#/components/schemas/Capabilities.Response'
+          x-field-uid: 1
+        default:
+          $ref: '../result/request.yaml#/components/responses/Failure'
+          x-field-uid: 2

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -249,15 +249,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '../result/capabilities.yaml#/components/schemas/Capabilities.Request'      
+              $ref: '../result/capabilities.yaml#/components/schemas/Capabilities.Request'
       responses:
         '200':
           description: >-
-            Capabilites response from the traffic generator
+            Capabilities response from the traffic generator.
           content:
             application/json:
               schema:
-                $ref: '../result/states.yaml#/components/schemas/Capabilities.Response'
+                $ref: '../result/capabilities.yaml#/components/schemas/Capabilities.Response'
           x-field-uid: 1
         default:
           $ref: '../result/request.yaml#/components/responses/Failure'

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -247,6 +247,34 @@ paths:
         default:
           $ref: '#/components/responses/Failure'
           x-field-uid: 2
+  /capabilities/capabilities:
+    description: |-
+      Capabilities API
+    post:
+      tags:
+      - Capabilities
+      operationId: get_capabilities
+      x-stream: server
+      requestBody:
+        description: |-
+          Capabilities request to the traffic generator.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Capabilities.Request'
+      responses:
+        '200':
+          description: |-
+            Capabilites response from the traffic generator
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Capabilities.Response'
+          x-field-uid: 1
+        default:
+          $ref: '#/components/responses/Failure'
+          x-field-uid: 2
   /capabilities/version:
     get:
       tags:
@@ -29056,6 +29084,145 @@ components:
           minimum: 1
           default: 100
           x-field-uid: 2
+    Capabilities.Request:
+      description: "Request to traffic generator for supported capabilities.\nAn implementation\
+        \ supporting capabilities API should support ability to return meanigful information\
+        \ \neven when no attributes are explicitly exposed in the capabilities request."
+      type: object
+      properties:
+        port_type:
+          $ref: '#/components/schemas/Capabilities.PortType'
+          x-field-uid: 1
+        request_type:
+          description: "If included_paths is set , this indicates that the user is\
+            \ interested in know about the objects and attributes \nsupported by the\
+            \ implementation on its endpoints in an heirarchial manner starting from\
+            \ the root or user specified sub-root of the full object heirarchy.\n\
+            If excluded_paths is set , this indicates that the user is interested\
+            \ in know about the objects and attributes \nspecifically NOT supported\
+            \ by the implementation on its endpoints in an heirarchial manner starting\
+            \ from the root or user specified sub-root of the full object heirarchy.\n\
+            Note that if the implementation itself is supporting an older version\
+            \ of models, it is possible that for excluded_paths request, it will not\
+            \ be able to return objects and attributes\nadded in later versions of\
+            \ the model at minimum."
+          type: string
+          default: included_paths
+          x-enum:
+            included_paths:
+              x-field-uid: 1
+            excluded_paths:
+              x-field-uid: 2
+          x-field-uid: 2
+          enum:
+          - included_paths
+          - excluded_paths
+        starting_root:
+          description: "The starting point of the hierarchy from where user is requesting\
+            \ for included/excluded capabilities.By default, the included/excluded\
+            \ objects/actions and attributes of the entire hierarchy is\nprovided.\
+            \ The starting_root should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum\
+            \ value of choice attribute >]]` where node-x is a valid child object\
+            \ of node-(x-1) and\noptional `attribute` is a child attribute of node-n\
+            \ i.e. it can also be used to request for providing included or excluded\
+            \ information about a specific attribute or value of a leaf choice attribute.\
+            \ \ne.g. a) To know related included or excluded attributes for BGP only\
+            \ , the starting_root  should be set as /set_config/devices/bgp ; \n \
+            \    b) To know whether IPv4 ping is supported or not , the starting_root\
+            \ should be set as /set_control_action/protocol/ipv4/ping"
+          type: string
+          default: /
+          x-field-uid: 3
+    Capabilities.Response:
+      description: |-
+        Container for Capabiities Response from the traffic generator implementation.
+      type: object
+      properties:
+        per_port_type_capabilities:
+          description: |-
+            Implementations should try to compress the returned capabilities information in terms of the following:
+            1) If the implementations support multiple types of port_types with different capabilities but is able to deduce that the current deployment can only support one or a sub-set of these port-types,
+              it should return the capabilties only of the sub-set of port_types supported by the current deployment of the implementation to which the request is made, unless specifically requested for.
+            2) If the request_type is of included_paths , it should include only the top-level nodes under which all supported objects and attributes are supported.
+              However, if only some of the attributes or child objects are supported under a node in the hierarchy , it should explicitly include all those child objects , specifically excluding the unsupported ones.
+            3) If the request_type is of excluded_paths , it should include only the top-level nodes under which all supported objects and attributes are unsupported.
+              However, if only some of the attributes or child objects are unsupported under a node in the hierarchy , it should explicitly include all those child objects , specifically excluding the supported ones.
+          type: array
+          items:
+            $ref: '#/components/schemas/Capabilities.PortTypeCapability'
+          x-field-uid: 1
+    Capabilities.PortTypeCapability:
+      description: "Capabilities supported by one specific port-type supported by\
+        \ the implementation.\nIf a specific port_type is requested, only that port_type\
+        \ should be included in the response. \nIf no specific port_type is requested,\
+        \ information on all supported port_types in context of current deployment\
+        \ should be returned.\nThe same port_type should not be returned more than\
+        \ once in the Capabilities response.\nThe array of paths contain the actual\
+        \ list of supported compressed paths of the object model that are supported\
+        \ or not supported by the port_type for which \nthe information is being returned\
+        \ , depending on whether the request_type is included_paths or excluded_paths\
+        \ ."
+      type: object
+      properties:
+        port_type:
+          $ref: '#/components/schemas/Capabilities.PortType'
+          x-field-uid: 1
+        request_type:
+          description: "If request_type is set in the request, that should be returned\
+            \ in this field . Otherwise , the default value of request_type (included_paths)\
+            \ , should be set.          "
+          type: string
+          x-enum:
+            included_paths:
+              x-field-uid: 1
+            excluded_paths:
+              x-field-uid: 2
+          x-field-uid: 2
+          enum:
+          - included_paths
+          - excluded_paths
+        starting_root:
+          description: |-
+            The starting_root in the request should be copied into this field in the response. If no starting_root is include , this field should be set to '/' , indicating the root  of the entire model hierarchy.
+          type: string
+          x-field-uid: 3
+        paths:
+          description: |-
+            The complete list of object and attribute paths that provide the user with the full set of included or excluded capabilties for the specific port_type for which the capabilities are being returned.
+          type: array
+          items:
+            $ref: '#/components/schemas/Capabilities.Path'
+          x-field-uid: 4
+    Capabilities.Path:
+      description: "A path indicating one specific object and all its children OR\
+        \ leaf attribute OR  a specific value of leaf 'choice' field of a leaf object\
+        \ of the model\nhierarchy that is supported or not supported by a specific\
+        \ port_type , depending on whether the request_type is included_paths or excluded_path.\
+        \        "
+      type: object
+      properties:
+        path:
+          description: |
+            A path indicating one specific object and all its children, one specific attribute at a leaf of the model hierachy or the specific value of 'choice' value at the leaf of the model
+            hierarchy that is supported or not supported by a specific port_type , depending on whether the request_type is included_paths or excluded_path.
+            The path string should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute >]]` where node-x is a valid child object of node-(x-1) and
+            optional `attribute` is a child attribute of node-n .
+          type: string
+          x-field-uid: 1
+    Capabilities.PortType:
+      description: |-
+        The information regarding the unique PortType for which the included or excluded capabilities are being returned.
+      type: object
+      properties:
+        value:
+          description: "An unique string in the context of a specific open-traffic-generator\
+            \ that denotes a specific type of group of test ports with same set of\
+            \ capabilties. e.g. 'ixia-c' could be the port_type.value for the reference\
+            \ ixia-c implementation. This name should be distinct and easily distinguishable\
+            \ by user of the test implementation  adhering to this open-traffic-generator\
+            \ model. "
+          type: string
+          x-field-uid: 1
     Pattern.Flow.Ethernet.Dst.Counter:
       description: |-
         mac counter pattern

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -266,7 +266,7 @@ paths:
       responses:
         '200':
           description: |-
-            Capabilites response from the traffic generator
+            Capabilities response from the traffic generator.
           content:
             application/json:
               schema:
@@ -29553,97 +29553,92 @@ components:
           default: 100
           x-field-uid: 2
     Capabilities.Request:
-      description: "Request to traffic generator for supported capabilities.\nAn implementation\
-        \ supporting capabilities API should support ability to return meanigful information\
-        \ \neven when no attributes are explicitly exposed in the capabilities request."
+      description: |-
+        Request to traffic generator for supported capabilities.
+        An implementation supporting capabilities API should support ability to return meaningful information
+        even when no attributes are explicitly exposed in the capabilities request.
       type: object
       properties:
         port_type:
           $ref: '#/components/schemas/Capabilities.PortType'
           x-field-uid: 1
         request_type:
-          description: "If included_paths is set , this indicates that the user is\
-            \ interested in know about the objects and attributes \nsupported by the\
-            \ implementation on its endpoints in an heirarchial manner starting from\
-            \ the root or user specified sub-root of the full object heirarchy.\n\
-            If excluded_paths is set , this indicates that the user is interested\
-            \ in know about the objects and attributes \nspecifically NOT supported\
-            \ by the implementation on its endpoints in an heirarchial manner starting\
-            \ from the root or user specified sub-root of the full object heirarchy.\n\
-            Note that if the implementation itself is supporting an older version\
-            \ of models, it is possible that for excluded_paths request, it will not\
-            \ be able to return objects and attributes\nadded in later versions of\
-            \ the model at minimum."
+          description: |-
+            If included_paths is set, this indicates that the user is interested in knowing about the objects and attributes
+            supported by the implementation on its endpoints in a hierarchical manner starting from the root or user specified sub-root of the full object hierarchy.
+            If excluded_paths is set, this indicates that the user is interested in knowing about the objects and attributes
+            specifically NOT supported by the implementation on its endpoints in a hierarchical manner starting from the root or user specified sub-root of the full object hierarchy.
+            Note that if the implementation itself is supporting an older version of models, it is possible that for excluded_paths request, it will not be able to return objects and attributes
+            added in later versions of the model at minimum.
           type: string
           default: included_paths
           x-enum:
             included_paths:
+              description: |-
+                Return the paths of objects and attributes that are supported by the implementation.
               x-field-uid: 1
             excluded_paths:
+              description: |-
+                Return the paths of objects and attributes that are NOT supported by the implementation.
               x-field-uid: 2
           x-field-uid: 2
           enum:
           - included_paths
           - excluded_paths
         starting_root:
-          description: "The starting point of the hierarchy from where user is requesting\
-            \ for included/excluded capabilities.By default, the included/excluded\
-            \ objects/actions and attributes of the entire hierarchy is\nprovided.\
-            \ The starting_root should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum\
-            \ value of choice attribute >]]` where node-x is a valid child object\
-            \ of node-(x-1) and\noptional `attribute` is a child attribute of node-n\
-            \ i.e. it can also be used to request for providing included or excluded\
-            \ information about a specific attribute or value of a leaf choice attribute.\
-            \ \ne.g. a) To know related included or excluded attributes for BGP only\
-            \ , the starting_root  should be set as /set_config/devices/bgp ; \n \
-            \    b) To know whether IPv4 ping is supported or not , the starting_root\
-            \ should be set as /set_control_action/protocol/ipv4/ping"
+          description: |-
+            The starting point of the hierarchy from where user is requesting for included/excluded capabilities. By default, the included/excluded objects/actions and attributes of the entire hierarchy is
+            provided. The starting_root should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute>]]` where node-x is a valid child object of node-(x-1) and
+            optional `attribute` is a child attribute of node-n i.e. it can also be used to request for providing included or excluded information about a specific attribute or value of a leaf choice attribute.
+            e.g. a) To know related included or excluded attributes for BGP only, the starting_root should be set as /set_config/devices/bgp;
+                 b) To know whether IPv4 ping is supported or not, the starting_root should be set as /set_control_action/protocol/ipv4/ping
           type: string
           default: /
           x-field-uid: 3
     Capabilities.Response:
       description: |-
-        Container for Capabiities Response from the traffic generator implementation.
+        Container for Capabilities response from the traffic generator implementation.
       type: object
       properties:
         per_port_type_capabilities:
           description: |-
             Implementations should try to compress the returned capabilities information in terms of the following:
             1) If the implementations support multiple types of port_types with different capabilities but is able to deduce that the current deployment can only support one or a sub-set of these port-types,
-              it should return the capabilties only of the sub-set of port_types supported by the current deployment of the implementation to which the request is made, unless specifically requested for.
-            2) If the request_type is of included_paths , it should include only the top-level nodes under which all supported objects and attributes are supported.
-              However, if only some of the attributes or child objects are supported under a node in the hierarchy , it should explicitly include all those child objects , specifically excluding the unsupported ones.
-            3) If the request_type is of excluded_paths , it should include only the top-level nodes under which all supported objects and attributes are unsupported.
-              However, if only some of the attributes or child objects are unsupported under a node in the hierarchy , it should explicitly include all those child objects , specifically excluding the supported ones.
+              it should return the capabilities only of the sub-set of port_types supported by the current deployment of the implementation to which the request is made, unless specifically requested for.
+            2) If the request_type is of included_paths, it should include only the top-level nodes under which all supported objects and attributes are supported.
+              However, if only some of the attributes or child objects are supported under a node in the hierarchy, it should explicitly include all those child objects, specifically excluding the unsupported ones.
+            3) If the request_type is of excluded_paths, it should include only the top-level nodes under which all supported objects and attributes are unsupported.
+              However, if only some of the attributes or child objects are unsupported under a node in the hierarchy, it should explicitly include all those child objects, specifically excluding the supported ones.
           type: array
           items:
             $ref: '#/components/schemas/Capabilities.PortTypeCapability'
           x-field-uid: 1
     Capabilities.PortTypeCapability:
-      description: "Capabilities supported by one specific port-type supported by\
-        \ the implementation.\nIf a specific port_type is requested, only that port_type\
-        \ should be included in the response. \nIf no specific port_type is requested,\
-        \ information on all supported port_types in context of current deployment\
-        \ should be returned.\nThe same port_type should not be returned more than\
-        \ once in the Capabilities response.\nThe array of paths contain the actual\
-        \ list of supported compressed paths of the object model that are supported\
-        \ or not supported by the port_type for which \nthe information is being returned\
-        \ , depending on whether the request_type is included_paths or excluded_paths\
-        \ ."
+      description: |-
+        Capabilities supported by one specific port-type supported by the implementation.
+        If a specific port_type is requested, only that port_type should be included in the response.
+        If no specific port_type is requested, information on all supported port_types in context of current deployment should be returned.
+        The same port_type should not be returned more than once in the Capabilities response.
+        The array of paths contain the actual list of supported compressed paths of the object model that are supported or not supported by the port_type for which
+        the information is being returned, depending on whether the request_type is included_paths or excluded_paths.
       type: object
       properties:
         port_type:
           $ref: '#/components/schemas/Capabilities.PortType'
           x-field-uid: 1
         request_type:
-          description: "If request_type is set in the request, that should be returned\
-            \ in this field . Otherwise , the default value of request_type (included_paths)\
-            \ , should be set.          "
+          description: |-
+            If request_type is set in the request, that should be returned in this field. Otherwise, the default value of request_type (included_paths) should be set.
           type: string
+          default: included_paths
           x-enum:
             included_paths:
+              description: |-
+                Return the paths of objects and attributes that are supported by the implementation.
               x-field-uid: 1
             excluded_paths:
+              description: |-
+                Return the paths of objects and attributes that are NOT supported by the implementation.
               x-field-uid: 2
           x-field-uid: 2
           enum:
@@ -29651,30 +29646,28 @@ components:
           - excluded_paths
         starting_root:
           description: |-
-            The starting_root in the request should be copied into this field in the response. If no starting_root is include , this field should be set to '/' , indicating the root  of the entire model hierarchy.
+            The starting_root in the request should be copied into this field in the response. If no starting_root is included, this field should be set to '/', indicating the root of the entire model hierarchy.
           type: string
           x-field-uid: 3
         paths:
           description: |-
-            The complete list of object and attribute paths that provide the user with the full set of included or excluded capabilties for the specific port_type for which the capabilities are being returned.
+            The complete list of object and attribute paths that provide the user with the full set of included or excluded capabilities for the specific port_type for which the capabilities are being returned.
           type: array
           items:
             $ref: '#/components/schemas/Capabilities.Path'
           x-field-uid: 4
     Capabilities.Path:
-      description: "A path indicating one specific object and all its children OR\
-        \ leaf attribute OR  a specific value of leaf 'choice' field of a leaf object\
-        \ of the model\nhierarchy that is supported or not supported by a specific\
-        \ port_type , depending on whether the request_type is included_paths or excluded_path.\
-        \        "
+      description: |-
+        A path indicating one specific object and all its children OR leaf attribute OR a specific value of leaf 'choice' field of a leaf object of the model
+        hierarchy that is supported or not supported by a specific port_type, depending on whether the request_type is included_paths or excluded_paths.
       type: object
       properties:
         path:
-          description: |
-            A path indicating one specific object and all its children, one specific attribute at a leaf of the model hierachy or the specific value of 'choice' value at the leaf of the model
-            hierarchy that is supported or not supported by a specific port_type , depending on whether the request_type is included_paths or excluded_path.
-            The path string should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute >]]` where node-x is a valid child object of node-(x-1) and
-            optional `attribute` is a child attribute of node-n .
+          description: |-
+            A path indicating one specific object and all its children, one specific attribute at a leaf of the model hierarchy or the specific value of 'choice' value at the leaf of the model
+            hierarchy that is supported or not supported by a specific port_type, depending on whether the request_type is included_paths or excluded_paths.
+            The path string should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute>]]` where node-x is a valid child object of node-(x-1) and
+            optional `attribute` is a child attribute of node-n.
           type: string
           x-field-uid: 1
     Capabilities.PortType:
@@ -29683,12 +29676,8 @@ components:
       type: object
       properties:
         value:
-          description: "An unique string in the context of a specific open-traffic-generator\
-            \ that denotes a specific type of group of test ports with same set of\
-            \ capabilties. e.g. 'ixia-c' could be the port_type.value for the reference\
-            \ ixia-c implementation. This name should be distinct and easily distinguishable\
-            \ by user of the test implementation  adhering to this open-traffic-generator\
-            \ model. "
+          description: |-
+            A unique string in the context of a specific open-traffic-generator that denotes a specific type of group of test ports with the same set of capabilities. e.g. 'ixia-c' could be the port_type.value for the reference ixia-c implementation. This name should be distinct and easily distinguishable by the user of the test implementation adhering to this open-traffic-generator model.
           type: string
           x-field-uid: 1
     Pattern.Flow.Ethernet.Dst.Counter:

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -20845,6 +20845,146 @@ message CaptureRequestCaptureSliceInitial {
   optional uint64 count = 2;
 }
 
+// Request to traffic generator for supported capabilities.
+// An implementation supporting capabilities API should support ability to return meanigful
+// information
+// even when no attributes are explicitly exposed in the capabilities request.
+message CapabilitiesRequest {
+
+  // Description missing in models
+  CapabilitiesPortType port_type = 1;
+
+  message RequestType {
+    enum Enum {
+      unspecified = 0;
+      included_paths = 1;
+      excluded_paths = 2;
+    }
+  }
+  // If included_paths is set , this indicates that the user is interested in know about
+  // the objects and attributes
+  // supported by the implementation on its endpoints in an heirarchial manner starting
+  // from the root or user specified sub-root of the full object heirarchy.
+  // If excluded_paths is set , this indicates that the user is interested in know about
+  // the objects and attributes
+  // specifically NOT supported by the implementation on its endpoints in an heirarchial
+  // manner starting from the root or user specified sub-root of the full object heirarchy.
+  // Note that if the implementation itself is supporting an older version of models,
+  // it is possible that for excluded_paths request, it will not be able to return objects
+  // and attributes
+  // added in later versions of the model at minimum.
+  // default = RequestType.Enum.included_paths
+  optional RequestType.Enum request_type = 2;
+
+  // The starting point of the hierarchy from where user is requesting for included/excluded
+  // capabilities.By default, the included/excluded objects/actions and attributes of
+  // the entire hierarchy is
+  // provided. The starting_root should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum
+  // value of choice attribute >]]` where node-x is a valid child object of node-(x-1)
+  // and
+  // optional `attribute` is a child attribute of node-n i.e. it can also be used to request
+  // for providing included or excluded information about a specific attribute or value
+  // of a leaf choice attribute.
+  // e.g. a) To know related included or excluded attributes for BGP only , the starting_root
+  // should be set as /set_config/devices/bgp ;
+  // b) To know whether IPv4 ping is supported or not , the starting_root should
+  // be set as /set_control_action/protocol/ipv4/ping
+  // default = /
+  optional string starting_root = 3;
+}
+
+// Container for Capabiities Response from the traffic generator implementation.
+message CapabilitiesResponse {
+
+  // Implementations should try to compress the returned capabilities information in terms
+  // of the following:
+  // 1) If the implementations support multiple types of port_types with different capabilities
+  // but is able to deduce that the current deployment can only support one or a sub-set
+  // of these port-types,
+  // it should return the capabilties only of the sub-set of port_types supported by
+  // the current deployment of the implementation to which the request is made, unless
+  // specifically requested for.
+  // 2) If the request_type is of included_paths , it should include only the top-level
+  // nodes under which all supported objects and attributes are supported.
+  // However, if only some of the attributes or child objects are supported under a
+  // node in the hierarchy , it should explicitly include all those child objects , specifically
+  // excluding the unsupported ones.
+  // 3) If the request_type is of excluded_paths , it should include only the top-level
+  // nodes under which all supported objects and attributes are unsupported.
+  // However, if only some of the attributes or child objects are unsupported under
+  // a node in the hierarchy , it should explicitly include all those child objects ,
+  // specifically excluding the supported ones.
+  repeated CapabilitiesPortTypeCapability per_port_type_capabilities = 1;
+}
+
+// Capabilities supported by one specific port-type supported by the implementation.
+// If a specific port_type is requested, only that port_type should be included in the
+// response.
+// If no specific port_type is requested, information on all supported port_types in
+// context of current deployment should be returned.
+// The same port_type should not be returned more than once in the Capabilities response.
+// The array of paths contain the actual list of supported compressed paths of the object
+// model that are supported or not supported by the port_type for which
+// the information is being returned , depending on whether the request_type is included_paths
+// or excluded_paths .
+message CapabilitiesPortTypeCapability {
+
+  // Description missing in models
+  CapabilitiesPortType port_type = 1;
+
+  message RequestType {
+    enum Enum {
+      unspecified = 0;
+      included_paths = 1;
+      excluded_paths = 2;
+    }
+  }
+  // If request_type is set in the request, that should be returned in this field . Otherwise
+  // , the default value of request_type (included_paths) , should be set.
+  optional RequestType.Enum request_type = 2;
+
+  // The starting_root in the request should be copied into this field in the response.
+  // If no starting_root is include , this field should be set to '/' , indicating the
+  // root  of the entire model hierarchy.
+  optional string starting_root = 3;
+
+  // The complete list of object and attribute paths that provide the user with the full
+  // set of included or excluded capabilties for the specific port_type for which the
+  // capabilities are being returned.
+  repeated CapabilitiesPath paths = 4;
+}
+
+// A path indicating one specific object and all its children OR leaf attribute OR
+// a specific value of leaf 'choice' field of a leaf object of the model
+// hierarchy that is supported or not supported by a specific port_type , depending
+// on whether the request_type is included_paths or excluded_path.
+message CapabilitiesPath {
+
+  // A path indicating one specific object and all its children, one specific attribute
+  // at a leaf of the model hierachy or the specific value of 'choice' value at the leaf
+  // of the model
+  // hierarchy that is supported or not supported by a specific port_type , depending
+  // on whether the request_type is included_paths or excluded_path.
+  // The path string should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum
+  // value of choice attribute >]]` where node-x is a valid child object of node-(x-1)
+  // and
+  // optional `attribute` is a child attribute of node-n .
+  // 
+  optional string path = 1;
+}
+
+// The information regarding the unique PortType for which the included or excluded
+// capabilities are being returned.
+message CapabilitiesPortType {
+
+  // An unique string in the context of a specific open-traffic-generator that denotes
+  // a specific type of group of test ports with same set of capabilties. e.g. 'ixia-c'
+  // could be the port_type.value for the reference ixia-c implementation. This name should
+  // be distinct and easily distinguishable by user of the test implementation  adhering
+  // to this open-traffic-generator model.
+  optional string value = 1;
+}
+
 // mac counter pattern
 message PatternFlowEthernetDstCounter {
 
@@ -35975,6 +36115,14 @@ message GetCaptureResponse {
   bytes response_bytes = 1;
 }
 
+
+message GetCapabilitiesRequest {
+  CapabilitiesRequest capabilities_request = 1;
+}
+message GetCapabilitiesResponse {
+  CapabilitiesResponse capabilities_response = 1;
+}
+
 message GetVersionResponse {
   Version version = 1;
 }
@@ -36038,6 +36186,10 @@ service Openapi {
   rpc GetCapture(GetCaptureRequest) returns (GetCaptureResponse);
   // streaming version of the rpc GetCapture
   rpc streamGetCapture(GetCaptureRequest) returns (stream Data);
+  // Description missing in models
+  rpc GetCapabilities(GetCapabilitiesRequest) returns (GetCapabilitiesResponse);
+  // streaming version of the rpc GetCapabilities
+  rpc streamGetCapabilities(GetCapabilitiesRequest) returns (stream Data);
   // Description missing in models
   rpc GetVersion(google.protobuf.Empty) returns (GetVersionResponse);
 }

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -21222,7 +21222,7 @@ message CaptureRequestCaptureSliceInitial {
 }
 
 // Request to traffic generator for supported capabilities.
-// An implementation supporting capabilities API should support ability to return meanigful
+// An implementation supporting capabilities API should support ability to return meaningful
 // information
 // even when no attributes are explicitly exposed in the capabilities request.
 message CapabilitiesRequest {
@@ -21237,14 +21237,14 @@ message CapabilitiesRequest {
       excluded_paths = 2;
     }
   }
-  // If included_paths is set , this indicates that the user is interested in know about
+  // If included_paths is set, this indicates that the user is interested in knowing about
   // the objects and attributes
-  // supported by the implementation on its endpoints in an heirarchial manner starting
-  // from the root or user specified sub-root of the full object heirarchy.
-  // If excluded_paths is set , this indicates that the user is interested in know about
+  // supported by the implementation on its endpoints in a hierarchical manner starting
+  // from the root or user specified sub-root of the full object hierarchy.
+  // If excluded_paths is set, this indicates that the user is interested in knowing about
   // the objects and attributes
-  // specifically NOT supported by the implementation on its endpoints in an heirarchial
-  // manner starting from the root or user specified sub-root of the full object heirarchy.
+  // specifically NOT supported by the implementation on its endpoints in a hierarchical
+  // manner starting from the root or user specified sub-root of the full object hierarchy.
   // Note that if the implementation itself is supporting an older version of models,
   // it is possible that for excluded_paths request, it will not be able to return objects
   // and attributes
@@ -21253,23 +21253,23 @@ message CapabilitiesRequest {
   optional RequestType.Enum request_type = 2;
 
   // The starting point of the hierarchy from where user is requesting for included/excluded
-  // capabilities.By default, the included/excluded objects/actions and attributes of
+  // capabilities. By default, the included/excluded objects/actions and attributes of
   // the entire hierarchy is
   // provided. The starting_root should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum
-  // value of choice attribute >]]` where node-x is a valid child object of node-(x-1)
+  // value of choice attribute>]]` where node-x is a valid child object of node-(x-1)
   // and
   // optional `attribute` is a child attribute of node-n i.e. it can also be used to request
   // for providing included or excluded information about a specific attribute or value
   // of a leaf choice attribute.
-  // e.g. a) To know related included or excluded attributes for BGP only , the starting_root
-  // should be set as /set_config/devices/bgp ;
-  // b) To know whether IPv4 ping is supported or not , the starting_root should
-  // be set as /set_control_action/protocol/ipv4/ping
+  // e.g. a) To know related included or excluded attributes for BGP only, the starting_root
+  // should be set as /set_config/devices/bgp;
+  // b) To know whether IPv4 ping is supported or not, the starting_root should be
+  // set as /set_control_action/protocol/ipv4/ping
   // default = /
   optional string starting_root = 3;
 }
 
-// Container for Capabiities Response from the traffic generator implementation.
+// Container for Capabilities response from the traffic generator implementation.
 message CapabilitiesResponse {
 
   // Implementations should try to compress the returned capabilities information in terms
@@ -21277,19 +21277,19 @@ message CapabilitiesResponse {
   // 1) If the implementations support multiple types of port_types with different capabilities
   // but is able to deduce that the current deployment can only support one or a sub-set
   // of these port-types,
-  // it should return the capabilties only of the sub-set of port_types supported by
+  // it should return the capabilities only of the sub-set of port_types supported by
   // the current deployment of the implementation to which the request is made, unless
   // specifically requested for.
-  // 2) If the request_type is of included_paths , it should include only the top-level
+  // 2) If the request_type is of included_paths, it should include only the top-level
   // nodes under which all supported objects and attributes are supported.
   // However, if only some of the attributes or child objects are supported under a
-  // node in the hierarchy , it should explicitly include all those child objects , specifically
+  // node in the hierarchy, it should explicitly include all those child objects, specifically
   // excluding the unsupported ones.
-  // 3) If the request_type is of excluded_paths , it should include only the top-level
+  // 3) If the request_type is of excluded_paths, it should include only the top-level
   // nodes under which all supported objects and attributes are unsupported.
   // However, if only some of the attributes or child objects are unsupported under
-  // a node in the hierarchy , it should explicitly include all those child objects ,
-  // specifically excluding the supported ones.
+  // a node in the hierarchy, it should explicitly include all those child objects, specifically
+  // excluding the supported ones.
   repeated CapabilitiesPortTypeCapability per_port_type_capabilities = 1;
 }
 
@@ -21301,8 +21301,8 @@ message CapabilitiesResponse {
 // The same port_type should not be returned more than once in the Capabilities response.
 // The array of paths contain the actual list of supported compressed paths of the object
 // model that are supported or not supported by the port_type for which
-// the information is being returned , depending on whether the request_type is included_paths
-// or excluded_paths .
+// the information is being returned, depending on whether the request_type is included_paths
+// or excluded_paths.
 message CapabilitiesPortTypeCapability {
 
   // Description missing in models
@@ -21315,37 +21315,37 @@ message CapabilitiesPortTypeCapability {
       excluded_paths = 2;
     }
   }
-  // If request_type is set in the request, that should be returned in this field . Otherwise
-  // , the default value of request_type (included_paths) , should be set.
+  // If request_type is set in the request, that should be returned in this field. Otherwise,
+  // the default value of request_type (included_paths) should be set.
+  // default = RequestType.Enum.included_paths
   optional RequestType.Enum request_type = 2;
 
   // The starting_root in the request should be copied into this field in the response.
-  // If no starting_root is include , this field should be set to '/' , indicating the
-  // root  of the entire model hierarchy.
+  // If no starting_root is included, this field should be set to '/', indicating the
+  // root of the entire model hierarchy.
   optional string starting_root = 3;
 
   // The complete list of object and attribute paths that provide the user with the full
-  // set of included or excluded capabilties for the specific port_type for which the
+  // set of included or excluded capabilities for the specific port_type for which the
   // capabilities are being returned.
   repeated CapabilitiesPath paths = 4;
 }
 
-// A path indicating one specific object and all its children OR leaf attribute OR
-// a specific value of leaf 'choice' field of a leaf object of the model
-// hierarchy that is supported or not supported by a specific port_type , depending
-// on whether the request_type is included_paths or excluded_path.
+// A path indicating one specific object and all its children OR leaf attribute OR a
+// specific value of leaf 'choice' field of a leaf object of the model
+// hierarchy that is supported or not supported by a specific port_type, depending on
+// whether the request_type is included_paths or excluded_paths.
 message CapabilitiesPath {
 
   // A path indicating one specific object and all its children, one specific attribute
-  // at a leaf of the model hierachy or the specific value of 'choice' value at the leaf
+  // at a leaf of the model hierarchy or the specific value of 'choice' value at the leaf
   // of the model
-  // hierarchy that is supported or not supported by a specific port_type , depending
-  // on whether the request_type is included_paths or excluded_path.
+  // hierarchy that is supported or not supported by a specific port_type, depending on
+  // whether the request_type is included_paths or excluded_paths.
   // The path string should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum
-  // value of choice attribute >]]` where node-x is a valid child object of node-(x-1)
+  // value of choice attribute>]]` where node-x is a valid child object of node-(x-1)
   // and
-  // optional `attribute` is a child attribute of node-n .
-  // 
+  // optional `attribute` is a child attribute of node-n.
   optional string path = 1;
 }
 
@@ -21353,10 +21353,10 @@ message CapabilitiesPath {
 // capabilities are being returned.
 message CapabilitiesPortType {
 
-  // An unique string in the context of a specific open-traffic-generator that denotes
-  // a specific type of group of test ports with same set of capabilties. e.g. 'ixia-c'
+  // A unique string in the context of a specific open-traffic-generator that denotes
+  // a specific type of group of test ports with the same set of capabilities. e.g. 'ixia-c'
   // could be the port_type.value for the reference ixia-c implementation. This name should
-  // be distinct and easily distinguishable by user of the test implementation  adhering
+  // be distinct and easily distinguishable by the user of the test implementation adhering
   // to this open-traffic-generator model.
   optional string value = 1;
 }

--- a/result/capabilities.yaml
+++ b/result/capabilities.yaml
@@ -1,0 +1,123 @@
+components:
+  schemas:
+    Capabilities.Request:
+      description: |-
+        Request to traffic generator for supported capabilities.
+        An implementation supporting capabilities API should support ability to return meanigful information 
+        even when no attributes are explicitly exposed in the capabilities request.
+      type: object
+      properties:
+        port_type:
+          $ref: '#/components/schemas/Capabilities.PortType'          
+          x-field-uid: 1
+        request_type:
+          description: |- 
+            If included_paths is set , this indicates that the user is interested in know about the objects and attributes 
+            supported by the implementation on its endpoints in an heirarchial manner starting from the root or user specified sub-root of the full object heirarchy.
+            If excluded_paths is set , this indicates that the user is interested in know about the objects and attributes 
+            specifically NOT supported by the implementation on its endpoints in an heirarchial manner starting from the root or user specified sub-root of the full object heirarchy.
+            Note that if the implementation itself is supporting an older version of models, it is possible that for excluded_paths request, it will not be able to return objects and attributes
+            added in later versions of the model at minimum.
+          type: string
+          default: included_paths 
+          x-enum: 
+            included_paths:
+              x-field-uid: 1
+            excluded_paths:
+              x-field-uid: 2
+          x-field-uid: 2
+        starting_root:
+          description: |-
+            The starting point of the hierarchy from where user is requesting for included/excluded capabilities.By default, the included/excluded objects/actions and attributes of the entire hierarchy is
+            provided. The starting_root should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute >]]` where node-x is a valid child object of node-(x-1) and
+            optional `attribute` is a child attribute of node-n i.e. it can also be used to request for providing included or excluded information about a specific attribute or value of a leaf choice attribute. 
+            e.g. a) To know related included or excluded attributes for BGP only , the starting_root  should be set as /set_config/devices/bgp ; 
+                 b) To know whether IPv4 ping is supported or not , the starting_root should be set as /set_control_action/protocol/ipv4/ping
+          type: string
+          default : "/"
+          x-field-uid: 3
+    Capabilities.Response:
+      description: |-
+        Container for Capabiities Response from the traffic generator implementation.
+      type: object
+      properties:          
+        per_port_type_capabilities:
+          description: |-            
+            Implementations should try to compress the returned capabilities information in terms of the following:
+            1) If the implementations support multiple types of port_types with different capabilities but is able to deduce that the current deployment can only support one or a sub-set of these port-types,
+              it should return the capabilties only of the sub-set of port_types supported by the current deployment of the implementation to which the request is made, unless specifically requested for.
+            2) If the request_type is of included_paths , it should include only the top-level nodes under which all supported objects and attributes are supported.
+              However, if only some of the attributes or child objects are supported under a node in the hierarchy , it should explicitly include all those child objects , specifically excluding the unsupported ones.
+            3) If the request_type is of excluded_paths , it should include only the top-level nodes under which all supported objects and attributes are unsupported.
+              However, if only some of the attributes or child objects are unsupported under a node in the hierarchy , it should explicitly include all those child objects , specifically excluding the supported ones.
+          type: array
+          items:
+            $ref: '#/components/schemas/Capabilities.PortTypeCapability'
+          x-field-uid: 1
+    Capabilities.PortTypeCapability:
+      description: |-
+        Capabilities supported by one specific port-type supported by the implementation.
+        If a specific port_type is requested, only that port_type should be included in the response. 
+        If no specific port_type is requested, information on all supported port_types in context of current deployment should be returned.
+        The same port_type should not be returned more than once in the Capabilities response.
+        The array of paths contain the actual list of supported compressed paths of the object model that are supported or not supported by the port_type for which 
+        the information is being returned , depending on whether the request_type is included_paths or excluded_paths .
+      type: object 
+      properties:
+        port_type:
+          $ref: '#/components/schemas/Capabilities.PortType'          
+          x-field-uid: 1
+        request_type:
+          description: >- 
+            If request_type is set in the request, that should be returned in this field . Otherwise , the default value of request_type (included_paths) , should be set.          
+          type: string
+          x-enum: 
+            included_paths:
+              x-field-uid: 1
+            excluded_paths:
+              x-field-uid: 2
+          x-field-uid: 2
+        starting_root:
+          description: >-
+            The starting_root in the request should be copied into this field in the response. If no starting_root is include , this field should be set to '/' , indicating the root 
+            of the entire model hierarchy.
+          type: string          
+          x-field-uid: 3
+        paths:
+          description: >-
+            The complete list of object and attribute paths that provide the user with the full set of included or excluded capabilties for the specific port_type for which the capabilities are being
+            returned.
+          type: array
+          items:
+            $ref: '#/components/schemas/Capabilities.Path'
+          x-field-uid: 4
+    Capabilities.Path:
+      description: |-
+        A path indicating one specific object and all its children OR leaf attribute OR  a specific value of leaf 'choice' field of a leaf object of the model
+        hierarchy that is supported or not supported by a specific port_type , depending on whether the request_type is included_paths or excluded_path.        
+      type: object
+      properties:
+        path:
+          description: |
+            A path indicating one specific object and all its children, one specific attribute at a leaf of the model hierachy or the specific value of 'choice' value at the leaf of the model
+            hierarchy that is supported or not supported by a specific port_type , depending on whether the request_type is included_paths or excluded_path.
+            The path string should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute >]]` where node-x is a valid child object of node-(x-1) and
+            optional `attribute` is a child attribute of node-n .
+          type: string
+          x-field-uid: 1
+    Capabilities.PortType:
+      description: >-
+          The information regarding the unique PortType for which the included or excluded capabilities are being returned.
+      type: object
+      properties:
+        value:
+          description: >-
+            An unique string in the context of a specific open-traffic-generator that denotes a specific type of group of test ports with same set of capabilties.
+            e.g. 'ixia-c' could be the port_type.value for the reference ixia-c implementation. This name should be distinct and easily distinguishable by user of the test implementation 
+            adhering to this open-traffic-generator model. 
+          type: string
+          x-field-uid: 1
+    
+
+            
+        

--- a/result/capabilities.yaml
+++ b/result/capabilities.yaml
@@ -3,53 +3,57 @@ components:
     Capabilities.Request:
       description: |-
         Request to traffic generator for supported capabilities.
-        An implementation supporting capabilities API should support ability to return meanigful information 
+        An implementation supporting capabilities API should support ability to return meaningful information
         even when no attributes are explicitly exposed in the capabilities request.
       type: object
       properties:
         port_type:
-          $ref: '#/components/schemas/Capabilities.PortType'          
+          $ref: '#/components/schemas/Capabilities.PortType'
           x-field-uid: 1
         request_type:
-          description: |- 
-            If included_paths is set , this indicates that the user is interested in know about the objects and attributes 
-            supported by the implementation on its endpoints in an heirarchial manner starting from the root or user specified sub-root of the full object heirarchy.
-            If excluded_paths is set , this indicates that the user is interested in know about the objects and attributes 
-            specifically NOT supported by the implementation on its endpoints in an heirarchial manner starting from the root or user specified sub-root of the full object heirarchy.
+          description: |-
+            If included_paths is set, this indicates that the user is interested in knowing about the objects and attributes
+            supported by the implementation on its endpoints in a hierarchical manner starting from the root or user specified sub-root of the full object hierarchy.
+            If excluded_paths is set, this indicates that the user is interested in knowing about the objects and attributes
+            specifically NOT supported by the implementation on its endpoints in a hierarchical manner starting from the root or user specified sub-root of the full object hierarchy.
             Note that if the implementation itself is supporting an older version of models, it is possible that for excluded_paths request, it will not be able to return objects and attributes
             added in later versions of the model at minimum.
           type: string
-          default: included_paths 
-          x-enum: 
+          default: included_paths
+          x-enum:
             included_paths:
+              description: >-
+                Return the paths of objects and attributes that are supported by the implementation.
               x-field-uid: 1
             excluded_paths:
+              description: >-
+                Return the paths of objects and attributes that are NOT supported by the implementation.
               x-field-uid: 2
           x-field-uid: 2
         starting_root:
           description: |-
-            The starting point of the hierarchy from where user is requesting for included/excluded capabilities.By default, the included/excluded objects/actions and attributes of the entire hierarchy is
-            provided. The starting_root should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute >]]` where node-x is a valid child object of node-(x-1) and
-            optional `attribute` is a child attribute of node-n i.e. it can also be used to request for providing included or excluded information about a specific attribute or value of a leaf choice attribute. 
-            e.g. a) To know related included or excluded attributes for BGP only , the starting_root  should be set as /set_config/devices/bgp ; 
-                 b) To know whether IPv4 ping is supported or not , the starting_root should be set as /set_control_action/protocol/ipv4/ping
+            The starting point of the hierarchy from where user is requesting for included/excluded capabilities. By default, the included/excluded objects/actions and attributes of the entire hierarchy is
+            provided. The starting_root should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute>]]` where node-x is a valid child object of node-(x-1) and
+            optional `attribute` is a child attribute of node-n i.e. it can also be used to request for providing included or excluded information about a specific attribute or value of a leaf choice attribute.
+            e.g. a) To know related included or excluded attributes for BGP only, the starting_root should be set as /set_config/devices/bgp;
+                 b) To know whether IPv4 ping is supported or not, the starting_root should be set as /set_control_action/protocol/ipv4/ping
           type: string
-          default : "/"
+          default: "/"
           x-field-uid: 3
     Capabilities.Response:
       description: |-
-        Container for Capabiities Response from the traffic generator implementation.
+        Container for Capabilities response from the traffic generator implementation.
       type: object
-      properties:          
+      properties:
         per_port_type_capabilities:
-          description: |-            
+          description: |-
             Implementations should try to compress the returned capabilities information in terms of the following:
             1) If the implementations support multiple types of port_types with different capabilities but is able to deduce that the current deployment can only support one or a sub-set of these port-types,
-              it should return the capabilties only of the sub-set of port_types supported by the current deployment of the implementation to which the request is made, unless specifically requested for.
-            2) If the request_type is of included_paths , it should include only the top-level nodes under which all supported objects and attributes are supported.
-              However, if only some of the attributes or child objects are supported under a node in the hierarchy , it should explicitly include all those child objects , specifically excluding the unsupported ones.
-            3) If the request_type is of excluded_paths , it should include only the top-level nodes under which all supported objects and attributes are unsupported.
-              However, if only some of the attributes or child objects are unsupported under a node in the hierarchy , it should explicitly include all those child objects , specifically excluding the supported ones.
+              it should return the capabilities only of the sub-set of port_types supported by the current deployment of the implementation to which the request is made, unless specifically requested for.
+            2) If the request_type is of included_paths, it should include only the top-level nodes under which all supported objects and attributes are supported.
+              However, if only some of the attributes or child objects are supported under a node in the hierarchy, it should explicitly include all those child objects, specifically excluding the unsupported ones.
+            3) If the request_type is of excluded_paths, it should include only the top-level nodes under which all supported objects and attributes are unsupported.
+              However, if only some of the attributes or child objects are unsupported under a node in the hierarchy, it should explicitly include all those child objects, specifically excluding the supported ones.
           type: array
           items:
             $ref: '#/components/schemas/Capabilities.PortTypeCapability'
@@ -57,35 +61,40 @@ components:
     Capabilities.PortTypeCapability:
       description: |-
         Capabilities supported by one specific port-type supported by the implementation.
-        If a specific port_type is requested, only that port_type should be included in the response. 
+        If a specific port_type is requested, only that port_type should be included in the response.
         If no specific port_type is requested, information on all supported port_types in context of current deployment should be returned.
         The same port_type should not be returned more than once in the Capabilities response.
-        The array of paths contain the actual list of supported compressed paths of the object model that are supported or not supported by the port_type for which 
-        the information is being returned , depending on whether the request_type is included_paths or excluded_paths .
-      type: object 
+        The array of paths contain the actual list of supported compressed paths of the object model that are supported or not supported by the port_type for which
+        the information is being returned, depending on whether the request_type is included_paths or excluded_paths.
+      type: object
       properties:
         port_type:
-          $ref: '#/components/schemas/Capabilities.PortType'          
+          $ref: '#/components/schemas/Capabilities.PortType'
           x-field-uid: 1
         request_type:
-          description: >- 
-            If request_type is set in the request, that should be returned in this field . Otherwise , the default value of request_type (included_paths) , should be set.          
+          description: >-
+            If request_type is set in the request, that should be returned in this field. Otherwise, the default value of request_type (included_paths) should be set.
           type: string
-          x-enum: 
+          default: included_paths
+          x-enum:
             included_paths:
+              description: >-
+                Return the paths of objects and attributes that are supported by the implementation.
               x-field-uid: 1
             excluded_paths:
+              description: >-
+                Return the paths of objects and attributes that are NOT supported by the implementation.
               x-field-uid: 2
           x-field-uid: 2
         starting_root:
           description: >-
-            The starting_root in the request should be copied into this field in the response. If no starting_root is include , this field should be set to '/' , indicating the root 
+            The starting_root in the request should be copied into this field in the response. If no starting_root is included, this field should be set to '/', indicating the root
             of the entire model hierarchy.
-          type: string          
+          type: string
           x-field-uid: 3
         paths:
           description: >-
-            The complete list of object and attribute paths that provide the user with the full set of included or excluded capabilties for the specific port_type for which the capabilities are being
+            The complete list of object and attribute paths that provide the user with the full set of included or excluded capabilities for the specific port_type for which the capabilities are being
             returned.
           type: array
           items:
@@ -93,31 +102,27 @@ components:
           x-field-uid: 4
     Capabilities.Path:
       description: |-
-        A path indicating one specific object and all its children OR leaf attribute OR  a specific value of leaf 'choice' field of a leaf object of the model
-        hierarchy that is supported or not supported by a specific port_type , depending on whether the request_type is included_paths or excluded_path.        
+        A path indicating one specific object and all its children OR leaf attribute OR a specific value of leaf 'choice' field of a leaf object of the model
+        hierarchy that is supported or not supported by a specific port_type, depending on whether the request_type is included_paths or excluded_paths.
       type: object
       properties:
         path:
-          description: |
-            A path indicating one specific object and all its children, one specific attribute at a leaf of the model hierachy or the specific value of 'choice' value at the leaf of the model
-            hierarchy that is supported or not supported by a specific port_type , depending on whether the request_type is included_paths or excluded_path.
-            The path string should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute >]]` where node-x is a valid child object of node-(x-1) and
-            optional `attribute` is a child attribute of node-n .
+          description: |-
+            A path indicating one specific object and all its children, one specific attribute at a leaf of the model hierarchy or the specific value of 'choice' value at the leaf of the model
+            hierarchy that is supported or not supported by a specific port_type, depending on whether the request_type is included_paths or excluded_paths.
+            The path string should always be of the generic format `/<node1>/<node2>/..../<node-n>[/<attribute[/choice/<enum value of choice attribute>]]` where node-x is a valid child object of node-(x-1) and
+            optional `attribute` is a child attribute of node-n.
           type: string
           x-field-uid: 1
     Capabilities.PortType:
       description: >-
-          The information regarding the unique PortType for which the included or excluded capabilities are being returned.
+        The information regarding the unique PortType for which the included or excluded capabilities are being returned.
       type: object
       properties:
         value:
           description: >-
-            An unique string in the context of a specific open-traffic-generator that denotes a specific type of group of test ports with same set of capabilties.
-            e.g. 'ixia-c' could be the port_type.value for the reference ixia-c implementation. This name should be distinct and easily distinguishable by user of the test implementation 
-            adhering to this open-traffic-generator model. 
+            A unique string in the context of a specific open-traffic-generator that denotes a specific type of group of test ports with the same set of capabilities.
+            e.g. 'ixia-c' could be the port_type.value for the reference ixia-c implementation. This name should be distinct and easily distinguishable by the user of the test implementation
+            adhering to this open-traffic-generator model.
           type: string
           x-field-uid: 1
-    
-
-            
-        


### PR DESCRIPTION
### Feature Overview
-  Issue TBD
-  API to allow end-users to retrieve supported/unsupported features of the model for a  specific implementation.

---

### Feature Details
 - [Redocly docs for this feature/branch](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/capabilities/artifacts/openapi.yaml&nocors#tag/Capabilities/operation/get_capabilities)
-  New API under capabilities called get_capabilities 

- [Dev-Snappi branch reference](https://github.com/open-traffic-generator/snappi/tree/capabilities)
- Example command to fetch the dev-snappi branch:
  ```
  go get github.com/open-traffic-generator/snappi/gosnappi@capabilities  ```

---

### Code snippets

```go
TBD go-snippets with default / include / exclude / sub-tree examples .
```

---

### Test Specification (Optional)
- This is not for use with DUT but rather to determine capabilities of a specific open-traffic-generator compliant implementation at outlined in above description/examples.
