### PR TITLE
Isis otf

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -18378,6 +18378,8 @@ components:
               x-field-uid: 6
             ospfv3:
               x-field-uid: 7
+            link:
+              x-field-uid: 8
           x-field-uid: 1
           enum:
           - all
@@ -18387,6 +18389,7 @@ components:
           - isis
           - ospfv2
           - ospfv3
+          - link
         all:
           $ref: '#/components/schemas/State.Protocol.All'
           x-field-uid: 2
@@ -18411,6 +18414,9 @@ components:
         rocev2:
           $ref: '#/components/schemas/State.Protocol.Rocev2'
           x-field-uid: 9
+        link:
+          $ref: '#/components/schemas/State.Protocol.Link'
+          x-field-uid: 10
     State.Port.Link:
       description: |-
         Sets the link of configured ports.
@@ -18757,6 +18763,9 @@ components:
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
+        links:
+          $ref: '#/components/schemas/State.Protocol.Isis.Links'
+          x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: |-
         Sets state of configured ISIS routers.
@@ -18945,6 +18954,68 @@ components:
           enum:
           - up
           - down
+    State.Protocol.Isis.Links:
+      description: |-
+        Sets the state of configured routes
+      type: object
+      properties:
+        names:
+          description: |
+            The names of interface object of a device Router objects to control. If no names are specified then all route objects that match the x-constraint will be affected.
+
+            x-constraint:
+            - /components/schemas/Isis.Interface/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Isis.Interface/properties/name
+          x-field-uid: 1
+        up:
+          description: |-
+            Set up to true or false to interface state in UP or DOWN state respectively.
+          type: boolean
+          default: true
+          x-field-uid: 2
+        metric:
+          description: |-
+            The cost metric associated with the link.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 10
+          x-field-uid: 3
+    State.Protocol.Link:
+      description: |-
+        Sets the state of configured routes
+      type: object
+      properties:
+        names:
+          description: |
+            The names of interface object of a device Router objects to control. If no names are specified then all route objects that match the x-constraint will be affected.
+
+            x-constraint:
+            - /components/schemas/Isis.Interface/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Isis.Interface/properties/name
+          x-field-uid: 1
+        up:
+          description: |-
+            Set up to true or false to interface state in UP or DOWN state respectively.
+          type: boolean
+          default: true
+          x-field-uid: 2
+        metric:
+          description: |-
+            The cost metric associated with the link.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 10
+          x-field-uid: 3
     Control.Action:
       description: |-
         Request for triggering action against configured resources.
@@ -19530,14 +19601,23 @@ components:
           x-enum:
             initiate_graceful_restart:
               x-field-uid: 1
+            overload_bit:
+              x-field-uid: 2
           x-field-uid: 1
           enum:
           - initiate_graceful_restart
+          - overload_bit
         initiate_graceful_restart:
           description: |-
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: '#/components/schemas/Action.Protocol.Isis.InitiateRestart'
           x-field-uid: 2
+        overload_bit:
+          description: |-
+            Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives, it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system not to use the overloaded IS router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
+          type: boolean
+          default: true
+          x-field-uid: 3
     Action.Protocol.Isis.InitiateRestart:
       description: "Timers T1 and T2 are used both by a restarting router and a starting\
         \ router. Timer T3 is used only by a restarting router.\n- Timer T1 is maintained\

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -18378,8 +18378,6 @@ components:
               x-field-uid: 6
             ospfv3:
               x-field-uid: 7
-            link:
-              x-field-uid: 8
           x-field-uid: 1
           enum:
           - all
@@ -18389,7 +18387,6 @@ components:
           - isis
           - ospfv2
           - ospfv3
-          - link
         all:
           $ref: '#/components/schemas/State.Protocol.All'
           x-field-uid: 2
@@ -18414,9 +18411,6 @@ components:
         rocev2:
           $ref: '#/components/schemas/State.Protocol.Rocev2'
           x-field-uid: 9
-        link:
-          $ref: '#/components/schemas/State.Protocol.Link'
-          x-field-uid: 10
     State.Port.Link:
       description: |-
         Sets the link of configured ports.
@@ -18763,8 +18757,8 @@ components:
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
-        links:
-          $ref: '#/components/schemas/State.Protocol.Isis.Links'
+        simulated_links:
+          $ref: '#/components/schemas/State.Protocol.Isis.SimLinks'
           x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: |-
@@ -18954,14 +18948,14 @@ components:
           enum:
           - up
           - down
-    State.Protocol.Isis.Links:
+    State.Protocol.Isis.SimLinks:
       description: |-
-        Sets the state of configured routes
+        Sets the state of configured one or more Simulated Links (Interfaces)
       type: object
       properties:
         names:
           description: |
-            The names of interface object of a device Router objects to control. If no names are specified then all route objects that match the x-constraint will be affected.
+            The names of interfaces object of a device Interface objects to control. If no names are specified then all Simulated Interface objects that match the x-constraint will be affected.
 
             x-constraint:
             - /components/schemas/Isis.Interface/properties/name
@@ -18973,49 +18967,10 @@ components:
           x-field-uid: 1
         up:
           description: |-
-            Set up to true or false to interface state in UP or DOWN state respectively.
+            Set up to true or false to interface state in UP or DOWN state respectively in both direction. Thats is the UP/DOWN state is applied for a simulated link, connecting, say, a Node A to Node B and Node B to  Node A in both directions.
           type: boolean
           default: true
           x-field-uid: 2
-        metric:
-          description: |-
-            The cost metric associated with the link.
-          type: integer
-          format: uint32
-          maximum: 16777215
-          default: 10
-          x-field-uid: 3
-    State.Protocol.Link:
-      description: |-
-        Sets the state of configured routes
-      type: object
-      properties:
-        names:
-          description: |
-            The names of interface object of a device Router objects to control. If no names are specified then all route objects that match the x-constraint will be affected.
-
-            x-constraint:
-            - /components/schemas/Isis.Interface/properties/name
-          type: array
-          items:
-            type: string
-          x-constraint:
-          - /components/schemas/Isis.Interface/properties/name
-          x-field-uid: 1
-        up:
-          description: |-
-            Set up to true or false to interface state in UP or DOWN state respectively.
-          type: boolean
-          default: true
-          x-field-uid: 2
-        metric:
-          description: |-
-            The cost metric associated with the link.
-          type: integer
-          format: uint32
-          maximum: 16777215
-          default: 10
-          x-field-uid: 3
     Control.Action:
       description: |-
         Request for triggering action against configured resources.
@@ -19612,7 +19567,7 @@ components:
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: '#/components/schemas/Action.Protocol.Isis.InitiateRestart'
           x-field-uid: 2
-        overload_bit:
+        set_overload_bit:
           description: |-
             Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives, it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system not to use the overloaded IS router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
           type: boolean

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.46.0
+  version: 1.48.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -4244,6 +4244,16 @@ components:
         learned_information_filter:
           x-field-uid: 8
           $ref: '#/components/schemas/Bgp.LearnedInformationFilter'
+        traditional_nlri_for_ipv4_routes:
+          description: "If set to false, all IPv4 routes are advertised using MP_REACH\
+            \ NLRI and withdrawn using MP_UNREACH NLRI  as defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3.\
+            \  By default ( when set to true) , all IPv4 routes are advertised using\
+            \ traditional or REACH_NLRI and withdrawn  using UNREACH_NLRI as defined\
+            \ in https://datatracker.ietf.org/doc/html/rfc4271#section-4.3 .  This\
+            \ is applicable only for BGPv4 peers.            "
+          type: boolean
+          default: true
+          x-field-uid: 16
         v4_routes:
           x-field-uid: 9
           description: |-
@@ -5201,6 +5211,18 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
+        ipv4_mpls_unicast_prefix:
+          description: |-
+            If enabled, will store the information related to MPLS Unicast IPv4 Prefixes recieved from the peer.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        ipv6_mpls_unicast_prefix:
+          description: |-
+            If enabled, will store the information related to MPLS Unicast IPv6 Prefixes recieved from the peer.
+          type: boolean
+          default: false
+          x-field-uid: 4
     Bgp.V4RouteRange:
       description: |-
         Emulated BGPv4 route range.
@@ -25236,9 +25258,15 @@ components:
                 x-field-uid: 1
               ipv6_unicast:
                 x-field-uid: 2
+              ipv4_mpls_unicast:
+                x-field-uid: 3
+              ipv6_mpls_unicast:
+                x-field-uid: 4
             enum:
             - ipv4_unicast
             - ipv6_unicast
+            - ipv4_mpls_unicast
+            - ipv6_mpls_unicast
           x-field-uid: 2
         ipv4_unicast_filters:
           description: |-
@@ -25354,6 +25382,16 @@ components:
           items:
             $ref: '#/components/schemas/BgpPrefixIpv6Unicast.State'
           x-field-uid: 3
+        ipv4_mpls_unicast_prefixes:
+          type: array
+          items:
+            $ref: '#/components/schemas/BgpPrefixIpv4MplsUnicast.State'
+          x-field-uid: 4
+        ipv6_mpls_unicast_prefixes:
+          type: array
+          items:
+            $ref: '#/components/schemas/BgpPrefixIpv6MplsUnicast.State'
+          x-field-uid: 5
     BgpPrefixIpv4Unicast.State:
       description: |-
         IPv4 unicast prefix.
@@ -25876,6 +25914,178 @@ components:
         link_bandwidth_subtype:
           x-field-uid: 2
           $ref: '#/components/schemas/Result.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth'
+    BgpPrefixIpv4MplsUnicast.State:
+      description: |-
+        IPv4 MPLS unicast prefix.
+      type: object
+      properties:
+        ipv4_address:
+          description: |-
+            An IPv4 unicast address
+          type: string
+          x-field-uid: 1
+        prefix_length:
+          type: integer
+          format: uint32
+          maximum: 32
+          x-field-uid: 2
+        origin:
+          x-field-uid: 3
+          description: |-
+            The origin of the prefix.
+          type: string
+          x-enum:
+            igp:
+              x-field-uid: 1
+            egp:
+              x-field-uid: 2
+            incomplete:
+              x-field-uid: 3
+          enum:
+          - igp
+          - egp
+          - incomplete
+        path_id:
+          x-field-uid: 4
+          description: |-
+            The path id.
+          type: integer
+          format: uint32
+        ipv4_next_hop:
+          x-field-uid: 5
+          description: |-
+            The IPv4 address of the egress interface.
+          type: string
+          format: ipv4
+        ipv6_next_hop:
+          x-field-uid: 6
+          description: |-
+            The IPv6 address of the egress interface.
+          type: string
+          format: ipv6
+        labels:
+          description: |-
+            One or more MPLS Label 24 bit values bound to this address prefix.
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 7
+        communities:
+          x-field-uid: 8
+          description: |-
+            Optional community attributes.
+          type: array
+          items:
+            $ref: '#/components/schemas/Result.BgpCommunity'
+        extended_communities:
+          description: |-
+            Optional received Extended Community attributes. Each received Extended Community attribute is available for retrieval in two forms. Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use. In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the  'structured' format which is an optional field.
+          type: array
+          items:
+            $ref: '#/components/schemas/Result.ExtendedCommunity'
+          x-field-uid: 9
+        as_path:
+          x-field-uid: 10
+          $ref: '#/components/schemas/Result.BgpAsPath'
+        local_preference:
+          x-field-uid: 11
+          description: |-
+            The local preference is a well-known attribute and the value is used for route selection. The route with the highest local preference value is preferred.
+          type: integer
+          format: uint32
+        multi_exit_discriminator:
+          x-field-uid: 12
+          description: |-
+            The multi exit discriminator (MED) is an optional non-transitive attribute and the value is used for route selection. The route with the lowest MED value is preferred.
+          type: integer
+          format: uint32
+    BgpPrefixIpv6MplsUnicast.State:
+      description: |-
+        IPv6 MPLS unicast prefix.
+      type: object
+      properties:
+        ipv6_address:
+          description: |-
+            An IPv6 unicast address
+          type: string
+          x-field-uid: 1
+        prefix_length:
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 2
+        origin:
+          x-field-uid: 3
+          description: |-
+            The origin of the prefix.
+          type: string
+          x-enum:
+            igp:
+              x-field-uid: 1
+            egp:
+              x-field-uid: 2
+            incomplete:
+              x-field-uid: 3
+          enum:
+          - igp
+          - egp
+          - incomplete
+        path_id:
+          x-field-uid: 4
+          description: |-
+            The path id.
+          type: integer
+          format: uint32
+        ipv4_next_hop:
+          x-field-uid: 5
+          description: |-
+            The IPv4 address of the egress interface.
+          type: string
+          format: ipv4
+        ipv6_next_hop:
+          x-field-uid: 6
+          description: |-
+            The IPv6 address of the egress interface.
+          type: string
+          format: ipv6
+        labels:
+          description: |-
+            One or more MPLS Label 24 bit values bound to this address prefix.
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 7
+        communities:
+          x-field-uid: 8
+          description: |-
+            Optional community attributes.
+          type: array
+          items:
+            $ref: '#/components/schemas/Result.BgpCommunity'
+        extended_communities:
+          description: |-
+            Optional received Extended Community attributes. Each received Extended Community attribute is available for retrieval in two forms. Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use. In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the  'structured' format which is an optional field.
+          type: array
+          items:
+            $ref: '#/components/schemas/Result.ExtendedCommunity'
+          x-field-uid: 9
+        as_path:
+          x-field-uid: 10
+          $ref: '#/components/schemas/Result.BgpAsPath'
+        local_preference:
+          x-field-uid: 11
+          description: |-
+            The local preference is a well-known attribute and the value is used for route selection. The route with the highest local preference value is preferred.
+          type: integer
+          format: uint32
+        multi_exit_discriminator:
+          x-field-uid: 12
+          description: |-
+            The multi exit discriminator (MED) is an optional non-transitive attribute and the value is used for route selection. The route with the lowest MED value is preferred.
+          type: integer
+          format: uint32
     Result.BgpCommunity:
       description: |-
         BGP communities provide additional capability for tagging routes and  for modifying BGP routing policy on upstream and downstream routers. BGP community is a 32-bit number which is broken into 16-bit AS number and  a 16-bit custom value.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -13985,6 +13985,7 @@ message StateProtocol {
       isis = 5;
       ospfv2 = 6;
       ospfv3 = 7;
+      link = 8;
     }
   }
   // Description missing in models
@@ -14014,6 +14015,9 @@ message StateProtocol {
 
   // Description missing in models
   StateProtocolRocev2 rocev2 = 9;
+
+  // Description missing in models
+  StateProtocolLink link = 10;
 }
 
 // Sets the link of configured ports.
@@ -14286,6 +14290,9 @@ message StateProtocolIsis {
 
   // Description missing in models
   StateProtocolIsisRouters routers = 2;
+
+  // Description missing in models
+  StateProtocolIsisLinks links = 3;
 }
 
 // Sets state of configured ISIS routers.
@@ -14442,6 +14449,46 @@ message StateProtocolRocev2Peers {
   // If the desired state is 'down', RoCEv2 session(s) would be brought down.
   // required = true
   optional State.Enum state = 2;
+}
+
+// Sets the state of configured routes
+message StateProtocolIsisLinks {
+
+  // The names of interface object of a device Router objects to control. If no names
+  // are specified then all route objects that match the x-constraint will be affected.
+  // 
+  // x-constraint:
+  // - /components/schemas/Isis.Interface/properties/name
+  // 
+  repeated string names = 1;
+
+  // Set up to true or false to interface state in UP or DOWN state respectively.
+  // default = True
+  optional bool up = 2;
+
+  // The cost metric associated with the link.
+  // default = 10
+  optional uint32 metric = 3;
+}
+
+// Sets the state of configured routes
+message StateProtocolLink {
+
+  // The names of interface object of a device Router objects to control. If no names
+  // are specified then all route objects that match the x-constraint will be affected.
+  // 
+  // x-constraint:
+  // - /components/schemas/Isis.Interface/properties/name
+  // 
+  repeated string names = 1;
+
+  // Set up to true or false to interface state in UP or DOWN state respectively.
+  // default = True
+  optional bool up = 2;
+
+  // The cost metric associated with the link.
+  // default = 10
+  optional uint32 metric = 3;
 }
 
 // Request for triggering action against configured resources.
@@ -14914,6 +14961,7 @@ message ActionProtocolIsis {
     enum Enum {
       unspecified = 0;
       initiate_graceful_restart = 1;
+      overload_bit = 2;
     }
   }
   // Description missing in models
@@ -14922,6 +14970,13 @@ message ActionProtocolIsis {
 
   // Configuration for the initiation of the IS-IS Graceful Restart.
   ActionProtocolIsisInitiateRestart initiate_graceful_restart = 2;
+
+  // Set Overload Bit to true to deal with transient problems that prevent an IS from
+  // storing all the LSPs it receives, it sets the Overload Bit in the non-pseudonode
+  // LSP number Zero that it generates. Then other system not to use the overloaded IS
+  // router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
+  // default = True
+  optional bool overload_bit = 3;
 }
 
 // Timers T1 and T2 are used both by a restarting router and a starting router. Timer

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -13985,7 +13985,6 @@ message StateProtocol {
       isis = 5;
       ospfv2 = 6;
       ospfv3 = 7;
-      link = 8;
     }
   }
   // Description missing in models
@@ -14015,9 +14014,6 @@ message StateProtocol {
 
   // Description missing in models
   StateProtocolRocev2 rocev2 = 9;
-
-  // Description missing in models
-  StateProtocolLink link = 10;
 }
 
 // Sets the link of configured ports.
@@ -14292,7 +14288,7 @@ message StateProtocolIsis {
   StateProtocolIsisRouters routers = 2;
 
   // Description missing in models
-  StateProtocolIsisLinks links = 3;
+  StateProtocolIsisSimLinks simulated_links = 3;
 }
 
 // Sets state of configured ISIS routers.
@@ -14451,44 +14447,23 @@ message StateProtocolRocev2Peers {
   optional State.Enum state = 2;
 }
 
-// Sets the state of configured routes
-message StateProtocolIsisLinks {
+// Sets the state of configured one or more Simulated Links (Interfaces)
+message StateProtocolIsisSimLinks {
 
-  // The names of interface object of a device Router objects to control. If no names
-  // are specified then all route objects that match the x-constraint will be affected.
+  // The names of interfaces object of a device Interface objects to control. If no names
+  // are specified then all Simulated Interface objects that match the x-constraint will
+  // be affected.
   // 
   // x-constraint:
   // - /components/schemas/Isis.Interface/properties/name
   // 
   repeated string names = 1;
 
-  // Set up to true or false to interface state in UP or DOWN state respectively.
+  // Set up to true or false to interface state in UP or DOWN state respectively in both
+  // direction. Thats is the UP/DOWN state is applied for a simulated link, connecting,
+  // say, a Node A to Node B and Node B to  Node A in both directions.
   // default = True
   optional bool up = 2;
-
-  // The cost metric associated with the link.
-  // default = 10
-  optional uint32 metric = 3;
-}
-
-// Sets the state of configured routes
-message StateProtocolLink {
-
-  // The names of interface object of a device Router objects to control. If no names
-  // are specified then all route objects that match the x-constraint will be affected.
-  // 
-  // x-constraint:
-  // - /components/schemas/Isis.Interface/properties/name
-  // 
-  repeated string names = 1;
-
-  // Set up to true or false to interface state in UP or DOWN state respectively.
-  // default = True
-  optional bool up = 2;
-
-  // The cost metric associated with the link.
-  // default = 10
-  optional uint32 metric = 3;
 }
 
 // Request for triggering action against configured resources.
@@ -14976,7 +14951,7 @@ message ActionProtocolIsis {
   // LSP number Zero that it generates. Then other system not to use the overloaded IS
   // router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
   // default = True
-  optional bool overload_bit = 3;
+  optional bool set_overload_bit = 3;
 }
 
 // Timers T1 and T2 are used both by a restarting router and a starting router. Timer

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.46.0
+/* Open Traffic Generator API 1.48.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -2941,6 +2941,14 @@ message BgpV4Peer {
   // Description missing in models
   BgpLearnedInformationFilter learned_information_filter = 8;
 
+  // If set to false, all IPv4 routes are advertised using MP_REACH NLRI and withdrawn
+  // using MP_UNREACH NLRI  as defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3.
+  // By default ( when set to true) , all IPv4 routes are advertised using traditional
+  // or REACH_NLRI and withdrawn  using UNREACH_NLRI as defined in https://datatracker.ietf.org/doc/html/rfc4271#section-4.3
+  // .  This is applicable only for BGPv4 peers.
+  // default = True
+  optional bool traditional_nlri_for_ipv4_routes = 16;
+
   // Emulated BGPv4 route ranges.
   repeated BgpV4RouteRange v4_routes = 9;
 
@@ -3718,6 +3726,16 @@ message BgpLearnedInformationFilter {
   // from the peer.
   // default = False
   optional bool unicast_ipv6_prefix = 2;
+
+  // If enabled, will store the information related to MPLS Unicast IPv4 Prefixes recieved
+  // from the peer.
+  // default = False
+  optional bool ipv4_mpls_unicast_prefix = 3;
+
+  // If enabled, will store the information related to MPLS Unicast IPv6 Prefixes recieved
+  // from the peer.
+  // default = False
+  optional bool ipv6_mpls_unicast_prefix = 4;
 }
 
 // Emulated BGPv4 route range.
@@ -18246,6 +18264,8 @@ message BgpPrefixStateRequest {
       unspecified = 0;
       ipv4_unicast = 1;
       ipv6_unicast = 2;
+      ipv4_mpls_unicast = 3;
+      ipv6_mpls_unicast = 4;
     }
   }
   // Specify which prefixes to return. If the list is empty or missing then all prefixes
@@ -18326,6 +18346,12 @@ message BgpPrefixesState {
 
   // Description missing in models
   repeated BgpPrefixIpv6UnicastState ipv6_unicast_prefixes = 3;
+
+  // Description missing in models
+  repeated BgpPrefixIpv4MplsUnicastState ipv4_mpls_unicast_prefixes = 4;
+
+  // Description missing in models
+  repeated BgpPrefixIpv6MplsUnicastState ipv6_mpls_unicast_prefixes = 5;
 }
 
 // IPv4 unicast prefix.
@@ -18734,6 +18760,114 @@ message ResultExtendedCommunityNonTransitive2OctetAsType {
 
   // Description missing in models
   ResultExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth link_bandwidth_subtype = 2;
+}
+
+// IPv4 MPLS unicast prefix.
+message BgpPrefixIpv4MplsUnicastState {
+
+  // An IPv4 unicast address
+  optional string ipv4_address = 1;
+
+  // Description missing in models
+  optional uint32 prefix_length = 2;
+
+  message Origin {
+    enum Enum {
+      unspecified = 0;
+      igp = 1;
+      egp = 2;
+      incomplete = 3;
+    }
+  }
+  // The origin of the prefix.
+  optional Origin.Enum origin = 3;
+
+  // The path id.
+  optional uint32 path_id = 4;
+
+  // The IPv4 address of the egress interface.
+  optional string ipv4_next_hop = 5;
+
+  // The IPv6 address of the egress interface.
+  optional string ipv6_next_hop = 6;
+
+  // One or more MPLS Label 24 bit values bound to this address prefix.
+  repeated uint32 labels = 7;
+
+  // Optional community attributes.
+  repeated ResultBgpCommunity communities = 8;
+
+  // Optional received Extended Community attributes. Each received Extended Community
+  // attribute is available for retrieval in two forms. Support of the 'raw' format in
+  // which all 8 bytes (16 hex characters) is always present and available for use. In
+  // addition, if supported by the implementation, the Extended Community attribute may
+  // also be retrieved in the  'structured' format which is an optional field.
+  repeated ResultExtendedCommunity extended_communities = 9;
+
+  // Description missing in models
+  ResultBgpAsPath as_path = 10;
+
+  // The local preference is a well-known attribute and the value is used for route selection.
+  // The route with the highest local preference value is preferred.
+  optional uint32 local_preference = 11;
+
+  // The multi exit discriminator (MED) is an optional non-transitive attribute and the
+  // value is used for route selection. The route with the lowest MED value is preferred.
+  optional uint32 multi_exit_discriminator = 12;
+}
+
+// IPv6 MPLS unicast prefix.
+message BgpPrefixIpv6MplsUnicastState {
+
+  // An IPv6 unicast address
+  optional string ipv6_address = 1;
+
+  // Description missing in models
+  optional uint32 prefix_length = 2;
+
+  message Origin {
+    enum Enum {
+      unspecified = 0;
+      igp = 1;
+      egp = 2;
+      incomplete = 3;
+    }
+  }
+  // The origin of the prefix.
+  optional Origin.Enum origin = 3;
+
+  // The path id.
+  optional uint32 path_id = 4;
+
+  // The IPv4 address of the egress interface.
+  optional string ipv4_next_hop = 5;
+
+  // The IPv6 address of the egress interface.
+  optional string ipv6_next_hop = 6;
+
+  // One or more MPLS Label 24 bit values bound to this address prefix.
+  repeated uint32 labels = 7;
+
+  // Optional community attributes.
+  repeated ResultBgpCommunity communities = 8;
+
+  // Optional received Extended Community attributes. Each received Extended Community
+  // attribute is available for retrieval in two forms. Support of the 'raw' format in
+  // which all 8 bytes (16 hex characters) is always present and available for use. In
+  // addition, if supported by the implementation, the Extended Community attribute may
+  // also be retrieved in the  'structured' format which is an optional field.
+  repeated ResultExtendedCommunity extended_communities = 9;
+
+  // Description missing in models
+  ResultBgpAsPath as_path = 10;
+
+  // The local preference is a well-known attribute and the value is used for route selection.
+  // The route with the highest local preference value is preferred.
+  optional uint32 local_preference = 11;
+
+  // The multi exit discriminator (MED) is an optional non-transitive attribute and the
+  // value is used for route selection. The route with the lowest MED value is preferred.
+  optional uint32 multi_exit_discriminator = 12;
 }
 
 // BGP communities provide additional capability for tagging routes and  for modifying

--- a/control/isis.yaml
+++ b/control/isis.yaml
@@ -18,12 +18,23 @@ components:
           x-enum:
             initiate_graceful_restart:
               x-field-uid: 1
+            overload_bit:
+              x-field-uid: 2
           x-field-uid: 1
         initiate_graceful_restart:
           description: >-
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: "#/components/schemas/Action.Protocol.Isis.InitiateRestart"
           x-field-uid: 2
+        overload_bit:
+          description: >-
+            Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives,
+            it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system
+            not to use the overloaded IS router as a tranisient router. 
+            Set Overload Bit to false, to toggle the above process.
+          type: boolean
+          default: true
+          x-field-uid: 3
 
     Action.Protocol.Isis.InitiateRestart:
       description: |-

--- a/control/isis.yaml
+++ b/control/isis.yaml
@@ -26,7 +26,7 @@ components:
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: "#/components/schemas/Action.Protocol.Isis.InitiateRestart"
           x-field-uid: 2
-        overload_bit:
+        set_overload_bit:
           description: >-
             Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives,
             it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -196,6 +196,9 @@ components:
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
+        links:
+          $ref: '#/components/schemas/State.Protocol.Isis.Links'
+          x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: >-
         Sets state of configured ISIS routers.
@@ -358,3 +361,63 @@ components:
               x-field-uid: 1
             down:
               x-field-uid: 2
+
+    State.Protocol.Isis.Links:
+      description: >-
+        Sets the state of configured routes
+      type: object
+      properties:
+        names:
+          description: >-
+            The names of interface object of a device Router objects to control.
+            If no names are specified then all route objects that match the x-constraint will be affected.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Isis.Interface/properties/name'
+          x-field-uid: 1
+        up:
+          description: >-
+            Set up to true or false to interface state in UP or DOWN state respectively.
+          type: boolean 
+          default: true
+          x-field-uid: 2
+        metric:
+          description: >-
+            The cost metric associated with the link.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 10
+          x-field-uid: 3
+
+    State.Protocol.Link:
+      description: >-
+        Sets the state of configured routes
+      type: object
+      properties:
+        names:
+          description: >-
+            The names of interface object of a device Router objects to control.
+            If no names are specified then all route objects that match the x-constraint will be affected.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Isis.Interface/properties/name'
+          x-field-uid: 1
+        up:
+          description: >-
+            Set up to true or false to interface state in UP or DOWN state respectively.
+          type: boolean 
+          default: true
+          x-field-uid: 2
+        metric:
+          description: >-
+            The cost metric associated with the link.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 10
+          x-field-uid: 3

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -196,8 +196,8 @@ components:
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
-        links:
-          $ref: '#/components/schemas/State.Protocol.Isis.Links'
+        simulated_links:
+          $ref: '#/components/schemas/State.Protocol.Isis.SimLinks'
           x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: >-
@@ -362,15 +362,15 @@ components:
             down:
               x-field-uid: 2
 
-    State.Protocol.Isis.Links:
+    State.Protocol.Isis.SimLinks:
       description: >-
-        Sets the state of configured routes
+        Sets the state of configured one or more Simulated Links (Interfaces)
       type: object
       properties:
         names:
           description: >-
-            The names of interface object of a device Router objects to control.
-            If no names are specified then all route objects that match the x-constraint will be affected.
+            The names of interfaces object of a device Interface objects to control.
+            If no names are specified then all Simulated Interface objects that match the x-constraint will be affected.
           type: array
           items:
             type: string
@@ -379,45 +379,8 @@ components:
           x-field-uid: 1
         up:
           description: >-
-            Set up to true or false to interface state in UP or DOWN state respectively.
+            Set up to true or false to interface state in UP or DOWN state respectively in both direction. Thats is the UP/DOWN state is applied for a simulated link,
+            connecting, say, a Node A to Node B and Node B to  Node A in both directions.
           type: boolean 
           default: true
           x-field-uid: 2
-        metric:
-          description: >-
-            The cost metric associated with the link.
-          type: integer
-          format: uint32
-          maximum: 16777215
-          default: 10
-          x-field-uid: 3
-
-    State.Protocol.Link:
-      description: >-
-        Sets the state of configured routes
-      type: object
-      properties:
-        names:
-          description: >-
-            The names of interface object of a device Router objects to control.
-            If no names are specified then all route objects that match the x-constraint will be affected.
-          type: array
-          items:
-            type: string
-          x-constraint:
-          - '/components/schemas/Isis.Interface/properties/name'
-          x-field-uid: 1
-        up:
-          description: >-
-            Set up to true or false to interface state in UP or DOWN state respectively.
-          type: boolean 
-          default: true
-          x-field-uid: 2
-        metric:
-          description: >-
-            The cost metric associated with the link.
-          type: integer
-          format: uint32
-          maximum: 16777215
-          default: 10
-          x-field-uid: 3

--- a/control/state.yaml
+++ b/control/state.yaml
@@ -93,8 +93,6 @@ components:
               x-field-uid: 6
             ospfv3:
               x-field-uid: 7
-            link:
-              x-field-uid: 8
           x-field-uid: 1
         all:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.All'
@@ -120,6 +118,3 @@ components:
         rocev2:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.Rocev2'
           x-field-uid: 9
-        link:
-          $ref: './protocol.yaml#/components/schemas/State.Protocol.Link'
-          x-field-uid: 10

--- a/control/state.yaml
+++ b/control/state.yaml
@@ -93,6 +93,8 @@ components:
               x-field-uid: 6
             ospfv3:
               x-field-uid: 7
+            link:
+              x-field-uid: 8
           x-field-uid: 1
         all:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.All'
@@ -118,3 +120,6 @@ components:
         rocev2:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.Rocev2'
           x-field-uid: 9
+        link:
+          $ref: './protocol.yaml#/components/schemas/State.Protocol.Link'
+          x-field-uid: 10


### PR DESCRIPTION
### Feature Overview
- **Related Issue:** (e.g., Fixes `#<https://partnerissuetracker.corp.google.com/issues/433281254>`)
- **Brief Description:**  
  A user will be able to change the following on-the-fly (OTF) for using OTG-API:

    - Turn on On/Off: Overload Bit.
    - Up/Down Simulated Link.
---
 Modifying the LINK Metric on the fly will be in a separate PR.
### Feature Details
 - [Redocly docs for this feature/branch](<https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/isis-otf/artifacts/openapi.yaml&nocors#tag/Control>)

**Following are just meant to locate where changes done in the model.**
A) Overload bit on the fly:

-   SetControlAction().Protocol().Isis().SetOverloadBit(true/false)

B) There two ways for changing the following
-   Simulated Link Up/Down on fly:

SetControlState().Protocol().Isis().Links().AddNames("Interface_name").SetUp(true/false)


