### PR TITLE
Support of negotiated port speed in KBps in port metrics response

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -20045,6 +20045,8 @@ components:
                 x-field-uid: 12
               last_change:
                 x-field-uid: 13
+              speed:
+                x-field-uid: 14
             enum:
             - transmit
             - location
@@ -20059,6 +20061,7 @@ components:
             - bytes_tx_rate
             - bytes_rx_rate
             - last_change
+            - speed
           x-field-uid: 2
     Port.Metric:
       type: object
@@ -20172,6 +20175,12 @@ components:
         data_integrity:
           $ref: '#/components/schemas/Metric.DataIntegrity'
           x-field-uid: 15
+        speed:
+          description: |-
+            The speed in KBps the frames are transmitted. The calculated speed for  a negotiated line speed of - 100 Gbps is 100 * 1024 / 8 = 12800 KBps - 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps - 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+          type: integer
+          format: uint64
+          x-field-uid: 16
     Metric.DataIntegrity:
       description: "The container for data integrity metrics. The container will be\
         \ empty if \noptions.port_options.data_integrity has not been enabled during\

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -20288,7 +20288,7 @@ components:
           x-field-uid: 15
         speed:
           description: |-
-            The speed in KBps the frames are transmitted. The calculated speed for  a negotiated line speed of (i) 100 Gbps is 100 * 1024 / 8 = 12800 KBps,  (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps,  (iii) 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+            The speed in KBps the frames are transmitted. The calculated speed for  a negotiated line speed of (i) 100 Gbps is 100 * 1024 * 1024 / 8 = 13107200 KBps,  (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 * 1024 / 8 = 214748365 KBps,  (iii) 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
           type: integer
           format: uint64
           x-field-uid: 16

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -20177,7 +20177,7 @@ components:
           x-field-uid: 15
         speed:
           description: |-
-            The speed in KBps the frames are transmitted. The calculated speed for  a negotiated line speed of - 100 Gbps is 100 * 1024 / 8 = 12800 KBps - 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps - 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+            The speed in KBps the frames are transmitted. The calculated speed for  a negotiated line speed of (i) 100 Gbps is 100 * 1024 / 8 = 12800 KBps,  (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps,  (iii) 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
           type: integer
           format: uint64
           x-field-uid: 16

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -15463,9 +15463,9 @@ message PortMetric {
   MetricDataIntegrity data_integrity = 15;
 
   // The speed in KBps the frames are transmitted. The calculated speed for  a negotiated
-  // line speed of (i) 100 Gbps is 100 * 1024 / 8 = 12800 KBps,  (ii) 1.6 Tbps (high performance
-  // devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps,  (iii) 10 Mbps (legacy devices)
-  // is 10 * 1024 / 8 = 1280 KBps
+  // line speed of (i) 100 Gbps is 100 * 1024 * 1024 / 8 = 13107200 KBps,  (ii) 1.6 Tbps
+  // (high performance devices) is 1.6 * 1024 * 1024 * 1024 / 8 = 214748365 KBps,  (iii)
+  // 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
   optional uint64 speed = 16;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -15273,6 +15273,7 @@ message PortMetricsRequest {
       bytes_tx_rate = 11;
       bytes_rx_rate = 12;
       last_change = 13;
+      speed = 14;
     }
   }
   // The list of column names that the returned result set will contain. If the list is
@@ -15358,6 +15359,12 @@ message PortMetric {
 
   // Description missing in models
   MetricDataIntegrity data_integrity = 15;
+
+  // The speed in KBps the frames are transmitted. The calculated speed for  a negotiated
+  // line speed of - 100 Gbps is 100 * 1024 / 8 = 12800 KBps - 1.6 Tbps (high performance
+  // devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps - 10 Mbps (legacy devices) is 10
+  // * 1024 / 8 = 1280 KBps
+  optional uint64 speed = 16;
 }
 
 // The container for data integrity metrics. The container will be empty if

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -15361,9 +15361,9 @@ message PortMetric {
   MetricDataIntegrity data_integrity = 15;
 
   // The speed in KBps the frames are transmitted. The calculated speed for  a negotiated
-  // line speed of - 100 Gbps is 100 * 1024 / 8 = 12800 KBps - 1.6 Tbps (high performance
-  // devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps - 10 Mbps (legacy devices) is 10
-  // * 1024 / 8 = 1280 KBps
+  // line speed of (i) 100 Gbps is 100 * 1024 / 8 = 12800 KBps,  (ii) 1.6 Tbps (high performance
+  // devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps,  (iii) 10 Mbps (legacy devices)
+  // is 10 * 1024 / 8 = 1280 KBps
   optional uint64 speed = 16;
 }
 

--- a/result/port.yaml
+++ b/result/port.yaml
@@ -163,9 +163,9 @@ components:
           description: >-
             The speed in KBps the frames are transmitted. The calculated speed for 
             a negotiated line speed of
-            - 100 Gbps is 100 * 1024 / 8 = 12800 KBps
-            - 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps
-            - 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+            (i) 100 Gbps is 100 * 1024 / 8 = 12800 KBps, 
+            (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps, 
+            (iii) 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
           type: integer
           format: uint64
           x-field-uid: 16

--- a/result/port.yaml
+++ b/result/port.yaml
@@ -163,8 +163,8 @@ components:
           description: >-
             The speed in KBps the frames are transmitted. The calculated speed for 
             a negotiated line speed of
-            (i) 100 Gbps is 100 * 1024 / 8 = 12800 KBps, 
-            (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps, 
+            (i) 100 Gbps is 100 * 1024 * 1024 / 8 = 13107200 KBps, 
+            (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 * 1024 / 8 = 214748365 KBps, 
             (iii) 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
           type: integer
           format: uint64

--- a/result/port.yaml
+++ b/result/port.yaml
@@ -50,6 +50,8 @@ components:
                 x-field-uid: 12
               last_change:
                 x-field-uid: 13
+              speed:
+                x-field-uid: 14
           x-field-uid: 2
     Port.Metric:
       type: object
@@ -157,6 +159,16 @@ components:
         data_integrity:
           $ref: '#/components/schemas/Metric.DataIntegrity'
           x-field-uid: 15
+        speed:
+          description: >-
+            The speed in KBps the frames are transmitted. The calculated speed for 
+            a negotiated line speed of
+            - 100 Gbps is 100 * 1024 / 8 = 12800 KBps
+            - 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 / 8 = 209715 KBps
+            - 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+          type: integer
+          format: uint64
+          x-field-uid: 16
     Metric.DataIntegrity:
       description: |-
         The container for data integrity metrics. The container will be empty if 


### PR DESCRIPTION
### Feature Overview
- **Related Issue:** (e.g., Fixes `#466`)
- **Brief Description:**  
  Add speed to port stats. This could help the customer with certain traffic stats calculations.

---

### Feature Details
 - [Redocly docs for this feature/branch](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-port-speed/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_metrics)
- **New Locations/Nomenclature:**  
  In port metrics we have added a new entry "speed" to signify speed in KBps the frames are transmitted.

- [Dev-Snappi branch reference](https://github.com/open-traffic-generator/snappi/tree/dev-port-speed)
- To fetch the dev-snappi branch:
  ```
  go get github.com/open-traffic-generator/snappi/gosnappi@dev-port-speed
  ```

---

### Code snippets

```go/python
...
req := gosnappi.NewMetricsRequest()
reqPort := req.Port()
res, err := client.GetMetrics(req)
...
Port Metrics
-----------------------------------------------------------------------------------------
Name    Frames Tx    Frames Rx    Speed
p1      1000         1000         12800
p2      1000         1000         12800
-----------------------------------------------------------------------------------------
```
