### PR TITLE
ISIS OTF: SIMULATED LINKS

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -18378,6 +18378,8 @@ components:
               x-field-uid: 6
             ospfv3:
               x-field-uid: 7
+            link:
+              x-field-uid: 8
           x-field-uid: 1
           enum:
           - all
@@ -18387,6 +18389,7 @@ components:
           - isis
           - ospfv2
           - ospfv3
+          - link
         all:
           $ref: '#/components/schemas/State.Protocol.All'
           x-field-uid: 2
@@ -18411,6 +18414,9 @@ components:
         rocev2:
           $ref: '#/components/schemas/State.Protocol.Rocev2'
           x-field-uid: 9
+        link:
+          $ref: '#/components/schemas/State.Protocol.Link'
+          x-field-uid: 10
     State.Port.Link:
       description: |-
         Sets the link of configured ports.
@@ -18757,6 +18763,9 @@ components:
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
+        links:
+          $ref: '#/components/schemas/State.Protocol.Isis.Links'
+          x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: |-
         Sets state of configured ISIS routers.
@@ -18945,6 +18954,68 @@ components:
           enum:
           - up
           - down
+    State.Protocol.Isis.Links:
+      description: |-
+        Sets the state of configured routes
+      type: object
+      properties:
+        names:
+          description: |
+            The names of interface object of a device Router objects to control. If no names are specified then all route objects that match the x-constraint will be affected.
+
+            x-constraint:
+            - /components/schemas/Isis.Interface/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Isis.Interface/properties/name
+          x-field-uid: 1
+        up:
+          description: |-
+            Set up to true or false to interface state in UP or DOWN state respectively.
+          type: boolean
+          default: true
+          x-field-uid: 2
+        metric:
+          description: |-
+            The cost metric associated with the link.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 10
+          x-field-uid: 3
+    State.Protocol.Link:
+      description: |-
+        Sets the state of configured routes
+      type: object
+      properties:
+        names:
+          description: |
+            The names of interface object of a device Router objects to control. If no names are specified then all route objects that match the x-constraint will be affected.
+
+            x-constraint:
+            - /components/schemas/Isis.Interface/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Isis.Interface/properties/name
+          x-field-uid: 1
+        up:
+          description: |-
+            Set up to true or false to interface state in UP or DOWN state respectively.
+          type: boolean
+          default: true
+          x-field-uid: 2
+        metric:
+          description: |-
+            The cost metric associated with the link.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 10
+          x-field-uid: 3
     Control.Action:
       description: |-
         Request for triggering action against configured resources.
@@ -19530,14 +19601,23 @@ components:
           x-enum:
             initiate_graceful_restart:
               x-field-uid: 1
+            overload_bit:
+              x-field-uid: 2
           x-field-uid: 1
           enum:
           - initiate_graceful_restart
+          - overload_bit
         initiate_graceful_restart:
           description: |-
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: '#/components/schemas/Action.Protocol.Isis.InitiateRestart'
           x-field-uid: 2
+        overload_bit:
+          description: |-
+            Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives, it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system not to use the overloaded IS router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
+          type: boolean
+          default: true
+          x-field-uid: 3
     Action.Protocol.Isis.InitiateRestart:
       description: "Timers T1 and T2 are used both by a restarting router and a starting\
         \ router. Timer T3 is used only by a restarting router.\n- Timer T1 is maintained\

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -18378,8 +18378,6 @@ components:
               x-field-uid: 6
             ospfv3:
               x-field-uid: 7
-            link:
-              x-field-uid: 8
           x-field-uid: 1
           enum:
           - all
@@ -18389,7 +18387,6 @@ components:
           - isis
           - ospfv2
           - ospfv3
-          - link
         all:
           $ref: '#/components/schemas/State.Protocol.All'
           x-field-uid: 2
@@ -18414,9 +18411,6 @@ components:
         rocev2:
           $ref: '#/components/schemas/State.Protocol.Rocev2'
           x-field-uid: 9
-        link:
-          $ref: '#/components/schemas/State.Protocol.Link'
-          x-field-uid: 10
     State.Port.Link:
       description: |-
         Sets the link of configured ports.
@@ -18763,8 +18757,8 @@ components:
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
-        links:
-          $ref: '#/components/schemas/State.Protocol.Isis.Links'
+        simulated_links:
+          $ref: '#/components/schemas/State.Protocol.Isis.SimLinks'
           x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: |-
@@ -18954,14 +18948,14 @@ components:
           enum:
           - up
           - down
-    State.Protocol.Isis.Links:
+    State.Protocol.Isis.SimLinks:
       description: |-
-        Sets the state of configured routes
+        Sets the state of configured one or more Simulated Links (Interfaces)
       type: object
       properties:
         names:
           description: |
-            The names of interface object of a device Router objects to control. If no names are specified then all route objects that match the x-constraint will be affected.
+            The names of interfaces object of a device Interface objects to control. If no names are specified then all Simulated Interface objects that match the x-constraint will be affected.
 
             x-constraint:
             - /components/schemas/Isis.Interface/properties/name
@@ -18973,49 +18967,10 @@ components:
           x-field-uid: 1
         up:
           description: |-
-            Set up to true or false to interface state in UP or DOWN state respectively.
+            Set up to true or false to interface state in UP or DOWN state respectively in both direction. Thats is the UP/DOWN state is applied for a simulated link, connecting, say, a Node A to Node B and Node B to  Node A in both directions.
           type: boolean
           default: true
           x-field-uid: 2
-        metric:
-          description: |-
-            The cost metric associated with the link.
-          type: integer
-          format: uint32
-          maximum: 16777215
-          default: 10
-          x-field-uid: 3
-    State.Protocol.Link:
-      description: |-
-        Sets the state of configured routes
-      type: object
-      properties:
-        names:
-          description: |
-            The names of interface object of a device Router objects to control. If no names are specified then all route objects that match the x-constraint will be affected.
-
-            x-constraint:
-            - /components/schemas/Isis.Interface/properties/name
-          type: array
-          items:
-            type: string
-          x-constraint:
-          - /components/schemas/Isis.Interface/properties/name
-          x-field-uid: 1
-        up:
-          description: |-
-            Set up to true or false to interface state in UP or DOWN state respectively.
-          type: boolean
-          default: true
-          x-field-uid: 2
-        metric:
-          description: |-
-            The cost metric associated with the link.
-          type: integer
-          format: uint32
-          maximum: 16777215
-          default: 10
-          x-field-uid: 3
     Control.Action:
       description: |-
         Request for triggering action against configured resources.
@@ -19612,7 +19567,7 @@ components:
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: '#/components/schemas/Action.Protocol.Isis.InitiateRestart'
           x-field-uid: 2
-        overload_bit:
+        set_overload_bit:
           description: |-
             Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives, it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system not to use the overloaded IS router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
           type: boolean

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.50.0
+  version: 1.51.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -13991,25 +13991,16 @@ components:
           x-field-uid: 14
           $ref: '#/components/schemas/Pattern.Flow.Ipv4.Dst'
         options:
+          description: |-
+            IPv4 options are optional extensions for the IPv4 header that can be utilised to provide additional information about the IPv4 datagram.  It is encoded as a series of type, length and value attributes.  The IP header length MUST be increased to accommodate the extra bytes needed to encode the IP options. The length of the all options included to a IPv4 header should not exceed 40 bytes since IPv4 Header length (4 bits) can at max specify 15 4-word octets for a total of 60 bytes which includes 20 bytes needed for mandatory attributes of the IPv4 header. If the user adds multiples IPv4 options that exceeds 40 bytes and specify header length as "auto", implementation should throw error. Currently IP options supported are: 1. router_alert option allows devices to intercept packets not addressed to them directly as defined in RFC2113. 2. custom option is provided to configure user defined IP options as needed. 3. timestamp option allows routers to record their local timestamp and IP address for latency measurement and path diagnostics as defined in RFC791.  4. end_of_options option allows routers to specify the end of options list. This may only be used if the end of the options does not coincide with the end of the IP header. It is a single octet value and padding is implicitly added to conform to a work boundary.
           type: array
           minItems: 0
           items:
             $ref: '#/components/schemas/Flow.Ipv4.Options'
           x-field-uid: 15
     Flow.Ipv4.Options:
-      description: "IPv4 options are optional extensions for the IPv4 header that\
-        \ can be utilised to provide additional information about the IPv4 datagram.\
-        \  It is encoded as a series of type, length and value attributes.  The IP\
-        \ header length MUST be increased to accommodate the extra bytes needed to\
-        \ encode the IP options. The length of the all options included to a IPv4\
-        \ header should not exceed 40 bytes since IPv4 Header length (4 bits) can\
-        \ at max specify 15 4-word octets for a total of 60 bytes which includes 20\
-        \ bytes needed for mandatory attributes of the IPv4 header. If the user adds\
-        \ multiples IPv4 options that exceeds 40 bytes and specify header length as\
-        \ \"auto\", implementation should throw error. Currently IP options supported\
-        \ are: 1. router_alert option allows devices to intercept packets not addressed\
-        \ to them directly as defined in RFC2113. 2. custom option is provided to\
-        \ configure user defined IP options as needed. "
+      description: |-
+        IPv4 options are optional extensions for the IPv4 header
       type: object
       properties:
         choice:
@@ -14021,12 +14012,21 @@ components:
               x-field-uid: 1
             custom:
               x-field-uid: 2
+            timestamp:
+              x-field-uid: 3
+            end_of_options:
+              x-field-uid: 4
           enum:
           - router_alert
           - custom
+          - timestamp
+          - end_of_options
         custom:
           $ref: '#/components/schemas/Flow.Ipv4Options.Custom'
           x-field-uid: 2
+        timestamp:
+          $ref: '#/components/schemas/Flow.Ipv4Options.Timestamp'
+          x-field-uid: 3
     Flow.Ipv4Options.Custom:
       description: |-
         User defined IP options to be appended to the IPv4 header.
@@ -14092,6 +14092,107 @@ components:
           format: uint32
           default: 0
           x-field-uid: 3
+    Flow.Ipv4Options.Timestamp:
+      description: |-
+        IPv4 timestamp option to be appended to the IPv4 header.
+      type: object
+      properties:
+        pointer:
+          $ref: '#/components/schemas/Flow.Ipv4Options.Timestamp.Pointer'
+          x-field-uid: 1
+        overflow:
+          description: |-
+            A counter that indicates the number of intermediate nodes that were unable to record a timestamp because the options data area was full.
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Overflow'
+        format:
+          $ref: '#/components/schemas/Flow.Ipv4Options.Timestamp.Format'
+          x-field-uid: 3
+    Flow.Ipv4Options.Timestamp.Pointer:
+      description: |-
+        The attribute pointer indicates the octet offset where the next router should begin recording its data.
+        Choices of input are,
+        1. auto : The OTG implementation can provide a system generated value for this property. If the implementation is unable to generate a value, the default value must be used.
+        2. value: User can configure the pointer value.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: auto
+          x-field-uid: 1
+          x-enum:
+            auto:
+              x-field-uid: 1
+            value:
+              x-field-uid: 2
+          enum:
+          - auto
+          - value
+        value:
+          type: integer
+          format: uint32
+          default: 5
+          minimum: 5
+          maximum: 40
+          x-field-uid: 2
+    Flow.Ipv4Options.Timestamp.Format:
+      description: |-
+        The format field defines the structural layout of the options data area and the specific recording logic routers must follow when appending timestamps and IP addresses.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            timestamps:
+              x-field-uid: 1
+            address_and_timestamps:
+              x-field-uid: 2
+            prespecified_address_and_timestamps:
+              x-field-uid: 3
+          x-field-uid: 1
+          enum:
+          - timestamps
+          - address_and_timestamps
+          - prespecified_address_and_timestamps
+        timestamps:
+          description: |-
+            A recording mode where routers append only their 32-bit universal timestamps sequentially into the options data area.
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/Flow.Ipv4Options.Timestamp.Format.Timestamps'
+          x-field-uid: 2
+        address_and_timestamps:
+          description: |-
+            A recording mode where each router appends its 32-bit IPv4 address followed immediately by its 32-bit universal timestamp into the options data area.
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps'
+          x-field-uid: 3
+        prespecified_address_and_timestamps:
+          description: |-
+            A selective recording mode where only routers whose IPv4 addresses match the pre-listed entries in the header record their 32-bit universal timestamps into the options data area.
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps'
+          x-field-uid: 4
+    Flow.Ipv4Options.Timestamp.Format.Timestamps:
+      type: object
+      properties:
+        timestamp:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.Timestamps.Timestamp'
+    Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps:
+      type: object
+      properties:
+        address:
+          x-field-uid: 1
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Address'
+        timestamp:
+          x-field-uid: 2
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Timestamp'
     Flow.Ipv4.Priority:
       description: |-
         A container for ipv4 raw, tos, dscp ip priorities.
@@ -32310,6 +32411,259 @@ components:
           x-field-uid: 5
         decrement:
           $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Custom.Type.OptionNumber.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Ipv4Options.Timestamp.Overflow.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+          maximum: 15
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+          maximum: 15
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+          maximum: 16
+    Pattern.Flow.Ipv4Options.Timestamp.Overflow:
+      description: |-
+        A counter that indicates the number of intermediate nodes that were unable to record a timestamp because the options data area was full.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+          maximum: 15
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+            maximum: 15
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Overflow.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Overflow.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Ipv4Options.Timestamp.Format.Timestamps.Timestamp.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Ipv4Options.Timestamp.Format.Timestamps.Timestamp:
+      description: |-
+        A 32-bit value representing the time of packet processing, recorded as the number of milliseconds elapsed since midnight Universal Time (UT).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.Timestamps.Timestamp.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.Timestamps.Timestamp.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Address.Counter:
+      description: |-
+        ipv4 counter pattern
+      type: object
+      properties:
+        start:
+          type: string
+          x-field-uid: 1
+          default: 0.0.0.0
+          format: ipv4
+        step:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.1
+          format: ipv4
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Address:
+      description: |-
+        IPv4 address of the router interface that handled the packet, serving as a network identifier for the corresponding timestamp entry.
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: string
+          x-field-uid: 2
+          default: 0.0.0.0
+          format: ipv4
+        values:
+          type: array
+          items:
+            type: string
+            format: ipv4
+          x-field-uid: 3
+          default:
+          - 0.0.0.0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Address.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Address.Counter'
+          x-field-uid: 6
+    Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Timestamp.Counter:
+      description: |-
+        integer counter pattern
+      type: object
+      properties:
+        start:
+          type: integer
+          x-field-uid: 1
+          default: 0
+          format: uint32
+        step:
+          type: integer
+          x-field-uid: 2
+          default: 1
+          format: uint32
+        count:
+          type: integer
+          x-field-uid: 3
+          default: 1
+          format: uint32
+    Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Timestamp:
+      description: |-
+        A 32-bit value representing the time of packet processing, recorded as the number of milliseconds elapsed since midnight Universal Time (UT).
+      type: object
+      properties:
+        choice:
+          type: string
+          x-enum:
+            value:
+              x-field-uid: 2
+            values:
+              x-field-uid: 3
+            increment:
+              x-field-uid: 4
+            decrement:
+              x-field-uid: 5
+          default: value
+          x-field-uid: 1
+          enum:
+          - value
+          - values
+          - increment
+          - decrement
+        value:
+          type: integer
+          x-field-uid: 2
+          default: 0
+          format: uint32
+        values:
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 3
+          default:
+          - 0
+        increment:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Timestamp.Counter'
+          x-field-uid: 5
+        decrement:
+          $ref: '#/components/schemas/Pattern.Flow.Ipv4Options.Timestamp.Format.AddressAndTimestamps.Timestamp.Counter'
           x-field-uid: 6
     Pattern.Flow.Ipv4.Priority.Raw.Counter:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -18763,7 +18763,7 @@ components:
           - down
     State.Protocol.Isis:
       description: |-
-        Sets state of configured ISIS routers.
+        Sets state of configured ISIS routers and Links.
       type: object
       required:
       - choice
@@ -18773,9 +18773,12 @@ components:
           x-enum:
             routers:
               x-field-uid: 1
+            simulated_links:
+              x-field-uid: 2
           x-field-uid: 1
           enum:
           - routers
+          - simulated_links
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19578,12 +19578,9 @@ components:
           x-enum:
             initiate_graceful_restart:
               x-field-uid: 1
-            overload_bit:
-              x-field-uid: 2
           x-field-uid: 1
           enum:
           - initiate_graceful_restart
-          - overload_bit
         initiate_graceful_restart:
           description: |-
             Configuration for the initiation of the IS-IS Graceful Restart.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19091,25 +19091,26 @@ components:
           x-constraint:
           - /components/schemas/Isis.Interface/properties/name
           x-field-uid: 1
-        up:
-          description: "Set up to true or false to interface state in UP or DOWN state\
-            \ respectively in both direction. Thats is the UP/DOWN state is applied\
-            \ for a simulated link,\nconnecting, say, a Node A to Node B and Node\
-            \ B to Node A in both directions.\nSetting to false will result in the\
-            \ selected set of Simulated Links to be set in disconnected state. This\
-            \ should result in the link to be removed from the \nExtended IS Reachability\
-            \ TLV in subsequent LSP transmitted ( with incremented Sequence Number\
-            \ ) from both the Simulated or Emulated Router on which this link is \n\
-            located as well the Simulated or Emulated Router at the other end of the\
-            \ link i.e. this will bring down the Simulated Links on both ends.\nSimilarly,\
-            \ setting to true should result in the neighbor information to be re-introduced\
-            \ in Extended IS Reachability sent in subsequent LSP Update by the \n\
-            Router containing the Simulated Link and the neighboring Router at the\
-            \ other end of the link. Note that if the link is already in 'up' state\
-            \ and the value is set \nto 'true' or it is in 'down' state and the value\
-            \ is set to 'false', those links in the request should be ignored.\n\n\
-            Example:\nSuppose Emulated Router ER (680000000003) is connected to Simulated\
-            \ Routers:  ST1('770000000001'), ST2('770000000002') and ST3('770000000003')\
+        state:
+          description: "description: |-\nSet ControlState to UP or DOWN to interface\
+            \ state in UP or DOWN state respectively in both directions. Thats is\
+            \ the UP/DOWN state is applied for a simulated link,\nconnecting, say,\
+            \ a Node A to Node B and Node B to Node A in both directions.\nSetting\
+            \ Control State to DOWN will result in the selected set of Simulated Links\
+            \ to be set in disconnected state. This should result in the link to be\
+            \ removed from the \nExtended IS Reachability TLV in subsequent LSP transmitted\
+            \ ( with incremented Sequence Number ) from both the Simulated or Emulated\
+            \ Router on which this link is \nlocated as well the Simulated or Emulated\
+            \ Router at the other end of the link i.e. this will bring down the Simulated\
+            \ Links on both ends.\nSimilarly, setting the Control State to UP should\
+            \ result in the neighbor information to be re-introduced in Extended IS\
+            \ Reachability sent in subsequent LSP Update by the \nRouter containing\
+            \ the Simulated Link and the neighboring Router at the other end of the\
+            \ link. Note that if the link is already in UP state and the Control State\
+            \ is set \nto UP again or if the state is in DOWN state and the Control\
+            \ State is set to DOWN again, those links in the request should be ignored.\n\
+            \nExample:\nSuppose Emulated Router ER (680000000003) is connected to\
+            \ Simulated Routers:  ST1('770000000001'), ST2('770000000002') and ST3('770000000003')\
             \ in a ring topology.\nER <--> ST1 <--> ST2\n^\t            (A) ^\n|\t\
             \t              |\nv \t          (B) v\n-------ST3-------\n\nBefore the\
             \ AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3\
@@ -19121,9 +19122,16 @@ components:
             \ as in ISIS Link State PDU (LSP) information in Get State\nLSP-ID of\
             \ ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']\n\
             LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']"
-          type: boolean
-          default: false
+          type: string
           x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          enum:
+          - up
+          - down
     Control.Action:
       description: |-
         Request for triggering action against configured resources.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.51.0
+  version: 1.52.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -20213,6 +20213,8 @@ components:
                 x-field-uid: 12
               last_change:
                 x-field-uid: 13
+              speed:
+                x-field-uid: 14
             enum:
             - transmit
             - location
@@ -20227,6 +20229,7 @@ components:
             - bytes_tx_rate
             - bytes_rx_rate
             - last_change
+            - speed
           x-field-uid: 2
     Port.Metric:
       type: object
@@ -20340,6 +20343,12 @@ components:
         data_integrity:
           $ref: '#/components/schemas/Metric.DataIntegrity'
           x-field-uid: 15
+        speed:
+          description: |-
+            The speed in KBps the frames are transmitted. The calculated speed for  a negotiated line speed of (i) 100 Gbps is 100 * 1024 * 1024 / 8 = 13107200 KBps,  (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 * 1024 / 8 = 214748365 KBps,  (iii) 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+          type: integer
+          format: uint64
+          x-field-uid: 16
     Metric.DataIntegrity:
       description: "The container for data integrity metrics. The container will be\
         \ empty if \noptions.port_options.data_integrity has not been enabled during\

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.46.0
+  version: 1.48.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -4244,6 +4244,16 @@ components:
         learned_information_filter:
           x-field-uid: 8
           $ref: '#/components/schemas/Bgp.LearnedInformationFilter'
+        traditional_nlri_for_ipv4_routes:
+          description: "If set to false, all IPv4 routes are advertised using MP_REACH\
+            \ NLRI and withdrawn using MP_UNREACH NLRI  as defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3.\
+            \  By default ( when set to true) , all IPv4 routes are advertised using\
+            \ traditional or REACH_NLRI and withdrawn  using UNREACH_NLRI as defined\
+            \ in https://datatracker.ietf.org/doc/html/rfc4271#section-4.3 .  This\
+            \ is applicable only for BGPv4 peers.            "
+          type: boolean
+          default: true
+          x-field-uid: 16
         v4_routes:
           x-field-uid: 9
           description: |-
@@ -5201,6 +5211,18 @@ components:
           type: boolean
           default: false
           x-field-uid: 2
+        ipv4_mpls_unicast_prefix:
+          description: |-
+            If enabled, will store the information related to MPLS Unicast IPv4 Prefixes recieved from the peer.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        ipv6_mpls_unicast_prefix:
+          description: |-
+            If enabled, will store the information related to MPLS Unicast IPv6 Prefixes recieved from the peer.
+          type: boolean
+          default: false
+          x-field-uid: 4
     Bgp.V4RouteRange:
       description: |-
         Emulated BGPv4 route range.
@@ -25236,9 +25258,15 @@ components:
                 x-field-uid: 1
               ipv6_unicast:
                 x-field-uid: 2
+              ipv4_mpls_unicast:
+                x-field-uid: 3
+              ipv6_mpls_unicast:
+                x-field-uid: 4
             enum:
             - ipv4_unicast
             - ipv6_unicast
+            - ipv4_mpls_unicast
+            - ipv6_mpls_unicast
           x-field-uid: 2
         ipv4_unicast_filters:
           description: |-
@@ -25354,6 +25382,16 @@ components:
           items:
             $ref: '#/components/schemas/BgpPrefixIpv6Unicast.State'
           x-field-uid: 3
+        ipv4_mpls_unicast_prefixes:
+          type: array
+          items:
+            $ref: '#/components/schemas/BgpPrefixIpv4MplsUnicast.State'
+          x-field-uid: 4
+        ipv6_mpls_unicast_prefixes:
+          type: array
+          items:
+            $ref: '#/components/schemas/BgpPrefixIpv6MplsUnicast.State'
+          x-field-uid: 5
     BgpPrefixIpv4Unicast.State:
       description: |-
         IPv4 unicast prefix.
@@ -25876,6 +25914,178 @@ components:
         link_bandwidth_subtype:
           x-field-uid: 2
           $ref: '#/components/schemas/Result.ExtendedCommunity.NonTransitive2OctetAsType.LinkBandwidth'
+    BgpPrefixIpv4MplsUnicast.State:
+      description: |-
+        IPv4 MPLS unicast prefix.
+      type: object
+      properties:
+        ipv4_address:
+          description: |-
+            An IPv4 unicast address
+          type: string
+          x-field-uid: 1
+        prefix_length:
+          type: integer
+          format: uint32
+          maximum: 32
+          x-field-uid: 2
+        origin:
+          x-field-uid: 3
+          description: |-
+            The origin of the prefix.
+          type: string
+          x-enum:
+            igp:
+              x-field-uid: 1
+            egp:
+              x-field-uid: 2
+            incomplete:
+              x-field-uid: 3
+          enum:
+          - igp
+          - egp
+          - incomplete
+        path_id:
+          x-field-uid: 4
+          description: |-
+            The path id.
+          type: integer
+          format: uint32
+        ipv4_next_hop:
+          x-field-uid: 5
+          description: |-
+            The IPv4 address of the egress interface.
+          type: string
+          format: ipv4
+        ipv6_next_hop:
+          x-field-uid: 6
+          description: |-
+            The IPv6 address of the egress interface.
+          type: string
+          format: ipv6
+        labels:
+          description: |-
+            One or more MPLS Label 24 bit values bound to this address prefix.
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 7
+        communities:
+          x-field-uid: 8
+          description: |-
+            Optional community attributes.
+          type: array
+          items:
+            $ref: '#/components/schemas/Result.BgpCommunity'
+        extended_communities:
+          description: |-
+            Optional received Extended Community attributes. Each received Extended Community attribute is available for retrieval in two forms. Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use. In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the  'structured' format which is an optional field.
+          type: array
+          items:
+            $ref: '#/components/schemas/Result.ExtendedCommunity'
+          x-field-uid: 9
+        as_path:
+          x-field-uid: 10
+          $ref: '#/components/schemas/Result.BgpAsPath'
+        local_preference:
+          x-field-uid: 11
+          description: |-
+            The local preference is a well-known attribute and the value is used for route selection. The route with the highest local preference value is preferred.
+          type: integer
+          format: uint32
+        multi_exit_discriminator:
+          x-field-uid: 12
+          description: |-
+            The multi exit discriminator (MED) is an optional non-transitive attribute and the value is used for route selection. The route with the lowest MED value is preferred.
+          type: integer
+          format: uint32
+    BgpPrefixIpv6MplsUnicast.State:
+      description: |-
+        IPv6 MPLS unicast prefix.
+      type: object
+      properties:
+        ipv6_address:
+          description: |-
+            An IPv6 unicast address
+          type: string
+          x-field-uid: 1
+        prefix_length:
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 2
+        origin:
+          x-field-uid: 3
+          description: |-
+            The origin of the prefix.
+          type: string
+          x-enum:
+            igp:
+              x-field-uid: 1
+            egp:
+              x-field-uid: 2
+            incomplete:
+              x-field-uid: 3
+          enum:
+          - igp
+          - egp
+          - incomplete
+        path_id:
+          x-field-uid: 4
+          description: |-
+            The path id.
+          type: integer
+          format: uint32
+        ipv4_next_hop:
+          x-field-uid: 5
+          description: |-
+            The IPv4 address of the egress interface.
+          type: string
+          format: ipv4
+        ipv6_next_hop:
+          x-field-uid: 6
+          description: |-
+            The IPv6 address of the egress interface.
+          type: string
+          format: ipv6
+        labels:
+          description: |-
+            One or more MPLS Label 24 bit values bound to this address prefix.
+          type: array
+          items:
+            type: integer
+            format: uint32
+          x-field-uid: 7
+        communities:
+          x-field-uid: 8
+          description: |-
+            Optional community attributes.
+          type: array
+          items:
+            $ref: '#/components/schemas/Result.BgpCommunity'
+        extended_communities:
+          description: |-
+            Optional received Extended Community attributes. Each received Extended Community attribute is available for retrieval in two forms. Support of the 'raw' format in which all 8 bytes (16 hex characters) is always present and available for use. In addition, if supported by the implementation, the Extended Community attribute may also be retrieved in the  'structured' format which is an optional field.
+          type: array
+          items:
+            $ref: '#/components/schemas/Result.ExtendedCommunity'
+          x-field-uid: 9
+        as_path:
+          x-field-uid: 10
+          $ref: '#/components/schemas/Result.BgpAsPath'
+        local_preference:
+          x-field-uid: 11
+          description: |-
+            The local preference is a well-known attribute and the value is used for route selection. The route with the highest local preference value is preferred.
+          type: integer
+          format: uint32
+        multi_exit_discriminator:
+          x-field-uid: 12
+          description: |-
+            The multi exit discriminator (MED) is an optional non-transitive attribute and the value is used for route selection. The route with the lowest MED value is preferred.
+          type: integer
+          format: uint32
     Result.BgpCommunity:
       description: |-
         BGP communities provide additional capability for tagging routes and  for modifying BGP routing policy on upstream and downstream routers. BGP community is a 32-bit number which is broken into 16-bit AS number and  a 16-bit custom value.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19104,17 +19104,17 @@ components:
             \ the neighbor relationship in their next LSP Update.\n            \n\
             Example:\nSuppose Emulated Router ER (680000000003) is connected to Simulated\
             \ Routers:  \nST1('770000000001'), ST2('770000000002') and ST3('770000000003')\
-            \ in a ring topology.\n\nER <--> ST1 <--> ST2 <--> ST3 <--> ER\n     \
-            \            (A)      (B)\n                 \nBefore the AB Link Down\
-            \ operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen\
-            \ \nas in ISIS Link State PDU (LSP) information in Get State\nLSP-ID of\
-            \ ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001',\
-            \ '770000000003']\nLSP-ID of ST3: 770000000003-00-00: IS-Reachability\
-            \ Neighbors : ['770000000002', '770000000001']\n\nAfter the AB Link Down\
-            \ operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen\
-            \ \nas in ISIS Link State PDU (LSP) information in Get State\nLSP-ID of\
-            \ ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']\n\
-            LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']"
+            \ in a ring topology.\n\nER <--> ST1 <--> ST2(A) <--> ST3(B) <--> ER\n\
+            \                 \nBefore the AB Link Down operation between ST2 & ST3\
+            \  the neighbors of ST2 & ST3 will be seen \nas in ISIS Link State PDU\
+            \ (LSP) information in Get State\nLSP-ID of ST2: 770000000002-00-00: IS-Reachability\
+            \ Neighbors : ['770000000001', '770000000003']\nLSP-ID of ST3: 770000000003-00-00:\
+            \ IS-Reachability Neighbors : ['770000000002', '770000000001']\n\nAfter\
+            \ the AB Link Down operation between ST2 & ST3  the neighbors of ST2 &\
+            \ ST3 will be seen \nas in ISIS Link State PDU (LSP) information in Get\
+            \ State\nLSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors\
+            \ : ['770000000001']\nLSP-ID of ST3: 770000000003-00-00: IS-Reachability\
+            \ Neighbors : ['770000000001']"
           type: string
           x-field-uid: 2
           x-enum:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -18980,7 +18980,7 @@ components:
       properties:
         names:
           description: |
-            The names of interfaces object of a device Interface objects to control. If no names are specified then all Simulated Interface objects that match the x-constraint will be affected.
+            The names of ISIS Simulated Links to control. If no names are specified then all ISIS Simulated Links in the configuration will be affected..
 
             x-constraint:
             - /components/schemas/Isis.Interface/properties/name
@@ -18991,10 +18991,37 @@ components:
           - /components/schemas/Isis.Interface/properties/name
           x-field-uid: 1
         up:
-          description: |-
-            Set up to true or false to interface state in UP or DOWN state respectively in both direction. Thats is the UP/DOWN state is applied for a simulated link, connecting, say, a Node A to Node B and Node B to  Node A in both directions.
+          description: "Set up to true or false to interface state in UP or DOWN state\
+            \ respectively in both direction. Thats is the UP/DOWN state is applied\
+            \ for a simulated link,\nconnecting, say, a Node A to Node B and Node\
+            \ B to Node A in both directions.\nSetting to false will result in the\
+            \ selected set of Simulated Links to be set in disconnected state. This\
+            \ should result in the link to be removed from the \nExtended IS Reachability\
+            \ TLV in subsequent LSP transmitted ( with incremented Sequence Number\
+            \ ) from both the Simulated or Emulated Router on which this link is \n\
+            located as well the Simulated or Emulated Router at the other end of the\
+            \ link i.e. this will bring down the Simulated Links on both ends.\nSimilarly,\
+            \ setting to true should result in the neighbor information to be re-introduced\
+            \ in Extended IS Reachability sent in subsequent LSP Update by the \n\
+            Router containing the Simulated Link and the neighboring Router at the\
+            \ other end of the link. Note that if the link is already in 'up' state\
+            \ and the value is set \nto 'true' or it is in 'down' state and the value\
+            \ is set to 'false', those links in the request should be ignored.\n\n\
+            Example:\nSuppose Emulated Router ER (680000000003) is connected to Simulated\
+            \ Routers:  ST1('770000000001'), ST2('770000000002') and ST3('770000000003')\
+            \ in a ring topology.\nER <--> ST1 <--> ST2\n^\t            (A) ^\n|\t\
+            \t              |\nv \t          (B) v\n-------ST3-------\n\nBefore the\
+            \ AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3\
+            \ will be seen as in ISIS Link State PDU (LSP) information in Get State\n\
+            LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001',\
+            \ '770000000003']\nLSP-ID of ST3: 770000000003-00-00: IS-Reachability\
+            \ Neighbors : ['770000000002', '770000000001']\n\nAfter the AB Link Down\
+            \ operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen\
+            \ as in ISIS Link State PDU (LSP) information in Get State\nLSP-ID of\
+            \ ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']\n\
+            LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']"
           type: boolean
-          default: true
+          default: false
           x-field-uid: 2
     Control.Action:
       description: |-

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19092,34 +19092,27 @@ components:
           - /components/schemas/Isis.Interface/properties/name
           x-field-uid: 1
         state:
-          description: "description: |-\nSet ControlState to UP or DOWN to interface\
-            \ state in UP or DOWN state respectively in both directions. Thats is\
-            \ the UP/DOWN state is applied for a simulated link,\nconnecting, say,\
-            \ a Node A to Node B and Node B to Node A in both directions.\nSetting\
-            \ Control State to DOWN will result in the selected set of Simulated Links\
-            \ to be set in disconnected state. This should result in the link to be\
-            \ removed from the \nExtended IS Reachability TLV in subsequent LSP transmitted\
-            \ ( with incremented Sequence Number ) from both the Simulated or Emulated\
-            \ Router on which this link is \nlocated as well the Simulated or Emulated\
-            \ Router at the other end of the link i.e. this will bring down the Simulated\
-            \ Links on both ends.\nSimilarly, setting the Control State to UP should\
-            \ result in the neighbor information to be re-introduced in Extended IS\
-            \ Reachability sent in subsequent LSP Update by the \nRouter containing\
-            \ the Simulated Link and the neighboring Router at the other end of the\
-            \ link. Note that if the link is already in UP state and the Control State\
-            \ is set \nto UP again or if the state is in DOWN state and the Control\
-            \ State is set to DOWN again, those links in the request should be ignored.\n\
-            \nExample:\nSuppose Emulated Router ER (680000000003) is connected to\
-            \ Simulated Routers:  ST1('770000000001'), ST2('770000000002') and ST3('770000000003')\
-            \ in a ring topology.\nER <--> ST1 <--> ST2\n^\t            (A) ^\n|\t\
-            \t              |\nv \t          (B) v\n-------ST3-------\n\nBefore the\
-            \ AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3\
-            \ will be seen as in ISIS Link State PDU (LSP) information in Get State\n\
-            LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001',\
+          description: "Sets the Control State of one or more Simulated Links to UP\
+            \ or DOWN. \nThe state change is applied bidirectionally — a link between\
+            \ IS-IS Routers A and B is affected \nin both directions simultaneously.\n\
+            Setting Control State to DOWN transitions the selected Simulated Links\
+            \ to a disconnected state. \nBoth the Simulated/Emulated Router hosting\
+            \ the link and the neighboring router at the far end \nwill remove the\
+            \ link from the Extended IS Reachability TLV in their next LSP transmission\
+            \ (with an incremented Sequence Number).\nSetting Control State to UP\
+            \ reconnects the selected Simulated Links. \nBoth routers will re-advertise\
+            \ the neighbor relationship in their next LSP Update.\n            \n\
+            Example:\nSuppose Emulated Router ER (680000000003) is connected to Simulated\
+            \ Routers:  \nST1('770000000001'), ST2('770000000002') and ST3('770000000003')\
+            \ in a ring topology.\n\nER <--> ST1 <--> ST2 <--> ST3 <--> ER\n     \
+            \            (A)      (B)\n                 \nBefore the AB Link Down\
+            \ operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen\
+            \ \nas in ISIS Link State PDU (LSP) information in Get State\nLSP-ID of\
+            \ ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001',\
             \ '770000000003']\nLSP-ID of ST3: 770000000003-00-00: IS-Reachability\
             \ Neighbors : ['770000000002', '770000000001']\n\nAfter the AB Link Down\
             \ operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen\
-            \ as in ISIS Link State PDU (LSP) information in Get State\nLSP-ID of\
+            \ \nas in ISIS Link State PDU (LSP) information in Get State\nLSP-ID of\
             \ ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']\n\
             LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']"
           type: string

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -7,7 +7,7 @@ info:
     \ issue](https://github.com/open-traffic-generator/models/issues) in the models\
     \ repository\n- [fork the models repository](https://github.com/open-traffic-generator/models)\
     \ and submit a PR"
-  version: 1.48.0
+  version: 1.50.0
   contact:
     url: https://github.com/open-traffic-generator/models
   license:
@@ -1983,7 +1983,7 @@ components:
           type: integer
           format: uint32
           minimum: 64
-          maximum: 9000
+          maximum: 14000
           default: 1500
           x-field-uid: 5
         ieee_media_defaults:
@@ -19504,6 +19504,16 @@ components:
         custom:
           $ref: '#/components/schemas/Device.Bgp.CustomError'
           x-field-uid: 9
+        fin_delay:
+          description: "Delay (in milliseconds) between generation of the Notification\
+            \ and transmission of FIN to close the \nTCP socket by the implementation.\
+            \ This is useful to ensure that the remote end has received and processed\n\
+            the Notification before closing the BGP session.            "
+          type: integer
+          format: uint32
+          maximum: 10000
+          default: 0
+          x-field-uid: 10
     Action.Protocol.Bgp.InitiateGracefulRestart:
       description: |-
         Initiates BGP Graceful Restart process for the selected BGP peers. If no name is specified then Graceful Restart will be sent to all configured BGP peers. To emulate scenarios where a peer sends a Notification and stops the session, an optional Notification object is included. If the remote peer and the local peer are both configured to perform Graceful Restart for Notification triggered session , this will result in  Graceful Restart scenario to be triggered as per RFC8538.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -19589,12 +19589,6 @@ components:
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: '#/components/schemas/Action.Protocol.Isis.InitiateRestart'
           x-field-uid: 2
-        set_overload_bit:
-          description: |-
-            Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives, it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system not to use the overloaded IS router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
-          type: boolean
-          default: true
-          x-field-uid: 3
     Action.Protocol.Isis.InitiateRestart:
       description: "Timers T1 and T2 are used both by a restarting router and a starting\
         \ router. Timer T3 is used only by a restarting router.\n- Timer T1 is maintained\

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -13985,6 +13985,7 @@ message StateProtocol {
       isis = 5;
       ospfv2 = 6;
       ospfv3 = 7;
+      link = 8;
     }
   }
   // Description missing in models
@@ -14014,6 +14015,9 @@ message StateProtocol {
 
   // Description missing in models
   StateProtocolRocev2 rocev2 = 9;
+
+  // Description missing in models
+  StateProtocolLink link = 10;
 }
 
 // Sets the link of configured ports.
@@ -14286,6 +14290,9 @@ message StateProtocolIsis {
 
   // Description missing in models
   StateProtocolIsisRouters routers = 2;
+
+  // Description missing in models
+  StateProtocolIsisLinks links = 3;
 }
 
 // Sets state of configured ISIS routers.
@@ -14442,6 +14449,46 @@ message StateProtocolRocev2Peers {
   // If the desired state is 'down', RoCEv2 session(s) would be brought down.
   // required = true
   optional State.Enum state = 2;
+}
+
+// Sets the state of configured routes
+message StateProtocolIsisLinks {
+
+  // The names of interface object of a device Router objects to control. If no names
+  // are specified then all route objects that match the x-constraint will be affected.
+  // 
+  // x-constraint:
+  // - /components/schemas/Isis.Interface/properties/name
+  // 
+  repeated string names = 1;
+
+  // Set up to true or false to interface state in UP or DOWN state respectively.
+  // default = True
+  optional bool up = 2;
+
+  // The cost metric associated with the link.
+  // default = 10
+  optional uint32 metric = 3;
+}
+
+// Sets the state of configured routes
+message StateProtocolLink {
+
+  // The names of interface object of a device Router objects to control. If no names
+  // are specified then all route objects that match the x-constraint will be affected.
+  // 
+  // x-constraint:
+  // - /components/schemas/Isis.Interface/properties/name
+  // 
+  repeated string names = 1;
+
+  // Set up to true or false to interface state in UP or DOWN state respectively.
+  // default = True
+  optional bool up = 2;
+
+  // The cost metric associated with the link.
+  // default = 10
+  optional uint32 metric = 3;
 }
 
 // Request for triggering action against configured resources.
@@ -14914,6 +14961,7 @@ message ActionProtocolIsis {
     enum Enum {
       unspecified = 0;
       initiate_graceful_restart = 1;
+      overload_bit = 2;
     }
   }
   // Description missing in models
@@ -14922,6 +14970,13 @@ message ActionProtocolIsis {
 
   // Configuration for the initiation of the IS-IS Graceful Restart.
   ActionProtocolIsisInitiateRestart initiate_graceful_restart = 2;
+
+  // Set Overload Bit to true to deal with transient problems that prevent an IS from
+  // storing all the LSPs it receives, it sets the Overload Bit in the non-pseudonode
+  // LSP number Zero that it generates. Then other system not to use the overloaded IS
+  // router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
+  // default = True
+  optional bool overload_bit = 3;
 }
 
 // Timers T1 and T2 are used both by a restarting router and a starting router. Timer

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -13985,7 +13985,6 @@ message StateProtocol {
       isis = 5;
       ospfv2 = 6;
       ospfv3 = 7;
-      link = 8;
     }
   }
   // Description missing in models
@@ -14015,9 +14014,6 @@ message StateProtocol {
 
   // Description missing in models
   StateProtocolRocev2 rocev2 = 9;
-
-  // Description missing in models
-  StateProtocolLink link = 10;
 }
 
 // Sets the link of configured ports.
@@ -14292,7 +14288,7 @@ message StateProtocolIsis {
   StateProtocolIsisRouters routers = 2;
 
   // Description missing in models
-  StateProtocolIsisLinks links = 3;
+  StateProtocolIsisSimLinks simulated_links = 3;
 }
 
 // Sets state of configured ISIS routers.
@@ -14451,44 +14447,23 @@ message StateProtocolRocev2Peers {
   optional State.Enum state = 2;
 }
 
-// Sets the state of configured routes
-message StateProtocolIsisLinks {
+// Sets the state of configured one or more Simulated Links (Interfaces)
+message StateProtocolIsisSimLinks {
 
-  // The names of interface object of a device Router objects to control. If no names
-  // are specified then all route objects that match the x-constraint will be affected.
+  // The names of interfaces object of a device Interface objects to control. If no names
+  // are specified then all Simulated Interface objects that match the x-constraint will
+  // be affected.
   // 
   // x-constraint:
   // - /components/schemas/Isis.Interface/properties/name
   // 
   repeated string names = 1;
 
-  // Set up to true or false to interface state in UP or DOWN state respectively.
+  // Set up to true or false to interface state in UP or DOWN state respectively in both
+  // direction. Thats is the UP/DOWN state is applied for a simulated link, connecting,
+  // say, a Node A to Node B and Node B to  Node A in both directions.
   // default = True
   optional bool up = 2;
-
-  // The cost metric associated with the link.
-  // default = 10
-  optional uint32 metric = 3;
-}
-
-// Sets the state of configured routes
-message StateProtocolLink {
-
-  // The names of interface object of a device Router objects to control. If no names
-  // are specified then all route objects that match the x-constraint will be affected.
-  // 
-  // x-constraint:
-  // - /components/schemas/Isis.Interface/properties/name
-  // 
-  repeated string names = 1;
-
-  // Set up to true or false to interface state in UP or DOWN state respectively.
-  // default = True
-  optional bool up = 2;
-
-  // The cost metric associated with the link.
-  // default = 10
-  optional uint32 metric = 3;
 }
 
 // Request for triggering action against configured resources.
@@ -14976,7 +14951,7 @@ message ActionProtocolIsis {
   // LSP number Zero that it generates. Then other system not to use the overloaded IS
   // router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
   // default = True
-  optional bool overload_bit = 3;
+  optional bool set_overload_bit = 3;
 }
 
 // Timers T1 and T2 are used both by a restarting router and a starting router. Timer

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14289,13 +14289,14 @@ message StateProtocolBgpPeers {
   optional State.Enum state = 2;
 }
 
-// Sets state of configured ISIS routers.
+// Sets state of configured ISIS routers and Links.
 message StateProtocolIsis {
 
   message Choice {
     enum Enum {
       unspecified = 0;
       routers = 1;
+      simulated_links = 2;
     }
   }
   // Description missing in models

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14954,7 +14954,6 @@ message ActionProtocolIsis {
     enum Enum {
       unspecified = 0;
       initiate_graceful_restart = 1;
-      overload_bit = 2;
     }
   }
   // Description missing in models

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.50.0
+/* Open Traffic Generator API 1.51.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -10350,21 +10350,26 @@ message FlowIpv4 {
   // Description missing in models
   PatternFlowIpv4Dst dst = 14;
 
-  // Description missing in models
+  // IPv4 options are optional extensions for the IPv4 header that can be utilised to
+  // provide additional information about the IPv4 datagram.  It is encoded as a series
+  // of type, length and value attributes.  The IP header length MUST be increased to
+  // accommodate the extra bytes needed to encode the IP options. The length of the all
+  // options included to a IPv4 header should not exceed 40 bytes since IPv4 Header length
+  // (4 bits) can at max specify 15 4-word octets for a total of 60 bytes which includes
+  // 20 bytes needed for mandatory attributes of the IPv4 header. If the user adds multiples
+  // IPv4 options that exceeds 40 bytes and specify header length as auto, implementation
+  // should throw error. Currently IP options supported are: 1. router_alert option allows
+  // devices to intercept packets not addressed to them directly as defined in RFC2113.
+  // 2. custom option is provided to configure user defined IP options as needed. 3. timestamp
+  // option allows routers to record their local timestamp and IP address for latency
+  // measurement and path diagnostics as defined in RFC791.  4. end_of_options option
+  // allows routers to specify the end of options list. This may only be used if the end
+  // of the options does not coincide with the end of the IP header. It is a single octet
+  // value and padding is implicitly added to conform to a work boundary.
   repeated FlowIpv4Options options = 15;
 }
 
-// IPv4 options are optional extensions for the IPv4 header that can be utilised to
-// provide additional information about the IPv4 datagram.  It is encoded as a series
-// of type, length and value attributes.  The IP header length MUST be increased to
-// accommodate the extra bytes needed to encode the IP options. The length of the all
-// options included to a IPv4 header should not exceed 40 bytes since IPv4 Header length
-// (4 bits) can at max specify 15 4-word octets for a total of 60 bytes which includes
-// 20 bytes needed for mandatory attributes of the IPv4 header. If the user adds multiples
-// IPv4 options that exceeds 40 bytes and specify header length as auto, implementation
-// should throw error. Currently IP options supported are: 1. router_alert option allows
-// devices to intercept packets not addressed to them directly as defined in RFC2113.
-// 2. custom option is provided to configure user defined IP options as needed.
+// IPv4 options are optional extensions for the IPv4 header
 message FlowIpv4Options {
 
   message Choice {
@@ -10372,6 +10377,8 @@ message FlowIpv4Options {
       unspecified = 0;
       router_alert = 1;
       custom = 2;
+      timestamp = 3;
+      end_of_options = 4;
     }
   }
   // Description missing in models
@@ -10380,6 +10387,9 @@ message FlowIpv4Options {
 
   // Description missing in models
   FlowIpv4OptionsCustom custom = 2;
+
+  // Description missing in models
+  FlowIpv4OptionsTimestamp timestamp = 3;
 }
 
 // User defined IP options to be appended to the IPv4 header.
@@ -10434,6 +10444,90 @@ message FlowIpv4OptionsCustomLength {
   // Description missing in models
   // default = 0
   optional uint32 value = 3;
+}
+
+// IPv4 timestamp option to be appended to the IPv4 header.
+message FlowIpv4OptionsTimestamp {
+
+  // Description missing in models
+  FlowIpv4OptionsTimestampPointer pointer = 1;
+
+  // A counter that indicates the number of intermediate nodes that were unable to record
+  // a timestamp because the options data area was full.
+  PatternFlowIpv4OptionsTimestampOverflow overflow = 2;
+
+  // Description missing in models
+  FlowIpv4OptionsTimestampFormat format = 3;
+}
+
+// The attribute pointer indicates the octet offset where the next router should begin
+// recording its data.
+// Choices of input are,
+// 1. auto : The OTG implementation can provide a system generated value for this property.
+// If the implementation is unable to generate a value, the default value must be used.
+// 2. value: User can configure the pointer value.
+message FlowIpv4OptionsTimestampPointer {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      auto = 1;
+      value = 2;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.auto
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 5
+  optional uint32 value = 2;
+}
+
+// The format field defines the structural layout of the options data area and the specific
+// recording logic routers must follow when appending timestamps and IP addresses.
+message FlowIpv4OptionsTimestampFormat {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      timestamps = 1;
+      address_and_timestamps = 2;
+      prespecified_address_and_timestamps = 3;
+    }
+  }
+  // Description missing in models
+  optional Choice.Enum choice = 1;
+
+  // A recording mode where routers append only their 32-bit universal timestamps sequentially
+  // into the options data area.
+  repeated FlowIpv4OptionsTimestampFormatTimestamps timestamps = 2;
+
+  // A recording mode where each router appends its 32-bit IPv4 address followed immediately
+  // by its 32-bit universal timestamp into the options data area.
+  repeated FlowIpv4OptionsTimestampFormatAddressAndTimestamps address_and_timestamps = 3;
+
+  // A selective recording mode where only routers whose IPv4 addresses match the pre-listed
+  // entries in the header record their 32-bit universal timestamps into the options data
+  // area.
+  repeated FlowIpv4OptionsTimestampFormatAddressAndTimestamps prespecified_address_and_timestamps = 4;
+}
+
+// Description missing in models
+message FlowIpv4OptionsTimestampFormatTimestamps {
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatTimestampsTimestamp timestamp = 1;
+}
+
+// Description missing in models
+message FlowIpv4OptionsTimestampFormatAddressAndTimestamps {
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsAddress address = 1;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsTimestamp timestamp = 2;
 }
 
 // A container for ipv4 raw, tos, dscp ip priorities.
@@ -23122,6 +23216,198 @@ message PatternFlowIpv4OptionsCustomTypeOptionNumber {
 
   // Description missing in models
   PatternFlowIpv4OptionsCustomTypeOptionNumberCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowIpv4OptionsTimestampOverflowCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// A counter that indicates the number of intermediate nodes that were unable to record
+// a timestamp because the options data area was full.
+message PatternFlowIpv4OptionsTimestampOverflow {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampOverflowCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampOverflowCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowIpv4OptionsTimestampFormatTimestampsTimestampCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// A 32-bit value representing the time of packet processing, recorded as the number
+// of milliseconds elapsed since midnight Universal Time (UT).
+message PatternFlowIpv4OptionsTimestampFormatTimestampsTimestamp {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatTimestampsTimestampCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatTimestampsTimestampCounter decrement = 6;
+}
+
+// ipv4 counter pattern
+message PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsAddressCounter {
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string start = 1;
+
+  // Description missing in models
+  // default = 0.0.0.1
+  optional string step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// IPv4 address of the router interface that handled the packet, serving as a network
+// identifier for the corresponding timestamp entry.
+message PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsAddress {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0.0.0.0
+  optional string value = 2;
+
+  // Description missing in models
+  // default = ['0.0.0.0']
+  repeated string values = 3;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsAddressCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsAddressCounter decrement = 6;
+}
+
+// integer counter pattern
+message PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsTimestampCounter {
+
+  // Description missing in models
+  // default = 0
+  optional uint32 start = 1;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 step = 2;
+
+  // Description missing in models
+  // default = 1
+  optional uint32 count = 3;
+}
+
+// A 32-bit value representing the time of packet processing, recorded as the number
+// of milliseconds elapsed since midnight Universal Time (UT).
+message PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsTimestamp {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      value = 2;
+      values = 3;
+      increment = 4;
+      decrement = 5;
+    }
+  }
+  // Description missing in models
+  // default = Choice.Enum.value
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  // default = 0
+  optional uint32 value = 2;
+
+  // Description missing in models
+  // default = [0]
+  repeated uint32 values = 3;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsTimestampCounter increment = 5;
+
+  // Description missing in models
+  PatternFlowIpv4OptionsTimestampFormatAddressAndTimestampsTimestampCounter decrement = 6;
 }
 
 // integer counter pattern

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14571,22 +14571,32 @@ message StateProtocolIsisSimLinks {
   // 
   repeated string names = 1;
 
-  // Set up to true or false to interface state in UP or DOWN state respectively in both
-  // direction. Thats is the UP/DOWN state is applied for a simulated link,
+  message State {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // description: |-
+  // Set ControlState to UP or DOWN to interface state in UP or DOWN state respectively
+  // in both directions. Thats is the UP/DOWN state is applied for a simulated link,
   // connecting, say, a Node A to Node B and Node B to Node A in both directions.
-  // Setting to false will result in the selected set of Simulated Links to be set in
-  // disconnected state. This should result in the link to be removed from the
+  // Setting Control State to DOWN will result in the selected set of Simulated Links
+  // to be set in disconnected state. This should result in the link to be removed from
+  // the
   // Extended IS Reachability TLV in subsequent LSP transmitted ( with incremented Sequence
   // Number ) from both the Simulated or Emulated Router on which this link is
   // located as well the Simulated or Emulated Router at the other end of the link i.e.
   // this will bring down the Simulated Links on both ends.
-  // Similarly, setting to true should result in the neighbor information to be re-introduced
-  // in Extended IS Reachability sent in subsequent LSP Update by the
+  // Similarly, setting the Control State to UP should result in the neighbor information
+  // to be re-introduced in Extended IS Reachability sent in subsequent LSP Update by
+  // the
   // Router containing the Simulated Link and the neighboring Router at the other end
-  // of the link. Note that if the link is already in 'up' state and the value is set
-  // 
-  // to 'true' or it is in 'down' state and the value is set to 'false', those links in
-  // the request should be ignored.
+  // of the link. Note that if the link is already in UP state and the Control State is
+  // set
+  // to UP again or if the state is in DOWN state and the Control State is set to DOWN
+  // again, those links in the request should be ignored.
   // 
   // Example:
   // Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:  ST1('770000000001'),
@@ -14606,8 +14616,7 @@ message StateProtocolIsisSimLinks {
   // be seen as in ISIS Link State PDU (LSP) information in Get State
   // LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']
   // LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']
-  // default = False
-  optional bool up = 2;
+  optional State.Enum state = 2;
 }
 
 // Request for triggering action against configured resources.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14578,42 +14578,35 @@ message StateProtocolIsisSimLinks {
       down = 2;
     }
   }
-  // description: |-
-  // Set ControlState to UP or DOWN to interface state in UP or DOWN state respectively
-  // in both directions. Thats is the UP/DOWN state is applied for a simulated link,
-  // connecting, say, a Node A to Node B and Node B to Node A in both directions.
-  // Setting Control State to DOWN will result in the selected set of Simulated Links
-  // to be set in disconnected state. This should result in the link to be removed from
-  // the
-  // Extended IS Reachability TLV in subsequent LSP transmitted ( with incremented Sequence
-  // Number ) from both the Simulated or Emulated Router on which this link is
-  // located as well the Simulated or Emulated Router at the other end of the link i.e.
-  // this will bring down the Simulated Links on both ends.
-  // Similarly, setting the Control State to UP should result in the neighbor information
-  // to be re-introduced in Extended IS Reachability sent in subsequent LSP Update by
-  // the
-  // Router containing the Simulated Link and the neighboring Router at the other end
-  // of the link. Note that if the link is already in UP state and the Control State is
-  // set
-  // to UP again or if the state is in DOWN state and the Control State is set to DOWN
-  // again, those links in the request should be ignored.
+  // Sets the Control State of one or more Simulated Links to UP or DOWN.
+  // The state change is applied bidirectionally — a link between IS-IS Routers A and
+  // B is affected
+  // in both directions simultaneously.
+  // Setting Control State to DOWN transitions the selected Simulated Links to a disconnected
+  // state.
+  // Both the Simulated/Emulated Router hosting the link and the neighboring router at
+  // the far end
+  // will remove the link from the Extended IS Reachability TLV in their next LSP transmission
+  // (with an incremented Sequence Number).
+  // Setting Control State to UP reconnects the selected Simulated Links.
+  // Both routers will re-advertise the neighbor relationship in their next LSP Update.
   // 
   // Example:
-  // Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:  ST1('770000000001'),
-  // ST2('770000000002') and ST3('770000000003') in a ring topology.
-  // ER <--> ST1 <--> ST2
-  // ^	            (A) ^
-  // |		              |
-  // v 	          (B) v
-  // -------ST3-------
+  // Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:
+  // ST1('770000000001'), ST2('770000000002') and ST3('770000000003') in a ring topology.
+  // 
+  // ER <--> ST1 <--> ST2 <--> ST3 <--> ER
+  // (A)      (B)
   // 
   // Before the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will
-  // be seen as in ISIS Link State PDU (LSP) information in Get State
+  // be seen
+  // as in ISIS Link State PDU (LSP) information in Get State
   // LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001', '770000000003']
   // LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000002', '770000000001']
   // 
   // After the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will
-  // be seen as in ISIS Link State PDU (LSP) information in Get State
+  // be seen
+  // as in ISIS Link State PDU (LSP) information in Get State
   // LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']
   // LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']
   optional State.Enum state = 2;

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.48.0
+/* Open Traffic Generator API 1.50.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -14898,6 +14898,14 @@ message ActionProtocolBgpNotification {
 
   // Description missing in models
   DeviceBgpCustomError custom = 9;
+
+  // Delay (in milliseconds) between generation of the Notification and transmission of
+  // FIN to close the
+  // TCP socket by the implementation. This is useful to ensure that the remote end has
+  // received and processed
+  // the Notification before closing the BGP session.
+  // default = 0
+  optional uint32 fin_delay = 10;
 }
 
 // Initiates BGP Graceful Restart process for the selected BGP peers. If no name is

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14469,9 +14469,8 @@ message StateProtocolRocev2Peers {
 // Sets the state of configured one or more Simulated Links (Interfaces)
 message StateProtocolIsisSimLinks {
 
-  // The names of interfaces object of a device Interface objects to control. If no names
-  // are specified then all Simulated Interface objects that match the x-constraint will
-  // be affected.
+  // The names of ISIS Simulated Links to control. If no names are specified then all
+  // ISIS Simulated Links in the configuration will be affected..
   // 
   // x-constraint:
   // - /components/schemas/Isis.Interface/properties/name
@@ -14479,9 +14478,41 @@ message StateProtocolIsisSimLinks {
   repeated string names = 1;
 
   // Set up to true or false to interface state in UP or DOWN state respectively in both
-  // direction. Thats is the UP/DOWN state is applied for a simulated link, connecting,
-  // say, a Node A to Node B and Node B to  Node A in both directions.
-  // default = True
+  // direction. Thats is the UP/DOWN state is applied for a simulated link,
+  // connecting, say, a Node A to Node B and Node B to Node A in both directions.
+  // Setting to false will result in the selected set of Simulated Links to be set in
+  // disconnected state. This should result in the link to be removed from the
+  // Extended IS Reachability TLV in subsequent LSP transmitted ( with incremented Sequence
+  // Number ) from both the Simulated or Emulated Router on which this link is
+  // located as well the Simulated or Emulated Router at the other end of the link i.e.
+  // this will bring down the Simulated Links on both ends.
+  // Similarly, setting to true should result in the neighbor information to be re-introduced
+  // in Extended IS Reachability sent in subsequent LSP Update by the
+  // Router containing the Simulated Link and the neighboring Router at the other end
+  // of the link. Note that if the link is already in 'up' state and the value is set
+  // 
+  // to 'true' or it is in 'down' state and the value is set to 'false', those links in
+  // the request should be ignored.
+  // 
+  // Example:
+  // Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:  ST1('770000000001'),
+  // ST2('770000000002') and ST3('770000000003') in a ring topology.
+  // ER <--> ST1 <--> ST2
+  // ^	            (A) ^
+  // |		              |
+  // v 	          (B) v
+  // -------ST3-------
+  // 
+  // Before the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will
+  // be seen as in ISIS Link State PDU (LSP) information in Get State
+  // LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001', '770000000003']
+  // LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000002', '770000000001']
+  // 
+  // After the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will
+  // be seen as in ISIS Link State PDU (LSP) information in Get State
+  // LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']
+  // LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']
+  // default = False
   optional bool up = 2;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14963,13 +14963,6 @@ message ActionProtocolIsis {
 
   // Configuration for the initiation of the IS-IS Graceful Restart.
   ActionProtocolIsisInitiateRestart initiate_graceful_restart = 2;
-
-  // Set Overload Bit to true to deal with transient problems that prevent an IS from
-  // storing all the LSPs it receives, it sets the Overload Bit in the non-pseudonode
-  // LSP number Zero that it generates. Then other system not to use the overloaded IS
-  // router as a tranisient router.  Set Overload Bit to false, to toggle the above process.
-  // default = True
-  optional bool set_overload_bit = 3;
 }
 
 // Timers T1 and T2 are used both by a restarting router and a starting router. Timer

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14595,8 +14595,7 @@ message StateProtocolIsisSimLinks {
   // Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:
   // ST1('770000000001'), ST2('770000000002') and ST3('770000000003') in a ring topology.
   // 
-  // ER <--> ST1 <--> ST2 <--> ST3 <--> ER
-  // (A)      (B)
+  // ER <--> ST1 <--> ST2(A) <--> ST3(B) <--> ER
   // 
   // Before the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will
   // be seen

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.46.0
+/* Open Traffic Generator API 1.48.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -2941,6 +2941,14 @@ message BgpV4Peer {
   // Description missing in models
   BgpLearnedInformationFilter learned_information_filter = 8;
 
+  // If set to false, all IPv4 routes are advertised using MP_REACH NLRI and withdrawn
+  // using MP_UNREACH NLRI  as defined in https://datatracker.ietf.org/doc/html/rfc4760#section-3.
+  // By default ( when set to true) , all IPv4 routes are advertised using traditional
+  // or REACH_NLRI and withdrawn  using UNREACH_NLRI as defined in https://datatracker.ietf.org/doc/html/rfc4271#section-4.3
+  // .  This is applicable only for BGPv4 peers.
+  // default = True
+  optional bool traditional_nlri_for_ipv4_routes = 16;
+
   // Emulated BGPv4 route ranges.
   repeated BgpV4RouteRange v4_routes = 9;
 
@@ -3718,6 +3726,16 @@ message BgpLearnedInformationFilter {
   // from the peer.
   // default = False
   optional bool unicast_ipv6_prefix = 2;
+
+  // If enabled, will store the information related to MPLS Unicast IPv4 Prefixes recieved
+  // from the peer.
+  // default = False
+  optional bool ipv4_mpls_unicast_prefix = 3;
+
+  // If enabled, will store the information related to MPLS Unicast IPv6 Prefixes recieved
+  // from the peer.
+  // default = False
+  optional bool ipv6_mpls_unicast_prefix = 4;
 }
 
 // Emulated BGPv4 route range.
@@ -18246,6 +18264,8 @@ message BgpPrefixStateRequest {
       unspecified = 0;
       ipv4_unicast = 1;
       ipv6_unicast = 2;
+      ipv4_mpls_unicast = 3;
+      ipv6_mpls_unicast = 4;
     }
   }
   // Specify which prefixes to return. If the list is empty or missing then all prefixes
@@ -18326,6 +18346,12 @@ message BgpPrefixesState {
 
   // Description missing in models
   repeated BgpPrefixIpv6UnicastState ipv6_unicast_prefixes = 3;
+
+  // Description missing in models
+  repeated BgpPrefixIpv4MplsUnicastState ipv4_mpls_unicast_prefixes = 4;
+
+  // Description missing in models
+  repeated BgpPrefixIpv6MplsUnicastState ipv6_mpls_unicast_prefixes = 5;
 }
 
 // IPv4 unicast prefix.
@@ -18734,6 +18760,114 @@ message ResultExtendedCommunityNonTransitive2OctetAsType {
 
   // Description missing in models
   ResultExtendedCommunityNonTransitive2OctetAsTypeLinkBandwidth link_bandwidth_subtype = 2;
+}
+
+// IPv4 MPLS unicast prefix.
+message BgpPrefixIpv4MplsUnicastState {
+
+  // An IPv4 unicast address
+  optional string ipv4_address = 1;
+
+  // Description missing in models
+  optional uint32 prefix_length = 2;
+
+  message Origin {
+    enum Enum {
+      unspecified = 0;
+      igp = 1;
+      egp = 2;
+      incomplete = 3;
+    }
+  }
+  // The origin of the prefix.
+  optional Origin.Enum origin = 3;
+
+  // The path id.
+  optional uint32 path_id = 4;
+
+  // The IPv4 address of the egress interface.
+  optional string ipv4_next_hop = 5;
+
+  // The IPv6 address of the egress interface.
+  optional string ipv6_next_hop = 6;
+
+  // One or more MPLS Label 24 bit values bound to this address prefix.
+  repeated uint32 labels = 7;
+
+  // Optional community attributes.
+  repeated ResultBgpCommunity communities = 8;
+
+  // Optional received Extended Community attributes. Each received Extended Community
+  // attribute is available for retrieval in two forms. Support of the 'raw' format in
+  // which all 8 bytes (16 hex characters) is always present and available for use. In
+  // addition, if supported by the implementation, the Extended Community attribute may
+  // also be retrieved in the  'structured' format which is an optional field.
+  repeated ResultExtendedCommunity extended_communities = 9;
+
+  // Description missing in models
+  ResultBgpAsPath as_path = 10;
+
+  // The local preference is a well-known attribute and the value is used for route selection.
+  // The route with the highest local preference value is preferred.
+  optional uint32 local_preference = 11;
+
+  // The multi exit discriminator (MED) is an optional non-transitive attribute and the
+  // value is used for route selection. The route with the lowest MED value is preferred.
+  optional uint32 multi_exit_discriminator = 12;
+}
+
+// IPv6 MPLS unicast prefix.
+message BgpPrefixIpv6MplsUnicastState {
+
+  // An IPv6 unicast address
+  optional string ipv6_address = 1;
+
+  // Description missing in models
+  optional uint32 prefix_length = 2;
+
+  message Origin {
+    enum Enum {
+      unspecified = 0;
+      igp = 1;
+      egp = 2;
+      incomplete = 3;
+    }
+  }
+  // The origin of the prefix.
+  optional Origin.Enum origin = 3;
+
+  // The path id.
+  optional uint32 path_id = 4;
+
+  // The IPv4 address of the egress interface.
+  optional string ipv4_next_hop = 5;
+
+  // The IPv6 address of the egress interface.
+  optional string ipv6_next_hop = 6;
+
+  // One or more MPLS Label 24 bit values bound to this address prefix.
+  repeated uint32 labels = 7;
+
+  // Optional community attributes.
+  repeated ResultBgpCommunity communities = 8;
+
+  // Optional received Extended Community attributes. Each received Extended Community
+  // attribute is available for retrieval in two forms. Support of the 'raw' format in
+  // which all 8 bytes (16 hex characters) is always present and available for use. In
+  // addition, if supported by the implementation, the Extended Community attribute may
+  // also be retrieved in the  'structured' format which is an optional field.
+  repeated ResultExtendedCommunity extended_communities = 9;
+
+  // Description missing in models
+  ResultBgpAsPath as_path = 10;
+
+  // The local preference is a well-known attribute and the value is used for route selection.
+  // The route with the highest local preference value is preferred.
+  optional uint32 local_preference = 11;
+
+  // The multi exit discriminator (MED) is an optional non-transitive attribute and the
+  // value is used for route selection. The route with the lowest MED value is preferred.
+  optional uint32 multi_exit_discriminator = 12;
 }
 
 // BGP communities provide additional capability for tagging routes and  for modifying

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1,4 +1,4 @@
-/* Open Traffic Generator API 1.51.0
+/* Open Traffic Generator API 1.52.0
  * Open Traffic Generator API defines a model-driven, vendor-neutral and standard
  * interface for emulating layer 2-7 network devices and generating test traffic.
  * 
@@ -15431,6 +15431,7 @@ message PortMetricsRequest {
       bytes_tx_rate = 11;
       bytes_rx_rate = 12;
       last_change = 13;
+      speed = 14;
     }
   }
   // The list of column names that the returned result set will contain. If the list is
@@ -15516,6 +15517,12 @@ message PortMetric {
 
   // Description missing in models
   MetricDataIntegrity data_integrity = 15;
+
+  // The speed in KBps the frames are transmitted. The calculated speed for  a negotiated
+  // line speed of (i) 100 Gbps is 100 * 1024 * 1024 / 8 = 13107200 KBps,  (ii) 1.6 Tbps
+  // (high performance devices) is 1.6 * 1024 * 1024 * 1024 / 8 = 214748365 KBps,  (iii)
+  // 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+  optional uint64 speed = 16;
 }
 
 // The container for data integrity metrics. The container will be empty if

--- a/control/isis.yaml
+++ b/control/isis.yaml
@@ -18,12 +18,23 @@ components:
           x-enum:
             initiate_graceful_restart:
               x-field-uid: 1
+            overload_bit:
+              x-field-uid: 2
           x-field-uid: 1
         initiate_graceful_restart:
           description: >-
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: "#/components/schemas/Action.Protocol.Isis.InitiateRestart"
           x-field-uid: 2
+        overload_bit:
+          description: >-
+            Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives,
+            it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system
+            not to use the overloaded IS router as a tranisient router. 
+            Set Overload Bit to false, to toggle the above process.
+          type: boolean
+          default: true
+          x-field-uid: 3
 
     Action.Protocol.Isis.InitiateRestart:
       description: |-

--- a/control/isis.yaml
+++ b/control/isis.yaml
@@ -26,7 +26,7 @@ components:
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: "#/components/schemas/Action.Protocol.Isis.InitiateRestart"
           x-field-uid: 2
-        overload_bit:
+        set_overload_bit:
           description: >-
             Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives,
             it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system

--- a/control/isis.yaml
+++ b/control/isis.yaml
@@ -18,8 +18,6 @@ components:
           x-enum:
             initiate_graceful_restart:
               x-field-uid: 1
-            overload_bit:
-              x-field-uid: 2
           x-field-uid: 1
         initiate_graceful_restart:
           description: >-
@@ -62,7 +60,6 @@ components:
         planned:
           $ref: "#/components/schemas/Action.Protocol.Isis.PlannedRestart"
           x-field-uid: 4
-
 
     Action.Protocol.Isis.UnplannedRestart:
       description: >-

--- a/control/isis.yaml
+++ b/control/isis.yaml
@@ -26,15 +26,6 @@ components:
             Configuration for the initiation of the IS-IS Graceful Restart.
           $ref: "#/components/schemas/Action.Protocol.Isis.InitiateRestart"
           x-field-uid: 2
-        set_overload_bit:
-          description: >-
-            Set Overload Bit to true to deal with transient problems that prevent an IS from storing all the LSPs it receives,
-            it sets the Overload Bit in the non-pseudonode LSP number Zero that it generates. Then other system
-            not to use the overloaded IS router as a tranisient router. 
-            Set Overload Bit to false, to toggle the above process.
-          type: boolean
-          default: true
-          x-field-uid: 3
 
     Action.Protocol.Isis.InitiateRestart:
       description: |-

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -196,6 +196,9 @@ components:
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
+        links:
+          $ref: '#/components/schemas/State.Protocol.Isis.Links'
+          x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: >-
         Sets state of configured ISIS routers.
@@ -358,3 +361,63 @@ components:
               x-field-uid: 1
             down:
               x-field-uid: 2
+
+    State.Protocol.Isis.Links:
+      description: >-
+        Sets the state of configured routes
+      type: object
+      properties:
+        names:
+          description: >-
+            The names of interface object of a device Router objects to control.
+            If no names are specified then all route objects that match the x-constraint will be affected.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Isis.Interface/properties/name'
+          x-field-uid: 1
+        up:
+          description: >-
+            Set up to true or false to interface state in UP or DOWN state respectively.
+          type: boolean 
+          default: true
+          x-field-uid: 2
+        metric:
+          description: >-
+            The cost metric associated with the link.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 10
+          x-field-uid: 3
+
+    State.Protocol.Link:
+      description: >-
+        Sets the state of configured routes
+      type: object
+      properties:
+        names:
+          description: >-
+            The names of interface object of a device Router objects to control.
+            If no names are specified then all route objects that match the x-constraint will be affected.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - '/components/schemas/Isis.Interface/properties/name'
+          x-field-uid: 1
+        up:
+          description: >-
+            Set up to true or false to interface state in UP or DOWN state respectively.
+          type: boolean 
+          default: true
+          x-field-uid: 2
+        metric:
+          description: >-
+            The cost metric associated with the link.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 10
+          x-field-uid: 3

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -196,8 +196,8 @@ components:
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
-        links:
-          $ref: '#/components/schemas/State.Protocol.Isis.Links'
+        simulated_links:
+          $ref: '#/components/schemas/State.Protocol.Isis.SimLinks'
           x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: >-
@@ -362,15 +362,15 @@ components:
             down:
               x-field-uid: 2
 
-    State.Protocol.Isis.Links:
+    State.Protocol.Isis.SimLinks:
       description: >-
-        Sets the state of configured routes
+        Sets the state of configured one or more Simulated Links (Interfaces)
       type: object
       properties:
         names:
           description: >-
-            The names of interface object of a device Router objects to control.
-            If no names are specified then all route objects that match the x-constraint will be affected.
+            The names of interfaces object of a device Interface objects to control.
+            If no names are specified then all Simulated Interface objects that match the x-constraint will be affected.
           type: array
           items:
             type: string
@@ -379,45 +379,8 @@ components:
           x-field-uid: 1
         up:
           description: >-
-            Set up to true or false to interface state in UP or DOWN state respectively.
+            Set up to true or false to interface state in UP or DOWN state respectively in both direction. Thats is the UP/DOWN state is applied for a simulated link,
+            connecting, say, a Node A to Node B and Node B to  Node A in both directions.
           type: boolean 
           default: true
           x-field-uid: 2
-        metric:
-          description: >-
-            The cost metric associated with the link.
-          type: integer
-          format: uint32
-          maximum: 16777215
-          default: 10
-          x-field-uid: 3
-
-    State.Protocol.Link:
-      description: >-
-        Sets the state of configured routes
-      type: object
-      properties:
-        names:
-          description: >-
-            The names of interface object of a device Router objects to control.
-            If no names are specified then all route objects that match the x-constraint will be affected.
-          type: array
-          items:
-            type: string
-          x-constraint:
-          - '/components/schemas/Isis.Interface/properties/name'
-          x-field-uid: 1
-        up:
-          description: >-
-            Set up to true or false to interface state in UP or DOWN state respectively.
-          type: boolean 
-          default: true
-          x-field-uid: 2
-        metric:
-          description: >-
-            The cost metric associated with the link.
-          type: integer
-          format: uint32
-          maximum: 16777215
-          default: 10
-          x-field-uid: 3

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -182,7 +182,7 @@ components:
               x-field-uid: 2
     State.Protocol.Isis:
       description: >-
-        Sets state of configured ISIS routers.
+        Sets state of configured ISIS routers and Links.
       type: object
       required:
         - choice
@@ -192,6 +192,8 @@ components:
           x-enum:
             routers:
               x-field-uid: 1
+            simulated_links:
+              x-field-uid: 2
           x-field-uid: 1
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -381,29 +381,29 @@ components:
           x-field-uid: 1
         state:
           description: |-
-            description: |-
-            Set ControlState to UP or DOWN to interface state in UP or DOWN state respectively in both directions. Thats is the UP/DOWN state is applied for a simulated link,
-            connecting, say, a Node A to Node B and Node B to Node A in both directions.
-            Setting Control State to DOWN will result in the selected set of Simulated Links to be set in disconnected state. This should result in the link to be removed from the 
-            Extended IS Reachability TLV in subsequent LSP transmitted ( with incremented Sequence Number ) from both the Simulated or Emulated Router on which this link is 
-            located as well the Simulated or Emulated Router at the other end of the link i.e. this will bring down the Simulated Links on both ends.
-            Similarly, setting the Control State to UP should result in the neighbor information to be re-introduced in Extended IS Reachability sent in subsequent LSP Update by the 
-            Router containing the Simulated Link and the neighboring Router at the other end of the link. Note that if the link is already in UP state and the Control State is set 
-            to UP again or if the state is in DOWN state and the Control State is set to DOWN again, those links in the request should be ignored.
-            
+            Sets the Control State of one or more Simulated Links to UP or DOWN. 
+            The state change is applied bidirectionally — a link between IS-IS Routers A and B is affected 
+            in both directions simultaneously.
+            Setting Control State to DOWN transitions the selected Simulated Links to a disconnected state. 
+            Both the Simulated/Emulated Router hosting the link and the neighboring router at the far end 
+            will remove the link from the Extended IS Reachability TLV in their next LSP transmission (with an incremented Sequence Number).
+            Setting Control State to UP reconnects the selected Simulated Links. 
+            Both routers will re-advertise the neighbor relationship in their next LSP Update.
+                        
             Example:
-            Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:  ST1('770000000001'), ST2('770000000002') and ST3('770000000003') in a ring topology.
-            ER <--> ST1 <--> ST2
-            ^	            (A) ^
-            |		              |
-            v 	          (B) v
-            -------ST3-------
+            Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:  
+            ST1('770000000001'), ST2('770000000002') and ST3('770000000003') in a ring topology.
 
-            Before the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen as in ISIS Link State PDU (LSP) information in Get State
+            ER <--> ST1 <--> ST2 <--> ST3 <--> ER
+                             (A)      (B)
+                             
+            Before the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen 
+            as in ISIS Link State PDU (LSP) information in Get State
             LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001', '770000000003']
             LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000002', '770000000001']
 
-            After the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen as in ISIS Link State PDU (LSP) information in Get State
+            After the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen 
+            as in ISIS Link State PDU (LSP) information in Get State
             LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']
             LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']
           type: string

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -371,8 +371,8 @@ components:
       properties:
         names:
           description: >-
-            The names of interfaces object of a device Interface objects to control.
-            If no names are specified then all Simulated Interface objects that match the x-constraint will be affected.
+            The names of ISIS Simulated Links to control.
+            If no names are specified then all ISIS Simulated Links in the configuration will be affected..
           type: array
           items:
             type: string
@@ -380,9 +380,31 @@ components:
           - '/components/schemas/Isis.Interface/properties/name'
           x-field-uid: 1
         up:
-          description: >-
+          description: |-
             Set up to true or false to interface state in UP or DOWN state respectively in both direction. Thats is the UP/DOWN state is applied for a simulated link,
-            connecting, say, a Node A to Node B and Node B to  Node A in both directions.
+            connecting, say, a Node A to Node B and Node B to Node A in both directions.
+            Setting to false will result in the selected set of Simulated Links to be set in disconnected state. This should result in the link to be removed from the 
+            Extended IS Reachability TLV in subsequent LSP transmitted ( with incremented Sequence Number ) from both the Simulated or Emulated Router on which this link is 
+            located as well the Simulated or Emulated Router at the other end of the link i.e. this will bring down the Simulated Links on both ends.
+            Similarly, setting to true should result in the neighbor information to be re-introduced in Extended IS Reachability sent in subsequent LSP Update by the 
+            Router containing the Simulated Link and the neighboring Router at the other end of the link. Note that if the link is already in 'up' state and the value is set 
+            to 'true' or it is in 'down' state and the value is set to 'false', those links in the request should be ignored.
+            
+            Example:
+            Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:  ST1('770000000001'), ST2('770000000002') and ST3('770000000003') in a ring topology.
+            ER <--> ST1 <--> ST2
+            ^	            (A) ^
+            |		              |
+            v 	          (B) v
+            -------ST3-------
+
+            Before the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen as in ISIS Link State PDU (LSP) information in Get State
+            LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001', '770000000003']
+            LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000002', '770000000001']
+
+            After the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen as in ISIS Link State PDU (LSP) information in Get State
+            LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']
+            LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']
           type: boolean 
-          default: true
+          default: false
           x-field-uid: 2

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -394,8 +394,7 @@ components:
             Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:  
             ST1('770000000001'), ST2('770000000002') and ST3('770000000003') in a ring topology.
 
-            ER <--> ST1 <--> ST2 <--> ST3 <--> ER
-                             (A)      (B)
+            ER <--> ST1 <--> ST2(A) <--> ST3(B) <--> ER
                              
             Before the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen 
             as in ISIS Link State PDU (LSP) information in Get State

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -379,16 +379,17 @@ components:
           x-constraint:
           - '/components/schemas/Isis.Interface/properties/name'
           x-field-uid: 1
-        up:
+        state:
           description: |-
-            Set up to true or false to interface state in UP or DOWN state respectively in both direction. Thats is the UP/DOWN state is applied for a simulated link,
+            description: |-
+            Set ControlState to UP or DOWN to interface state in UP or DOWN state respectively in both directions. Thats is the UP/DOWN state is applied for a simulated link,
             connecting, say, a Node A to Node B and Node B to Node A in both directions.
-            Setting to false will result in the selected set of Simulated Links to be set in disconnected state. This should result in the link to be removed from the 
+            Setting Control State to DOWN will result in the selected set of Simulated Links to be set in disconnected state. This should result in the link to be removed from the 
             Extended IS Reachability TLV in subsequent LSP transmitted ( with incremented Sequence Number ) from both the Simulated or Emulated Router on which this link is 
             located as well the Simulated or Emulated Router at the other end of the link i.e. this will bring down the Simulated Links on both ends.
-            Similarly, setting to true should result in the neighbor information to be re-introduced in Extended IS Reachability sent in subsequent LSP Update by the 
-            Router containing the Simulated Link and the neighboring Router at the other end of the link. Note that if the link is already in 'up' state and the value is set 
-            to 'true' or it is in 'down' state and the value is set to 'false', those links in the request should be ignored.
+            Similarly, setting the Control State to UP should result in the neighbor information to be re-introduced in Extended IS Reachability sent in subsequent LSP Update by the 
+            Router containing the Simulated Link and the neighboring Router at the other end of the link. Note that if the link is already in UP state and the Control State is set 
+            to UP again or if the state is in DOWN state and the Control State is set to DOWN again, those links in the request should be ignored.
             
             Example:
             Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:  ST1('770000000001'), ST2('770000000002') and ST3('770000000003') in a ring topology.
@@ -405,6 +406,10 @@ components:
             After the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will be seen as in ISIS Link State PDU (LSP) information in Get State
             LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']
             LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']
-          type: boolean 
-          default: false
+          type: string
           x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2

--- a/control/state.yaml
+++ b/control/state.yaml
@@ -93,8 +93,6 @@ components:
               x-field-uid: 6
             ospfv3:
               x-field-uid: 7
-            link:
-              x-field-uid: 8
           x-field-uid: 1
         all:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.All'
@@ -120,6 +118,3 @@ components:
         rocev2:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.Rocev2'
           x-field-uid: 9
-        link:
-          $ref: './protocol.yaml#/components/schemas/State.Protocol.Link'
-          x-field-uid: 10

--- a/control/state.yaml
+++ b/control/state.yaml
@@ -93,6 +93,8 @@ components:
               x-field-uid: 6
             ospfv3:
               x-field-uid: 7
+            link:
+              x-field-uid: 8
           x-field-uid: 1
         all:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.All'
@@ -118,3 +120,6 @@ components:
         rocev2:
           $ref: './protocol.yaml#/components/schemas/State.Protocol.Rocev2'
           x-field-uid: 9
+        link:
+          $ref: './protocol.yaml#/components/schemas/State.Protocol.Link'
+          x-field-uid: 10


### PR DESCRIPTION
### Feature Overview
- **Related Issue:** <https://partnerissuetracker.corp.google.com/issues/433281254>`)
- **Brief Description:**  
Disable/Enable Simulated Links on the fly
---

### Feature Details
 - [Redocly docs for this feature/branch](<https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/isis-otf-st-link/artifacts/openapi.yaml&nocors#tag/Configuration/operation/update_config>)
- **New Locations/Nomenclature:**  
set_control_state: State.Protocol.Isis.SimLinks

  ```
  go get github.com/open-traffic-generator/snappi/gosnappi@<isis-otf-st-link>
  ```

---

### Code snippets
_cs := gosnappi.NewControlState()
	cs.Protocol().Isis().SimulatedLinks().
		SetNames(simLinkNames).
                SetState(gosnappi.StateProtocolIsisSimLinksState.DOWN)/ SetState(gosnappi.StateProtocolIsisSimLinksState.UP)_