### PR TITLE
Dev port speed

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -18864,7 +18864,7 @@ components:
           - down
     State.Protocol.Isis:
       description: |-
-        Sets state of configured ISIS routers.
+        Sets state of configured ISIS routers and Links.
       type: object
       required:
       - choice
@@ -18874,12 +18874,18 @@ components:
           x-enum:
             routers:
               x-field-uid: 1
+            simulated_links:
+              x-field-uid: 2
           x-field-uid: 1
           enum:
           - routers
+          - simulated_links
         routers:
           $ref: '#/components/schemas/State.Protocol.Isis.Routers'
           x-field-uid: 2
+        simulated_links:
+          $ref: '#/components/schemas/State.Protocol.Isis.SimLinks'
+          x-field-uid: 3
     State.Protocol.Isis.Routers:
       description: |-
         Sets state of configured ISIS routers.
@@ -19058,6 +19064,57 @@ components:
             \ 'up', underlying IP interface(s) would be brought up automatically (if\
             \ not already up),\n would attempt to bring up the RoCEv2 session(s).\n\
             If the desired state is 'down', RoCEv2 session(s) would be brought down. "
+          type: string
+          x-field-uid: 2
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          enum:
+          - up
+          - down
+    State.Protocol.Isis.SimLinks:
+      description: |-
+        Sets the state of configured one or more Simulated Links (Interfaces)
+      type: object
+      properties:
+        names:
+          description: |
+            The names of ISIS Simulated Links to control. If no names are specified then all ISIS Simulated Links in the configuration will be affected..
+
+            x-constraint:
+            - /components/schemas/Isis.Interface/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Isis.Interface/properties/name
+          x-field-uid: 1
+        state:
+          description: "Sets the Control State of one or more Simulated Links to UP\
+            \ or DOWN. \nThe state change is applied bidirectionally — a link between\
+            \ IS-IS Routers A and B is affected \nin both directions simultaneously.\n\
+            Setting Control State to DOWN transitions the selected Simulated Links\
+            \ to a disconnected state. \nBoth the Simulated/Emulated Router hosting\
+            \ the link and the neighboring router at the far end \nwill remove the\
+            \ link from the Extended IS Reachability TLV in their next LSP transmission\
+            \ (with an incremented Sequence Number).\nSetting Control State to UP\
+            \ reconnects the selected Simulated Links. \nBoth routers will re-advertise\
+            \ the neighbor relationship in their next LSP Update.\n            \n\
+            Example:\nSuppose Emulated Router ER (680000000003) is connected to Simulated\
+            \ Routers:  \nST1('770000000001'), ST2('770000000002') and ST3('770000000003')\
+            \ in a ring topology.\n\nER <--> ST1 <--> ST2(A) <--> ST3(B) <--> ER\n\
+            \                 \nBefore the AB Link Down operation between ST2 & ST3\
+            \  the neighbors of ST2 & ST3 will be seen \nas in ISIS Link State PDU\
+            \ (LSP) information in Get State\nLSP-ID of ST2: 770000000002-00-00: IS-Reachability\
+            \ Neighbors : ['770000000001', '770000000003']\nLSP-ID of ST3: 770000000003-00-00:\
+            \ IS-Reachability Neighbors : ['770000000002', '770000000001']\n\nAfter\
+            \ the AB Link Down operation between ST2 & ST3  the neighbors of ST2 &\
+            \ ST3 will be seen \nas in ISIS Link State PDU (LSP) information in Get\
+            \ State\nLSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors\
+            \ : ['770000000001']\nLSP-ID of ST3: 770000000003-00-00: IS-Reachability\
+            \ Neighbors : ['770000000001']"
           type: string
           x-field-uid: 2
           x-enum:

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -20288,7 +20288,7 @@ components:
           x-field-uid: 15
         speed:
           description: |-
-            The speed in KBps the frames are transmitted. The calculated speed for  a negotiated line speed of (i) 100 Gbps is 100 * 1024 * 1024 / 8 = 13107200 KBps,  (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 * 1024 / 8 = 214748365 KBps,  (iii) 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+            The speed in KBps the frames are transmitted. The calculated speed for  a negotiated line speed of (i) 100 Gbps is 100 * 1000 * 1000 / 8 = 12500000 KBps, (ii) 1.6 Tbps (high performance devices) is 1.6 * 1000 * 1000 * 1000 / 8 = 200000000 KBps, (iii) 10 Mbps (legacy devices) is 10 * 1000 / 8 = 1250 KBps
           type: integer
           format: uint64
           x-field-uid: 16

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -15463,9 +15463,9 @@ message PortMetric {
   MetricDataIntegrity data_integrity = 15;
 
   // The speed in KBps the frames are transmitted. The calculated speed for  a negotiated
-  // line speed of (i) 100 Gbps is 100 * 1024 * 1024 / 8 = 13107200 KBps,  (ii) 1.6 Tbps
-  // (high performance devices) is 1.6 * 1024 * 1024 * 1024 / 8 = 214748365 KBps,  (iii)
-  // 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+  // line speed of (i) 100 Gbps is 100 * 1000 * 1000 / 8 = 12500000 KBps, (ii) 1.6 Tbps
+  // (high performance devices) is 1.6 * 1000 * 1000 * 1000 / 8 = 200000000 KBps, (iii)
+  // 10 Mbps (legacy devices) is 10 * 1000 / 8 = 1250 KBps
   optional uint64 speed = 16;
 }
 

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -14383,13 +14383,14 @@ message StateProtocolBgpPeers {
   optional State.Enum state = 2;
 }
 
-// Sets state of configured ISIS routers.
+// Sets state of configured ISIS routers and Links.
 message StateProtocolIsis {
 
   message Choice {
     enum Enum {
       unspecified = 0;
       routers = 1;
+      simulated_links = 2;
     }
   }
   // Description missing in models
@@ -14398,6 +14399,9 @@ message StateProtocolIsis {
 
   // Description missing in models
   StateProtocolIsisRouters routers = 2;
+
+  // Description missing in models
+  StateProtocolIsisSimLinks simulated_links = 3;
 }
 
 // Sets state of configured ISIS routers.
@@ -14553,6 +14557,57 @@ message StateProtocolRocev2Peers {
   // would attempt to bring up the RoCEv2 session(s).
   // If the desired state is 'down', RoCEv2 session(s) would be brought down.
   // required = true
+  optional State.Enum state = 2;
+}
+
+// Sets the state of configured one or more Simulated Links (Interfaces)
+message StateProtocolIsisSimLinks {
+
+  // The names of ISIS Simulated Links to control. If no names are specified then all
+  // ISIS Simulated Links in the configuration will be affected..
+  // 
+  // x-constraint:
+  // - /components/schemas/Isis.Interface/properties/name
+  // 
+  repeated string names = 1;
+
+  message State {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // Sets the Control State of one or more Simulated Links to UP or DOWN.
+  // The state change is applied bidirectionally — a link between IS-IS Routers A and
+  // B is affected
+  // in both directions simultaneously.
+  // Setting Control State to DOWN transitions the selected Simulated Links to a disconnected
+  // state.
+  // Both the Simulated/Emulated Router hosting the link and the neighboring router at
+  // the far end
+  // will remove the link from the Extended IS Reachability TLV in their next LSP transmission
+  // (with an incremented Sequence Number).
+  // Setting Control State to UP reconnects the selected Simulated Links.
+  // Both routers will re-advertise the neighbor relationship in their next LSP Update.
+  // 
+  // Example:
+  // Suppose Emulated Router ER (680000000003) is connected to Simulated Routers:
+  // ST1('770000000001'), ST2('770000000002') and ST3('770000000003') in a ring topology.
+  // 
+  // ER <--> ST1 <--> ST2(A) <--> ST3(B) <--> ER
+  // 
+  // Before the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will
+  // be seen
+  // as in ISIS Link State PDU (LSP) information in Get State
+  // LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001', '770000000003']
+  // LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000002', '770000000001']
+  // 
+  // After the AB Link Down operation between ST2 & ST3  the neighbors of ST2 & ST3 will
+  // be seen
+  // as in ISIS Link State PDU (LSP) information in Get State
+  // LSP-ID of ST2: 770000000002-00-00: IS-Reachability Neighbors : ['770000000001']
+  // LSP-ID of ST3: 770000000003-00-00: IS-Reachability Neighbors : ['770000000001']
   optional State.Enum state = 2;
 }
 

--- a/result/port.yaml
+++ b/result/port.yaml
@@ -163,9 +163,9 @@ components:
           description: >-
             The speed in KBps the frames are transmitted. The calculated speed for 
             a negotiated line speed of
-            (i) 100 Gbps is 100 * 1024 * 1024 / 8 = 13107200 KBps, 
-            (ii) 1.6 Tbps (high performance devices) is 1.6 * 1024 * 1024 * 1024 / 8 = 214748365 KBps, 
-            (iii) 10 Mbps (legacy devices) is 10 * 1024 / 8 = 1280 KBps
+            (i) 100 Gbps is 100 * 1000 * 1000 / 8 = 12500000 KBps,
+            (ii) 1.6 Tbps (high performance devices) is 1.6 * 1000 * 1000 * 1000 / 8 = 200000000 KBps,
+            (iii) 10 Mbps (legacy devices) is 10 * 1000 / 8 = 1250 KBps
           type: integer
           format: uint64
           x-field-uid: 16


### PR DESCRIPTION
### Feature Overview
- **Related Issue:** (e.g., Fixes `#466`)
- **Brief Description:**  
  Add speed to port stats. This could help the customer with certain traffic stats calculations.

---

### Feature Details
 - [Redocly docs for this feature/branch](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/dev-port-speed/artifacts/openapi.yaml&nocors#tag/Monitor/operation/get_metrics)
- **New Locations/Nomenclature:**  
  In port metrics we have added a new entry "speed" to signify speed in KBps the frames are transmitted.

- [Dev-Snappi branch reference](https://github.com/open-traffic-generator/snappi/tree/dev-port-speed)
- To fetch the dev-snappi branch:
  ```
  go get github.com/open-traffic-generator/snappi/gosnappi@dev-port-speed
  ```

---

### Code snippets

```go/python
...
req := gosnappi.NewMetricsRequest()
reqPort := req.Port()
res, err := client.GetMetrics(req)
...
Port Metrics
-----------------------------------------------------------------------------------------
Name    Frames Tx    Frames Rx    Speed
p1      1000         1000         12500
p2      1000         1000         12500
-----------------------------------------------------------------------------------------
```