### PR TITLE
making "destination_ip_address" an optional field

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -12814,7 +12814,6 @@ components:
       type: object
       required:
       - name
-      - destination_ip_address
       properties:
         name:
           x-field-uid: 1
@@ -12985,7 +12984,6 @@ components:
       type: object
       required:
       - name
-      - destination_ip_address
       properties:
         name:
           x-field-uid: 1

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -9447,7 +9447,6 @@ message Rocev2V4Peer {
   optional string name = 1;
 
   // Specify the destination ip address.
-  // required = true
   optional string destination_ip_address = 2;
 
   // This allows the user to set  multiple QPs and its properties between a pair of source
@@ -9562,7 +9561,6 @@ message Rocev2V6Peer {
   optional string name = 1;
 
   // Specify the destination ip address.
-  // required = true
   optional string destination_ip_address = 2;
 
   // This allows the user to set  multiple QPs and its properties between a pair of source

--- a/device/rocev2/rocev2ipv4.yaml
+++ b/device/rocev2/rocev2ipv4.yaml
@@ -35,7 +35,7 @@ components:
       description: >-
         Configuration for RoCEv2 IPv4 peers.
       type: object
-      required: [name, destination_ip_address]
+      required: [name]
       properties:
         name:
           x-include: ../../common/common.yaml#/components/schemas/Named.Object/properties/name

--- a/device/rocev2/rocev2ipv6.yaml
+++ b/device/rocev2/rocev2ipv6.yaml
@@ -35,7 +35,7 @@ components:
       description: >-
         Configuration for RoCEv2 IPv6 peer settings.
       type: object
-      required: [name, destination_ip_address]
+      required: [name]
       properties:
         name:
           x-include: ../../common/common.yaml#/components/schemas/Named.Object/properties/name


### PR DESCRIPTION
### Feature Overview

- **Brief Description:**  
 There can be instances where we do not want to set destination Peer for a RoCEv2 peer. In that case, keeping the "destination_ip_address" a required field doesn't makes sense. Hence removing it from the required section.

### Code snippets
    rocev2_1, rocev2_2 = d1.rocev2, d2.rocev2
    rocev2_1_int, rocev2_2_int = rocev2_1.ipv4_interfaces.add(), rocev2_2.ipv4_interfaces.add()
    rocev2_1_int.ipv4_name, rocev2_2_int.ipv4_name = ip1.name, ip2.name
    rocev2_1_int.ib_mtu, rocev2_2_int.ib_mtu = 1027, 1027
    rocev2_1_peer, rocev2_2_peer = rocev2_1_int.peers.add(), rocev2_2_int.peers.add()
    rocev2_1_peer.name, rocev2_2_peer.name = "RoCEv2 1", "RoCEv2 2"
    rocev2_1_peer.destination_ip_address = ip2.address
    ###Not Setting destination ip address for 2nd peer
