### PR TITLE
Add IS-IS SRv6 OTG model (RFC 9352)

### DIFF
--- a/MODEL-GUIDE.md
+++ b/MODEL-GUIDE.md
@@ -9,10 +9,14 @@ This document describes the philosophy and the best practices to be followed whi
 * [Modeling Best Practices](#modeling-best-practices)
   * [Adding New APIs](#adding-new-apis)
   * [Properties](#properties)
+    * [Object Presence vs. Enable Booleans](#object-presence-vs-enable-booleans)
+    * [Config Schemas vs. State/Result Schemas](#config-schemas-vs-stateresult-schemas)
   * [Naming](#naming)
+    * [Cross-File References](#cross-file-references)
   * [Keyword Limitations](#keyword-limitations)
   * [Keyword Extensions](#keyword-extensions)
   * [Descriptions](#descriptions)
+* [Building & Validating](#building--validating)
 * [Pull Requests](#pull-requests)
 
 ## Philosophy
@@ -47,12 +51,80 @@ This document describes the philosophy and the best practices to be followed whi
 
 ### Properties
 
-* Don't expose a property if it must always be a particular value (eg. prefix length for loopback IP addresses).
+* Don’t expose a property if it must always be a particular value (eg. prefix length for loopback IP addresses).
 * Give descriptive names to properties, so that it’s apparent what value it is supposed to hold. e.g. `port_names` vs `port`
 * Choose sensible values for default, min and max.
 * Do not assign defaults to properties for which holding a null value has a meaning.
 * Do not mark properties are required if they can hold sensible default values.
+* A property MUST NOT be both `required` AND have a `default` value. The build will reject it with a `TypeError`. If a default exists, the field is optional by definition.
 * Use proper `x-status`.
+
+#### Object Presence vs. Enable Booleans
+
+* Do NOT add an `active`, `enable`, or `include_*` boolean alongside a `$ref` (object) field to control whether it is included. Object presence is self-describing: setting the field means "include it", omitting it means "do not include it". The boolean is redundant and adds API noise.
+
+  ```yaml
+  # WRONG — include_sid_structure is redundant for a $ref field
+  include_sid_structure:
+    type: boolean
+    default: false
+    x-field-uid: 4
+  sid_structure:
+    $ref: ‘#/components/schemas/Foo.SidStructure’
+    x-field-uid: 5
+
+  # CORRECT — object presence is the gate
+  sid_structure:
+    $ref: ‘#/components/schemas/Foo.SidStructure’
+    x-field-uid: 4
+  ```
+
+* DO use an `include_*` boolean alongside a scalar field (integer, boolean, string) when the difference between "not advertised" and "advertised with value 0 / false" is meaningful. In these cases, the scalar’s default alone cannot communicate intent.
+
+  ```yaml
+  # Correct — include boolean needed: max_sl=0 means "advertised as 0",
+  # while include_max_sl=false means "do not advertise this MSD type at all"
+  include_max_sl:
+    type: boolean
+    default: false
+    x-field-uid: 1
+  max_sl:
+    type: integer
+    format: uint32
+    default: 0
+    x-field-uid: 2
+  ```
+
+#### Config Schemas vs. State/Result Schemas
+
+* **Config schemas** (under `device/` and related) represent configuration intent. They SHOULD have sensible `default` values on optional fields.
+
+* **State/Result schemas** (under `result/`) represent values received or learned from the network. They MUST NOT have `default` values — absence of a field means it was not present in the received message; presence means it was received with that value.
+
+* State schemas MUST NOT include `include_*` boolean controls. The presence of a field IS the indicator that it was received.
+
+  ```yaml
+  # Config schema — include flags control advertisement; defaults set baseline
+  IsisFoo.NodeMsd:
+    properties:
+      include_max_sl:
+        type: boolean
+        default: false
+        x-field-uid: 1
+      max_sl:
+        type: integer
+        format: uint32
+        default: 0
+        x-field-uid: 2
+
+  # State schema — no include flags, no defaults; presence = received
+  IsisLsp.NodeMsd:
+    properties:
+      max_sl:
+        type: integer
+        format: uint32
+        x-field-uid: 1
+  ```
 
 ### Naming
 
@@ -73,6 +145,21 @@ This document describes the philosophy and the best practices to be followed whi
 
 * `schema`
   * top level `schema objects` should avoid properties as simple data types and strive to encapsulate those properties in an object to allow for future extensibility.
+  * Config schemas use `Protocol.Feature` namespace (e.g., `Isis.SegmentRouting`, `Bgp.V4Peer`).
+  * State/result schemas that represent received protocol data typically use a `ProtocolLsp.Feature` or `ProtocolState.Feature` namespace (e.g., `IsisLsp.SRv6Capability`, `BgpPeer.State`) to make the config vs. state distinction explicit.
+
+#### Cross-File References
+
+* When a schema in one YAML file references a schema defined in another YAML file within the same model, use a relative path `$ref`:
+
+  ```yaml
+  srv6_locators:
+    type: array
+    items:
+      $ref: './srv6.yaml#/components/schemas/IsisSRv6.Locator'
+  ```
+
+* Within the same file, use the local `#/components/schemas/SchemaName` form.
 
 ### Keyword Limitations
 
@@ -401,6 +488,8 @@ The build script will enforce the following keyword conventions:
   * They need to be unique (within the object), and once assigned can never be changed/re-used, even if the field itself is deprecated and eventually removed.  
   * They are required for maintaining protobuff backwards compatibility.  
   * Should follow protobuff [Assigning Field Numbers](https://developers.google.com/protocol-buffers/docs/proto3#assigning_field_numbers) conventions.
+  * On a development branch that has not yet been published/merged, UIDs may be renumbered when fields are added or removed during the design phase. Once a schema is published (merged to the main branch and released), UIDs are permanently frozen and renumbering is forbidden even on a new branch.
+  * When adding new fields to an existing published schema, always assign the next available UID — never fill gaps left by deprecated/removed fields.
 
   * Use-Case : Adding a New Property to an Existing Object
     * Adding a new property 'peer_name' to an existing object.
@@ -479,6 +568,31 @@ The build script will enforce the following keyword conventions:
     * _"Number of times `session_state` changed from `up` to `down`"_ instead of
     * _"Number of times the session went from Up to Down state"_
 
+
+## Building & Validating
+
+* Always run the build after any YAML change to catch structural errors early.
+* The build must be run with the virtual environment activated so that the code generator (`openapiart`) and the formatter (`black`) use the correct Python:
+
+  ```bash
+  source .venv/Scripts/activate && python build.py   # Windows (Git Bash / bash shell)
+  source .venv/bin/activate && python build.py        # Linux / macOS
+  ```
+
+  Running `python build.py` without activating the venv, or calling the venv Python directly (`.venv/Scripts/python.exe build.py`), can cause the `black` subprocess launched by `openapiart` to use a different Python installation and fail.
+
+* A successful build produces updated artifacts under `artifacts/`. The following files from that directory are intentionally committed to git as part of a PR (they are the published API contract):
+  * `artifacts/openapi.yaml` — merged OpenAPI specification
+  * `artifacts/openapi.html` — rendered API documentation
+  * `artifacts/otg.proto` — protobuf service definition
+
+* The following generated files under `artifacts/` MUST NOT be committed to git. They are large machine-generated outputs that are re-created locally by each developer on build:
+  * `artifacts/otg/otg.py` — generated Python SDK
+  * `artifacts/otg/otg_pb2.py` — generated protobuf Python bindings
+  * `artifacts/otg/otg_pb2_grpc.py` — generated gRPC Python bindings
+  * `artifacts/otg/__init__.py`
+
+  These files should be listed in `.gitignore` (or the equivalent) to prevent accidental commits.
 
 ## Pull Requests
 

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -3387,40 +3387,6 @@ components:
           type: boolean
           default: false
           x-field-uid: 17
-        include_source_router_id:
-          description: |-
-            Controls whether Source Router ID Sub-TLVs (RFC 9350 Section 5) are included in this locator's IPv6 Reachability prefix advertisement. - none: No Source Router ID sub-TLV included (default). - ipv4: Include IPv4 Source Router ID sub-TLV (type 11). - ipv6: Include IPv6 Source Router ID sub-TLV (type 12). - ipv4_and_ipv6: Include both IPv4 and IPv6 sub-TLVs. Used with Flex-Algo (algorithm 128-255) to identify the originating router for prefix advertisements. Applies only when advertise_locator_as_prefix is true.
-          type: string
-          default: none
-          x-enum:
-            none:
-              x-field-uid: 1
-            ipv4:
-              x-field-uid: 2
-            ipv6:
-              x-field-uid: 3
-            ipv4_and_ipv6:
-              x-field-uid: 4
-          x-field-uid: 18
-          enum:
-          - none
-          - ipv4
-          - ipv6
-          - ipv4_and_ipv6
-        ipv4_source_router_id:
-          description: |-
-            IPv4 Source Router ID value advertised in the IPv4 Source Router ID Sub-TLV (type 11, RFC 9350 Section 5). Identifies the originating router for this Flex-Algo prefix advertisement. Applicable when include_source_router_id is 'ipv4' or 'ipv4_and_ipv6'.
-          type: string
-          format: ipv4
-          default: 0.0.0.0
-          x-field-uid: 19
-        ipv6_source_router_id:
-          description: |-
-            IPv6 Source Router ID value advertised in the IPv6 Source Router ID Sub-TLV (type 12, RFC 9350 Section 5). Identifies the originating router for this Flex-Algo prefix advertisement. Applicable when include_source_router_id is 'ipv6' or 'ipv4_and_ipv6'.
-          type: string
-          format: ipv6
-          default: '::'
-          x-field-uid: 20
     IsisSRv6.EndSid:
       description: |-
         SRv6 End SID Sub-TLV (sub-TLV type 5) carried within the SRv6 Locator TLV (TLV type 27). Advertises a locally instantiated node-local SRv6 SID and its associated endpoint behavior. The SID value must be allocated from within the parent locator's prefix. Valid behaviors for node-local End SIDs are End (with PSP/USP/USD flavor variants) and decapsulation behaviors (End.DT4, End.DT6, End.DT46). Reference: RFC 9352 Section 7.2, RFC 8986.
@@ -27890,18 +27856,6 @@ components:
             Anycast flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4). Set if present and indicates this locator is an anycast prefix shared across multiple routers.
           type: boolean
           x-field-uid: 12
-        ipv4_source_router_id:
-          description: |-
-            IPv4 Source Router ID learned from the IPv4 Source Router ID Sub-TLV (type 11, RFC 9350 Section 5) in the locator's IPv6 Reachability prefix advertisement. Present only if advertised by the originating router.
-          type: string
-          format: ipv4
-          x-field-uid: 13
-        ipv6_source_router_id:
-          description: |-
-            IPv6 Source Router ID learned from the IPv6 Source Router ID Sub-TLV (type 12, RFC 9350 Section 5) in the locator's IPv6 Reachability prefix advertisement. Present only if advertised by the originating router.
-          type: string
-          format: ipv6
-          x-field-uid: 14
     IsisLsp.SRv6EndSid:
       description: |-
         SRv6 End SID Sub-TLV (sub-TLV type 5) learned from an SRv6 Locator TLV (type 27) in a received LSP. Describes a node-local SRv6 SID, its endpoint behavior, and optional SID structure information. Reference: RFC 9352 Section 7.2, RFC 8986.

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -2755,11 +2755,23 @@ components:
           x-unique: global
         adjacency_sids:
           description: |-
-            List of Adjacency Segment Identifier (Adj-SID) sub-TLVs.
+            List of SR-MPLS Adjacency Segment Identifier (Adj-SID) sub-TLVs for this interface (RFC 8667).
           type: array
           items:
             $ref: '#/components/schemas/IsisInterface.AdjacencySid'
           x-field-uid: 14
+        srv6_adj_sids:
+          description: |-
+            List of SRv6 Adjacency SID Sub-TLVs (End.X SID) for this interface. Point-to-point interfaces advertise End.X SID Sub-TLV (sub-TLV type 43); broadcast interfaces advertise LAN End.X SID Sub-TLV (sub-TLV type 44). Each entry binds a 128-bit SRv6 SID to this specific outgoing adjacency and advertises the associated endpoint behavior. Reference: RFC 9352 Sections 8.1-8.2.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSRv6.AdjSid'
+          x-field-uid: 15
+        srv6_link_msd:
+          description: |-
+            Link-level SRv6 Maximum SID Depth (MSD) capabilities for this interface. Advertised as MSD sub-TLVs within the neighbor TLVs (Extended IS Reachability TLV 22 / MT-ISN TLV 222) to signal the SRv6 SRH processing capacity of this specific link. Reference: RFC 8491, RFC 9352 Section 6.
+          $ref: '#/components/schemas/IsisSRv6.LinkMsd'
+          x-field-uid: 16
     IsisInterface.Level:
       description: |-
         Configuration for the properties of Level 1 Hello.
@@ -3139,6 +3151,595 @@ components:
           minimum: 0
           maximum: 255
           x-field-uid: 9
+    IsisSRv6.NodeCapability:
+      description: |-
+        SRv6 Capabilities Sub-TLV (sub-TLV type 25) carried within the IS-IS Router CAPABILITY TLV (TLV 242, RFC 7981). Announces that this IS-IS router is an SRv6 Segment Endpoint Node and optionally supports the O-bit for OAM operations. Node-level SRv6 Maximum SID Depth (MSD) values are also advertised here per RFC 8491. Reference: RFC 9352 Section 2.
+      type: object
+      properties:
+        o_flag:
+          description: |-
+            OAM flag (bit 1 of the Flags field in the SRv6 Capabilities Sub-TLV). When set, indicates that this router supports the use of the O-bit in the Segment Routing Header (SRH) for Operations, Administration and Maintenance (OAM) operations as defined in RFC 9259.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        node_msds:
+          description: |-
+            Node-level SRv6 Maximum SID Depth (MSD) capabilities advertised as MSD sub-TLVs within the Router Capability TLV per RFC 8491. These signal the maximum SRH stack depth this router supports for specific SRv6 forwarding behaviors (RFC 9352 Section 6).
+          $ref: '#/components/schemas/IsisSRv6.NodeMsd'
+          x-field-uid: 2
+        c_flag:
+          description: |-
+            Compression (uSID) flag at the node level. When set, announces that this node supports Micro-SID (uSID) compressed encoding for SRv6 SIDs as described in RFC 9800. This flag is carried in the SRv6 Capabilities Sub-TLV (sub-TLV type 25) Flags field. Reference: RFC 9352 Section 2, RFC 9800.
+          type: boolean
+          default: false
+          x-field-uid: 3
+    IsisSRv6.NodeMsd:
+      description: |-
+        Node-level SRv6 Maximum SID Depth (MSD) capabilities. Each include_* flag controls whether the corresponding MSD type is advertised; the paired value field sets the advertised depth. MSD Type 41 = Max SL, Type 42 = Max End Pop, Type 44 = Max H.Encaps, Type 45 = Max End D. Reference: RFC 8491, RFC 9352 Section 6.
+      type: object
+      properties:
+        include_max_sl:
+          description: |-
+            When true, advertises the Maximum Segments Left (Max SL) MSD sub-TLV (MSD-Type 41). Signals the maximum value of the Segments Left (SL) field in an SRH that this router can process.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        max_sl:
+          description: |-
+            Maximum value of the Segments Left (SL) field in an SRH that this router can process (MSD-Type 41, RFC 9352 Section 6). A value of 0 indicates no SRH processing capability.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        include_max_end_pop_srh:
+          description: |-
+            When true, advertises the Max-End-Pop-SRH MSD sub-TLV (MSD-Type 42). Signals the maximum number of SIDs in the top SRH that this router can pop using PSP or USP End behaviors.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        max_end_pop_srh:
+          description: |-
+            Maximum number of SIDs in the top SRH that this router can pop using PSP or USP End behaviors (MSD-Type 42, RFC 9352 Section 6). A value of 0 means the router cannot apply these behaviors.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 4
+        include_max_h_encaps:
+          description: |-
+            When true, advertises the Max-H-Encaps MSD sub-TLV (MSD-Type 44). Signals the maximum number of SIDs that can be pushed via the H.Encaps headend encapsulation behavior.
+          type: boolean
+          default: false
+          x-field-uid: 5
+        max_h_encaps:
+          description: |-
+            Maximum number of SIDs this router can insert in the SRH using the H.Encaps behavior (MSD-Type 44, RFC 9352 Section 6). A value of 0 with E-flag set indicates IPinIP encapsulation without SRH.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 6
+        include_max_end_d_srh:
+          description: |-
+            When true, advertises the Max-End-D-SRH MSD sub-TLV (MSD-Type 45). Signals the maximum number of SIDs in the SRH when applying decapsulation behaviors (End.DT4, End.DT6, End.DT46, End.DX4, End.DX6).
+          type: boolean
+          default: false
+          x-field-uid: 7
+        max_end_d_srh:
+          description: |-
+            Maximum number of SIDs in the SRH that this router can handle while applying decapsulation behaviors such as End.DT6, End.DT4 or End.DT46 (MSD-Type 45, RFC 9352 Section 6). A value of 0 indicates no decapsulation support.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 8
+        include_max_t_insert:
+          description: |-
+            When true, advertises the Maximum T.Insert MSD sub-TLV (MSD-Type 43). Signals the maximum number of SIDs that can be inserted as a new SRH using the T.Insert headend behavior (RFC 8986 Section 5.3). Used for transit insertion of SRv6 policy. Reference: RFC 8491.
+          type: boolean
+          default: false
+          x-field-uid: 9
+        max_t_insert:
+          description: |-
+            Maximum number of SIDs this router can insert using the T.Insert behavior (MSD-Type 43, RFC 8491). A value of 0 indicates T.Insert is not supported.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 10
+    IsisSRv6.Locator:
+      description: |-
+        IS-IS SRv6 Locator TLV (TLV type 27), as defined in RFC 9352 Section 7.1. Advertises an SRv6 locator prefix that identifies this SRv6-capable router and binds it to a specific IGP algorithm (standard SPF or Flex-Algo per RFC 9350). One Locator TLV is required per topology/algorithm combination. The SRv6 SID space is structured as: Locator prefix | Function | Argument, where the locator prefix is routable and the function identifies the specific endpoint behavior (RFC 8986 Section 3.1).
+      type: object
+      required:
+      - locator
+      - name
+      properties:
+        name:
+          x-field-uid: 1
+          description: |-
+            Globally unique name of an object. It also serves as the primary key for arrays of objects.
+          type: string
+          x-unique: global
+        locator:
+          description: |-
+            The SRv6 locator IPv6 prefix for this TLV. This routable IPv6 prefix identifies the advertising node within the SRv6 domain. All SRv6 SIDs advertised under this locator must be allocated from this prefix.
+          type: string
+          format: ipv6
+          x-field-uid: 2
+        prefix_length:
+          description: |-
+            Number of significant bits in the locator field (1-128). Defines the length of the SRv6 locator prefix. The combined bit budget of the locator, function, and argument fields must not exceed 128 bits (RFC 9352 Section 3.1).
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 128
+          default: 64
+          x-field-uid: 3
+        algorithm:
+          description: |-
+            IGP Algorithm identifier for this locator (RFC 8665). 0 = standard SPF, 1 = Strict SPF. Values 128-255 represent Flexible Algorithms (Flex-Algo) as defined in RFC 9350. The algorithm determines the path computation method used to reach this locator. One Locator TLV is required per algorithm binding.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          default: 0
+          x-field-uid: 4
+        metric:
+          description: |-
+            The metric (cost) associated with this SRv6 locator prefix. Uses the same semantics as IS-IS Extended IP reachability metric (RFC 9352 Section 7.1).
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 0
+          x-field-uid: 5
+        redistribution_type:
+          description: |-
+            Controls the Up/Down redistribution bit for this locator. 'up' = normal advertisement (default); 'down' = the locator has been leaked from Level 2 to Level 1 (RFC 5305). Must be consistent with the d_flag setting.
+          type: string
+          default: up
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          x-field-uid: 6
+          enum:
+          - up
+          - down
+        d_flag:
+          description: |-
+            Down bit (D-flag, bit 0 of the Flags field in the SRv6 Locator TLV). MUST be set when the locator is leaked from Level 2 to Level 1 to prevent routing loops. Locator TLVs with the D-flag set MUST NOT be re-advertised from L1 to L2 (RFC 9352 Section 7.1).
+          type: boolean
+          default: false
+          x-field-uid: 7
+        mt_id:
+          description: |-
+            Multi-Topology Identifier (MT-ID) for this locator advertisement. Specifies which IS-IS topology this locator belongs to. 0 = default topology. Valid range 0-4095 (RFC 5120).
+          type: integer
+          format: uint32
+          maximum: 4095
+          default: 0
+          x-field-uid: 8
+        end_sids:
+          description: |-
+            List of SRv6 End SID Sub-TLVs (sub-TLV type 5) associated with this locator. Each End SID advertises a locally instantiated node-local SRv6 SID, its endpoint behavior (End, End.DT4, End.DT6, End.DT46 and their flavor variants), and optional SID structure information (RFC 9352 Section 7.2).
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSRv6.EndSid'
+          x-field-uid: 9
+        advertise_locator_as_prefix:
+          description: |-
+            When true, the locator prefix is also advertised as an IS-IS IPv6 Reachability prefix (TLV 236/237) in addition to the SRv6 Locator TLV (type 27). This enables non-SRv6-capable routers to route toward the locator as an ordinary IPv6 prefix. Typically suppressed automatically when algorithm is a Flex-Algo value (128-255).
+          type: boolean
+          default: true
+          x-field-uid: 10
+        route_metric:
+          description: |-
+            Metric value used when advertising the locator prefix in the IPv6 Reachability TLV (TLV 236/237). Applies only when advertise_locator_as_prefix is true.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 0
+          x-field-uid: 11
+        route_origin:
+          description: |-
+            Origin type for the locator prefix when advertised in the IPv6 Reachability TLV (TLV 236/237). 'internal' = intra-area prefix (default); 'external' = redistributed from another protocol. Applies only when advertise_locator_as_prefix is true.
+          type: string
+          default: internal
+          x-enum:
+            internal:
+              x-field-uid: 1
+            external:
+              x-field-uid: 2
+          x-field-uid: 12
+          enum:
+          - internal
+          - external
+        prefix_attr_enabled:
+          description: |-
+            When true, includes the Prefix Attribute Flags Sub-TLV (sub-TLV type 4, RFC 7794) in the locator's IPv6 Reachability advertisement. Enables advertising X, R, N, and A flags for this locator prefix. Applies only when advertise_locator_as_prefix is true.
+          type: boolean
+          default: false
+          x-field-uid: 13
+        x_flag:
+          description: |-
+            External prefix flag (bit 0 of Prefix Attribute Flags sub-TLV, RFC 7794). When set, indicates this locator prefix was redistributed from another protocol. Applicable only when prefix_attr_enabled is true.
+          type: boolean
+          default: false
+          x-field-uid: 14
+        r_flag:
+          description: |-
+            Re-advertisement flag (bit 1 of Prefix Attribute Flags sub-TLV, RFC 7794). When set, indicates this locator prefix has been leaked between IS-IS levels. Applicable only when prefix_attr_enabled is true.
+          type: boolean
+          default: false
+          x-field-uid: 15
+        n_flag:
+          description: |-
+            Node flag (bit 2 of Prefix Attribute Flags sub-TLV, RFC 7794). When set, indicates this prefix identifies the advertising router (e.g., a loopback or router-ID prefix). Applicable only when prefix_attr_enabled is true.
+          type: boolean
+          default: false
+          x-field-uid: 16
+        a_flag:
+          description: |-
+            Anycast flag (bit 5 of Prefix Attribute Flags sub-TLV, RFC 7794). When set, indicates this prefix is an anycast prefix shared across multiple routers. Applicable only when prefix_attr_enabled is true.
+          type: boolean
+          default: false
+          x-field-uid: 17
+        include_source_router_id:
+          description: |-
+            Controls whether Source Router ID Sub-TLVs (RFC 9350 Section 5) are included in this locator's IPv6 Reachability prefix advertisement. - none: No Source Router ID sub-TLV included (default). - ipv4: Include IPv4 Source Router ID sub-TLV (type 11). - ipv6: Include IPv6 Source Router ID sub-TLV (type 12). - ipv4_and_ipv6: Include both IPv4 and IPv6 sub-TLVs. Used with Flex-Algo (algorithm 128-255) to identify the originating router for prefix advertisements. Applies only when advertise_locator_as_prefix is true.
+          type: string
+          default: none
+          x-enum:
+            none:
+              x-field-uid: 1
+            ipv4:
+              x-field-uid: 2
+            ipv6:
+              x-field-uid: 3
+            ipv4_and_ipv6:
+              x-field-uid: 4
+          x-field-uid: 18
+          enum:
+          - none
+          - ipv4
+          - ipv6
+          - ipv4_and_ipv6
+        ipv4_source_router_id:
+          description: |-
+            IPv4 Source Router ID value advertised in the IPv4 Source Router ID Sub-TLV (type 11, RFC 9350 Section 5). Identifies the originating router for this Flex-Algo prefix advertisement. Applicable when include_source_router_id is 'ipv4' or 'ipv4_and_ipv6'.
+          type: string
+          format: ipv4
+          default: 0.0.0.0
+          x-field-uid: 19
+        ipv6_source_router_id:
+          description: |-
+            IPv6 Source Router ID value advertised in the IPv6 Source Router ID Sub-TLV (type 12, RFC 9350 Section 5). Identifies the originating router for this Flex-Algo prefix advertisement. Applicable when include_source_router_id is 'ipv6' or 'ipv4_and_ipv6'.
+          type: string
+          format: ipv6
+          default: '::'
+          x-field-uid: 20
+    IsisSRv6.EndSid:
+      description: |-
+        SRv6 End SID Sub-TLV (sub-TLV type 5) carried within the SRv6 Locator TLV (TLV type 27). Advertises a locally instantiated node-local SRv6 SID and its associated endpoint behavior. The SID value must be allocated from within the parent locator's prefix. Valid behaviors for node-local End SIDs are End (with PSP/USP/USD flavor variants) and decapsulation behaviors (End.DT4, End.DT6, End.DT46). Reference: RFC 9352 Section 7.2, RFC 8986.
+      type: object
+      properties:
+        sid:
+          description: |-
+            The 128-bit SRv6 SID value in IPv6 address format. Must be allocated from within the parent locator's prefix space, following the structure: Locator | Function | Argument (RFC 8986 Section 3.1).
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        endpoint_behavior:
+          description: |-
+            The endpoint behavior for this SRv6 End SID, encoded as a 2-octet behavior codepoint (RFC 8986 Section 7.4). Defines how the router processes packets arriving with this SID as the Active Segment. Valid node-level behaviors for End SID Sub-TLV type 5 are End variants (with PSP/USP/USD flavors) and decapsulation behaviors.
+          type: string
+          default: end
+          x-enum:
+            end:
+              description: |-
+                End (RFC 8986 codepoint 1). Basic node SID; decrements Segments Left and performs a FIB lookup in the default VRF using the next SID as the destination address.
+              x-field-uid: 1
+            end_with_psp:
+              description: |-
+                End with Penultimate Segment Pop (PSP) flavor (RFC 8986 codepoint 2). At the penultimate segment the SRH is removed before forwarding to the ultimate endpoint node.
+              x-field-uid: 2
+            end_with_usp:
+              description: |-
+                End with Ultimate Segment Pop (USP) flavor (RFC 8986 codepoint 3). At the ultimate endpoint the SRH is removed before upper-layer protocol processing.
+              x-field-uid: 3
+            end_with_psp_usp:
+              description: |-
+                End with PSP and USP flavors combined (RFC 8986 codepoint 4).
+              x-field-uid: 4
+            end_with_usd:
+              description: |-
+                End with Ultimate Segment Decapsulation (USD) flavor (RFC 8986 codepoint 28). Removes the outer IPv6 header at the ultimate segment and forwards the inner packet.
+              x-field-uid: 5
+            end_with_psp_usd:
+              description: |-
+                End with PSP and USD flavors combined (RFC 8986 codepoint 29).
+              x-field-uid: 6
+            end_with_usp_usd:
+              description: |-
+                End with USP and USD flavors combined (RFC 8986 codepoint 30).
+              x-field-uid: 7
+            end_with_psp_usp_usd:
+              description: |-
+                End with PSP, USP and USD flavors combined (RFC 8986 codepoint 31).
+              x-field-uid: 8
+            end_dt4:
+              description: |-
+                End.DT4 decapsulation and IPv4 table lookup (RFC 8986 codepoint 19). Decapsulates the outer IPv6 header and performs an IPv4 FIB lookup in a specific VRF table T. Used for IPv4 L3VPN services over SRv6.
+              x-field-uid: 9
+            end_dt6:
+              description: |-
+                End.DT6 decapsulation and IPv6 table lookup (RFC 8986 codepoint 18). Decapsulates the outer IPv6 header and performs an IPv6 FIB lookup in a specific VRF table T. Used for IPv6 L3VPN services over SRv6.
+              x-field-uid: 10
+            end_dt46:
+              description: |-
+                End.DT46 decapsulation and dual-stack IP table lookup (RFC 8986 codepoint 20). Decapsulates and performs FIB lookup for both IPv4 and IPv6 inner packets in the appropriate VRF table. Used for dual-stack L3VPN over SRv6.
+              x-field-uid: 11
+          x-field-uid: 2
+          enum:
+          - end
+          - end_with_psp
+          - end_with_usp
+          - end_with_psp_usp
+          - end_with_usd
+          - end_with_psp_usd
+          - end_with_usp_usd
+          - end_with_psp_usp_usd
+          - end_dt4
+          - end_dt6
+          - end_dt46
+        c_flag:
+          description: |-
+            Compression (uSID) flag. When set, indicates that this SID supports Micro-SID (uSID) compressed encoding, enabling multiple node segments to be packed within a single 128-bit SID carrier using the Argument field. Requires the SRv6 SID Structure Sub-Sub-TLV to be included to describe the bit allocation. Reference: draft-filsfils-spring-net-pgm-extension-srv6-usid, RFC 9800.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        sid_structure:
+          description: |-
+            SRv6 SID Structure Sub-Sub-TLV (type 1) describing the internal bit-field decomposition of this SID value. Specifies the Locator Block, Locator Node, Function, and Argument lengths in bits. The sum of all four lengths must not exceed 128. When present, the sub-sub-TLV is included in the advertisement. Typically set when c_flag is true (RFC 9352 Section 9).
+          $ref: '#/components/schemas/IsisSRv6.SidStructure'
+          x-field-uid: 4
+    IsisSRv6.AdjSid:
+      description: |-
+        SRv6 Adjacency SID Sub-TLV for IS-IS interfaces. Point-to-point adjacencies use End.X SID Sub-TLV (sub-TLV type 43); LAN adjacencies use LAN End.X SID Sub-TLV (sub-TLV type 44). The End.X SID binds a 128-bit SRv6 SID to a specific outgoing interface and next-hop, enabling traffic steering across a specific L3 adjacency. Valid behaviors include End.X variants (with PSP/USP/USD flavors) and cross-connect decapsulation behaviors (End.DX4, End.DX6). Reference: RFC 9352 Sections 8.1-8.2, RFC 8986 Section 4.3.
+      type: object
+      properties:
+        sid:
+          description: |-
+            The 128-bit SRv6 SID value in IPv6 address format for this adjacency. Must be allocated from the advertising node's locator prefix space.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        endpoint_behavior:
+          description: |-
+            The endpoint behavior for this adjacency SID, encoded as a 2-octet behavior codepoint (RFC 8986 Section 7.4). Valid adjacency-level behaviors for End.X SID Sub-TLV types 43/44 are End.X variants (with PSP/USP/USD flavors) and per-CE cross-connect decapsulation behaviors (End.DX4, End.DX6).
+          type: string
+          default: end_x
+          x-enum:
+            end_x:
+              description: |-
+                End.X adjacency L3 cross-connect (RFC 8986 codepoint 5). Decrements Segments Left and forwards the packet over the specific adjacency set J to the next-hop node.
+              x-field-uid: 1
+            end_x_with_psp:
+              description: |-
+                End.X with Penultimate Segment Pop (PSP) flavor (RFC 8986 codepoint 6). Removes the SRH at the penultimate node before forwarding over adjacency J.
+              x-field-uid: 2
+            end_x_with_usp:
+              description: |-
+                End.X with Ultimate Segment Pop (USP) flavor (RFC 8986 codepoint 7). Removes the SRH at the ultimate adjacency endpoint before upper-layer processing.
+              x-field-uid: 3
+            end_x_with_psp_usp:
+              description: |-
+                End.X with PSP and USP flavors combined (RFC 8986 codepoint 8).
+              x-field-uid: 4
+            end_x_with_usd:
+              description: |-
+                End.X with Ultimate Segment Decapsulation (USD) flavor (RFC 8986 codepoint 32). Removes outer IPv6 header at the ultimate adjacency endpoint.
+              x-field-uid: 5
+            end_x_with_psp_usd:
+              description: |-
+                End.X with PSP and USD flavors combined (RFC 8986 codepoint 33).
+              x-field-uid: 6
+            end_x_with_usp_usd:
+              description: |-
+                End.X with USP and USD flavors combined (RFC 8986 codepoint 34).
+              x-field-uid: 7
+            end_x_with_psp_usp_usd:
+              description: |-
+                End.X with PSP, USP and USD flavors combined (RFC 8986 codepoint 35).
+              x-field-uid: 8
+            end_dx4:
+              description: |-
+                End.DX4 per-CE IPv4 cross-connect (RFC 8986 codepoint 17). Decapsulates the outer IPv6 header and forwards the inner IPv4 packet to a CE peer over adjacency J. Used for IPv4 VPWS and per-CE L3VPN services over SRv6.
+              x-field-uid: 9
+            end_dx6:
+              description: |-
+                End.DX6 per-CE IPv6 cross-connect (RFC 8986 codepoint 16). Decapsulates the outer IPv6 header and forwards the inner IPv6 packet to a CE peer over adjacency J. Used for IPv6 VPWS and per-CE L3VPN services over SRv6.
+              x-field-uid: 10
+          x-field-uid: 2
+          enum:
+          - end_x
+          - end_x_with_psp
+          - end_x_with_usp
+          - end_x_with_psp_usp
+          - end_x_with_usd
+          - end_x_with_psp_usd
+          - end_x_with_usp_usd
+          - end_x_with_psp_usp_usd
+          - end_dx4
+          - end_dx6
+        b_flag:
+          description: |-
+            Backup flag (B-flag, bit 0). When set, the End.X SID is eligible for IP Fast-ReRoute (IP-FRR) protection, indicating a backup adjacency that can protect traffic when the primary adjacency fails (RFC 9352 Section 8.1).
+          type: boolean
+          default: false
+          x-field-uid: 3
+        s_flag:
+          description: |-
+            Set flag (S-flag, bit 1). When set, the End.X SID refers to a set of adjacencies (e.g., parallel links, ECMP group). The same SID value may be assigned to multiple adjacencies forming the set (RFC 9352 Section 8.1).
+          type: boolean
+          default: false
+          x-field-uid: 4
+        p_flag:
+          description: |-
+            Persistent flag (P-flag, bit 2). When set, the End.X SID value is persistently allocated and remains consistent across router restarts and interface flap events (RFC 9352 Section 8.1).
+          type: boolean
+          default: false
+          x-field-uid: 5
+        weight:
+          description: |-
+            Weight for load balancing across adjacencies sharing the same End.X SID (applicable when S-flag is set). Traffic is distributed proportionally across the adjacency set according to the weight values (RFC 9352 Section 8.1).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          default: 0
+          x-field-uid: 6
+        algorithm:
+          description: |-
+            IGP algorithm associated with this adjacency SID (RFC 8665). 0 = standard SPF, 1 = Strict SPF, 128-255 = Flex-Algo (RFC 9350). Binds the adjacency SID to the corresponding topology or path computation algorithm.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          default: 0
+          x-field-uid: 7
+        c_flag:
+          description: |-
+            Compression (uSID) flag. When set, indicates this adjacency SID supports Micro-SID (uSID) compressed encoding, allowing multiple adjacency micro-segments to be stacked within a single 128-bit SID carrier using the Argument field.
+          type: boolean
+          default: false
+          x-field-uid: 8
+        sid_structure:
+          description: |-
+            SRv6 SID Structure Sub-Sub-TLV (type 1) describing the internal bit-field decomposition of this adjacency SID. Specifies the Locator Block, Locator Node, Function, and Argument lengths in bits. When present, the sub-sub-TLV is included in the advertisement. Typically set when c_flag is true (RFC 9352 Section 9).
+          $ref: '#/components/schemas/IsisSRv6.SidStructure'
+          x-field-uid: 9
+    IsisSRv6.SidStructure:
+      description: |-
+        SRv6 SID Structure Sub-Sub-TLV (type 1), carried within SRv6 SID Sub-TLVs (End SID type 5, End.X SID type 43/44). Describes the internal bit-field decomposition of the SRv6 SID value so that receiving routers can interpret each field independently. The four length fields (lb_length + ln_length + function_length + argument_length) MUST NOT exceed 128 bits. Required when advertising Micro-SID (uSID) SIDs to describe the compressed encoding. Example for common uSID F3216 format:
+          lb_length=32, ln_length=16, function_length=16, argument_length=0
+        Reference: RFC 9352 Section 9, RFC 9800.
+      type: object
+      properties:
+        locator_block_length:
+          description: |-
+            Number of bits in the Locator Block (LB) field of the SID. The Locator Block is the common IPv6 prefix shared across all SIDs within the same SRv6 domain block (e.g., 32 bits in the uSID F3216 format). Minimum value 1.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 128
+          default: 32
+          x-field-uid: 1
+        locator_node_length:
+          description: |-
+            Number of bits in the Locator Node (LN) field of the SID. Identifies the specific node within the Locator Block (e.g., 16 bits in the uSID F3216 format, providing up to 65534 addressable nodes per domain block).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 128
+          default: 16
+          x-field-uid: 2
+        function_length:
+          description: |-
+            Number of bits in the Function field of the SID. Identifies the specific endpoint behavior instantiated on this node (e.g., 16 bits in the uSID F3216 format, supporting up to 65534 distinct functions per node).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 128
+          default: 16
+          x-field-uid: 3
+        argument_length:
+          description: |-
+            Number of bits in the Argument field of the SID. Carries additional per-behavior information such as VPN table identifiers or compressed next-SID encodings for Micro-SID stacking. Set to 0 for standard SIDs that carry no argument. When non-zero in a uSID context, enables packing multiple micro-segment identifiers within a single 128-bit SID carrier (RFC 9800).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 128
+          default: 0
+          x-field-uid: 4
+    IsisSRv6.LinkMsd:
+      description: |-
+        Link-level SRv6 Maximum SID Depth (MSD) capabilities advertised per IS-IS interface. Signals the SRv6 SRH processing capacity specific to this link, which may differ from the node-level MSD values. Advertised as MSD sub-TLVs within the neighbor TLVs per RFC 8491. Reference: RFC 8491, RFC 9352 Section 6.
+      type: object
+      properties:
+        include_max_sl:
+          description: |-
+            When true, advertises the Maximum Segments Left (Max SL) MSD (MSD-Type 41) at the link level. Signals the maximum SL value in an SRH that can be processed on this interface.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        max_sl:
+          description: |-
+            Maximum value of the Segments Left (SL) field in an SRH that this interface can process (MSD-Type 41). A value of 0 indicates no SRH processing support on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        include_max_end_pop_srh:
+          description: |-
+            When true, advertises the Max-End-Pop-SRH MSD (MSD-Type 42) at the link level.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        max_end_pop_srh:
+          description: |-
+            Maximum number of SIDs in the top SRH for PSP or USP End behaviors on this interface (MSD-Type 42). A value of 0 indicates these behaviors are not supported on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 4
+        include_max_h_encaps:
+          description: |-
+            When true, advertises the Max-H-Encaps MSD (MSD-Type 44) at the link level.
+          type: boolean
+          default: false
+          x-field-uid: 5
+        max_h_encaps:
+          description: |-
+            Maximum number of SIDs for H.Encaps behavior on this interface (MSD-Type 44). A value of 0 indicates H.Encaps is not supported on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 6
+        include_max_end_d_srh:
+          description: |-
+            When true, advertises the Max-End-D-SRH MSD (MSD-Type 45) at the link level.
+          type: boolean
+          default: false
+          x-field-uid: 7
+        max_end_d_srh:
+          description: |-
+            Maximum number of SIDs in the SRH for decapsulation behaviors (End.DT4/DT6/DT46/DX4/DX6) on this interface (MSD-Type 45). A value of 0 indicates decapsulation behaviors are not supported on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 8
+        include_max_t_insert:
+          description: |-
+            When true, advertises the Maximum T.Insert MSD (MSD-Type 43) at the link level. Signals the maximum number of SIDs that can be inserted via the T.Insert headend behavior on this specific interface. Reference: RFC 8491.
+          type: boolean
+          default: false
+          x-field-uid: 9
+        max_t_insert:
+          description: |-
+            Maximum number of SIDs insertable via T.Insert behavior on this interface (MSD-Type 43, RFC 8491). A value of 0 indicates T.Insert is not supported on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 10
     Isis.Basic:
       description: |-
         This contains ISIS router basic properties.
@@ -3738,27 +4339,31 @@ components:
       required:
       - name
     Isis.SegmentRouting:
-      description: "Segment Routing (SR) allows for a flexible definition of end-to-end\
-        \ paths within IGP topologies by encoding paths as sequences of topological\
-        \ sub-paths, \ncalled \"segments\". These segments are advertised by the link-state\
-        \ routing protocols (IS-IS and OSPF). \nPrefix segments represent an ECMP-aware\
-        \ shortest path to a prefix (or a node), as per the state of the IGP topology.\
-        \ \nAdjacency segments represent a hop over a specific adjacency between two\
-        \ nodes in the IGP. \nA prefix segment is typically a multi-hop path while\
-        \ an adjacency segment, in most of the cases, is a one-hop path. \nThese segments\
-        \ act as topological sub-paths that can be combined together to form the required\
-        \ path.\nReference: https://datatracker.ietf.org/doc/html/rfc8667.:w\nAn implementation\
-        \ may advertise Router Capability with default values if a user does not even\
-        \ set the properties \nof Router Capability and Segment Routing Capability.\
-        \  "
+      description: |-
+        Segment Routing (SR) allows for a flexible definition of end-to-end paths within IGP topologies by encoding paths as sequences of topological sub-paths,
+        called "segments". These segments are advertised by the link-state routing protocols (IS-IS and OSPF).
+        Prefix segments represent an ECMP-aware shortest path to a prefix (or a node), as per the state of the IGP topology.
+        Adjacency segments represent a hop over a specific adjacency between two nodes in the IGP.
+        A prefix segment is typically a multi-hop path while an adjacency segment, in most of the cases, is a one-hop path.
+        These segments act as topological sub-paths that can be combined together to form the required path.
+        Reference: https://datatracker.ietf.org/doc/html/rfc8667.
+        An implementation may advertise Router Capability with default values if a user does not even set the properties
+        of Router Capability and Segment Routing Capability.
       type: object
       properties:
         router_capability:
-          description: "Optional IS-IS TLV named CAPABILITY, formed of multiple sub-TLVs,\
-            \ which allows a router to announce its\ncapabilities within an IS-IS\
-            \ level or the entire routing domain.        "
+          description: |-
+            Optional IS-IS TLV named CAPABILITY, formed of multiple sub-TLVs, which allows a router to announce its
+            capabilities within an IS-IS level or the entire routing domain.
           $ref: '#/components/schemas/Isis.RouterCapability'
           x-field-uid: 1
+        srv6_locators:
+          description: |-
+            List of SRv6 Locator TLVs (TLV type 27) to be advertised by this IS-IS router. Each locator binds an IPv6 prefix to an IGP algorithm (standard SPF or Flex-Algo per RFC 9350) and carries End SID Sub-TLVs for locally instantiated node-level SRv6 SIDs. One Locator TLV is required per topology/algorithm combination. Reference: RFC 9352 Section 7.1.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSRv6.Locator'
+          x-field-uid: 2
     Isis.RouterCapability:
       description: |-
         Container for the configuration of IS-IS Router CAPABILITY TLV.
@@ -3867,6 +4472,11 @@ components:
           items:
             $ref: '#/components/schemas/IsisSR.Srlb'
           x-field-uid: 7
+        srv6_capability:
+          description: |-
+            SRv6 Capabilities Sub-TLV (sub-TLV type 25) carried within this Router CAPABILITY TLV. Announces that this router is an SRv6 Segment Endpoint Node and advertises optional OAM (O-flag) support and node-level SRv6 Maximum SID Depth (MSD) values. Reference: RFC 9352 Section 2, RFC 8491.
+          $ref: '#/components/schemas/IsisSRv6.NodeCapability'
+          x-field-uid: 8
     Isis.SRCapability:
       description: "Container for the configuration of IS-IS SR-CAPABILITY TLV that\
         \ Segment Routing requires \neach router to advertise its SR data plane capability\
@@ -26473,6 +27083,17 @@ components:
           items:
             $ref: '#/components/schemas/IsisLsp.Capability'
           x-field-uid: 8
+        srv6_locator_tlvs:
+          description: |-
+            Array of SRv6 Locator TLVs (type 27) present in this LSP.
+            Each entry represents one SRv6 locator prefix advertisement,
+            binding a node-local IPv6 prefix to an IGP algorithm and carrying
+            node-local End SID Sub-TLVs for SRv6 endpoint behaviors.
+            Reference: RFC 9352 Section 7.1.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.SRv6LocatorTlv'
+          x-field-uid: 9
     IsisLsp.Hostname:
       description: |-
         It contains Hostname for the TLV 137.
@@ -26570,11 +27191,23 @@ components:
           x-field-uid: 1
         adjacency_sids:
           description: |-
-            List of segment routing adjacency SIDs.
+            List of SR-MPLS Adjacency SID sub-TLVs (sub-TLV types 31/32,
+            RFC 8667) learned from this neighbor.
           type: array
           items:
             $ref: '#/components/schemas/IsisLsp.AdjacencySid'
           x-field-uid: 2
+        srv6_adj_sids:
+          description: |-
+            List of SRv6 Adjacency SID Sub-TLVs (End.X SID sub-TLV type 43
+            for P2P or LAN End.X SID sub-TLV type 44 for broadcast) learned
+            from this neighbor. Each entry carries a 128-bit SRv6 SID bound
+            to a specific outgoing adjacency.
+            Reference: RFC 9352 Sections 8.1-8.2.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.SRv6AdjSid'
+          x-field-uid: 3
     IsisLsp.Ipv4InternalReachabilityTlv:
       description: |-
         This container defines list of IPv4 internal reachability information in one IPv4 internal reachability TLV.
@@ -26919,6 +27552,15 @@ components:
           items:
             $ref: '#/components/schemas/IsisLsp.Srlb'
           x-field-uid: 6
+        srv6_capability:
+          description: |-
+            SRv6 Capabilities Sub-TLV (sub-TLV type 25) present within this
+            Router CAPABILITY TLV. Announces that the originating router is
+            an SRv6 Segment Endpoint Node, indicates OAM support (O-flag),
+            and carries node-level SRv6 Maximum SID Depth (MSD) values.
+            Reference: RFC 9352 Section 2, RFC 8491.
+          $ref: '#/components/schemas/IsisLsp.SRv6Capability'
+          x-field-uid: 7
     IsisLsp.SRCapability:
       description: |-
         Container of IS-IS SR-CAPABILITY Sub-Tlv.
@@ -27103,6 +27745,396 @@ components:
             remains consistent across router restart and/or interface flap.
           type: boolean
           x-field-uid: 6
+    IsisLsp.SRv6Capability:
+      description: |-
+        SRv6 Capabilities Sub-TLV (sub-TLV type 25) learned from the IS-IS Router CAPABILITY TLV (TLV 242) in a received LSP. Indicates that the originating router is an SRv6 Segment Endpoint Node and carries optional OAM support (O-flag) and node-level SRv6 MSD values. Reference: RFC 9352 Section 2, RFC 8491.
+      type: object
+      properties:
+        o_flag:
+          description: |-
+            OAM flag (bit 1). When set, the originating router supports the use of the O-bit in the Segment Routing Header (SRH) for OAM operations as defined in RFC 9259.
+          type: boolean
+          x-field-uid: 1
+        node_msds:
+          description: |-
+            Node-level SRv6 Maximum SID Depth (MSD) values learned from MSD sub-TLVs within the Router Capability TLV.
+          $ref: '#/components/schemas/IsisLsp.SRv6NodeMsd'
+          x-field-uid: 2
+        c_flag:
+          description: |-
+            Compression (uSID) flag. When set, the originating router supports Micro-SID (uSID) compressed encoding for SRv6 SIDs. Learned from the Flags field of the SRv6 Capabilities Sub-TLV (sub-TLV type 25). Reference: RFC 9352 Section 2, RFC 9800.
+          type: boolean
+          x-field-uid: 3
+    IsisLsp.SRv6NodeMsd:
+      description: |-
+        Node-level SRv6 Maximum SID Depth (MSD) values learned from a received LSP. Each field represents the advertised depth limit for a specific SRv6 forwarding behavior. MSD Type 41 = Max SL, Type 42 = Max End Pop, Type 44 = Max H.Encaps, Type 45 = Max End D. Reference: RFC 8491, RFC 9352 Section 6.
+      type: object
+      properties:
+        max_sl:
+          description: |-
+            Maximum value of the Segments Left (SL) field in an SRH that the originating router can process (MSD-Type 41). Absent if not advertised; value of 0 means no SRH processing support.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 1
+        max_end_pop_srh:
+          description: |-
+            Maximum number of SIDs in the top SRH that the originating router can pop using PSP or USP End behaviors (MSD-Type 42). Absent if not advertised.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 2
+        max_h_encaps:
+          description: |-
+            Maximum number of SIDs the originating router can push via H.Encaps behavior (MSD-Type 44). Absent if not advertised.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 3
+        max_end_d_srh:
+          description: |-
+            Maximum number of SIDs in the SRH the originating router can handle for decapsulation behaviors End.DT4/DT6/DT46/DX4/DX6 (MSD-Type 45). Absent if not advertised.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 4
+        max_t_insert:
+          description: |-
+            Maximum number of SIDs the originating router can insert using the T.Insert headend behavior (MSD-Type 43, RFC 8491). Absent if not advertised by the originating router.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 5
+    IsisLsp.SRv6LocatorTlv:
+      description: |-
+        SRv6 Locator TLV (TLV type 27) learned from a received IS-IS LSP. Carries an SRv6 locator prefix that identifies the originating node, the associated IGP algorithm, metric, and a list of locally instantiated End SID Sub-TLVs. Reference: RFC 9352 Section 7.1.
+      type: object
+      properties:
+        locator:
+          description: |-
+            The SRv6 locator IPv6 prefix advertised in this TLV.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        prefix_length:
+          description: |-
+            Number of significant bits in the locator field (1-128).
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 128
+          x-field-uid: 2
+        algorithm:
+          description: |-
+            IGP algorithm identifier for this locator. 0 = SPF, 1 = Strict SPF, 128-255 = Flex-Algo (RFC 9350, RFC 8665).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          x-field-uid: 3
+        metric:
+          description: |-
+            The metric (cost) associated with this SRv6 locator prefix.
+          type: integer
+          format: uint32
+          x-field-uid: 4
+        redistribution_type:
+          description: |-
+            Up/Down redistribution bit for this locator advertisement. 'up' = normal advertisement; 'down' = leaked from L2 to L1.
+          type: string
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          x-field-uid: 5
+          enum:
+          - up
+          - down
+        d_flag:
+          description: |-
+            Down bit (D-flag). Set when this locator was leaked from Level 2 to Level 1 (RFC 9352 Section 7.1).
+          type: boolean
+          x-field-uid: 6
+        mt_id:
+          description: |-
+            Multi-Topology ID for this locator. 0 = default topology.
+          type: integer
+          format: uint32
+          maximum: 4095
+          x-field-uid: 7
+        end_sids:
+          description: |-
+            List of SRv6 End SID Sub-TLVs (sub-TLV type 5) carried within this Locator TLV. Each entry describes a node-local SRv6 SID and its endpoint behavior. Reference: RFC 9352 Section 7.2.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.SRv6EndSid'
+          x-field-uid: 8
+        x_flag:
+          description: |-
+            External prefix flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4). Present in the locator's IPv6 Reachability advertisement when advertised by the originating router. Set if the locator prefix was redistributed from another protocol.
+          type: boolean
+          x-field-uid: 9
+        r_flag:
+          description: |-
+            Re-advertisement flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4). Set if present and indicates the locator prefix was leaked between IS-IS levels.
+          type: boolean
+          x-field-uid: 10
+        n_flag:
+          description: |-
+            Node flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4). Set if present and indicates this locator prefix identifies the advertising router.
+          type: boolean
+          x-field-uid: 11
+        a_flag:
+          description: |-
+            Anycast flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4). Set if present and indicates this locator is an anycast prefix shared across multiple routers.
+          type: boolean
+          x-field-uid: 12
+        ipv4_source_router_id:
+          description: |-
+            IPv4 Source Router ID learned from the IPv4 Source Router ID Sub-TLV (type 11, RFC 9350 Section 5) in the locator's IPv6 Reachability prefix advertisement. Present only if advertised by the originating router.
+          type: string
+          format: ipv4
+          x-field-uid: 13
+        ipv6_source_router_id:
+          description: |-
+            IPv6 Source Router ID learned from the IPv6 Source Router ID Sub-TLV (type 12, RFC 9350 Section 5) in the locator's IPv6 Reachability prefix advertisement. Present only if advertised by the originating router.
+          type: string
+          format: ipv6
+          x-field-uid: 14
+    IsisLsp.SRv6EndSid:
+      description: |-
+        SRv6 End SID Sub-TLV (sub-TLV type 5) learned from an SRv6 Locator TLV (type 27) in a received LSP. Describes a node-local SRv6 SID, its endpoint behavior, and optional SID structure information. Reference: RFC 9352 Section 7.2, RFC 8986.
+      type: object
+      properties:
+        sid:
+          description: |-
+            The 128-bit SRv6 SID value in IPv6 address format.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        endpoint_behavior:
+          description: |-
+            Endpoint behavior codepoint for this End SID (RFC 8986 Section 7.4). Indicates how the originating router processes packets arriving with this SID as the Active Segment.
+          type: string
+          x-enum:
+            end:
+              description: |-
+                End (RFC 8986 codepoint 1).
+              x-field-uid: 1
+            end_with_psp:
+              description: |-
+                End with PSP flavor (RFC 8986 codepoint 2).
+              x-field-uid: 2
+            end_with_usp:
+              description: |-
+                End with USP flavor (RFC 8986 codepoint 3).
+              x-field-uid: 3
+            end_with_psp_usp:
+              description: |-
+                End with PSP+USP flavors (RFC 8986 codepoint 4).
+              x-field-uid: 4
+            end_with_usd:
+              description: |-
+                End with USD flavor (RFC 8986 codepoint 28).
+              x-field-uid: 5
+            end_with_psp_usd:
+              description: |-
+                End with PSP+USD flavors (RFC 8986 codepoint 29).
+              x-field-uid: 6
+            end_with_usp_usd:
+              description: |-
+                End with USP+USD flavors (RFC 8986 codepoint 30).
+              x-field-uid: 7
+            end_with_psp_usp_usd:
+              description: |-
+                End with PSP+USP+USD flavors (RFC 8986 codepoint 31).
+              x-field-uid: 8
+            end_dt4:
+              description: |-
+                End.DT4 IPv4 table lookup (RFC 8986 codepoint 19).
+              x-field-uid: 9
+            end_dt6:
+              description: |-
+                End.DT6 IPv6 table lookup (RFC 8986 codepoint 18).
+              x-field-uid: 10
+            end_dt46:
+              description: |-
+                End.DT46 dual-stack table lookup (RFC 8986 codepoint 20).
+              x-field-uid: 11
+          x-field-uid: 2
+          enum:
+          - end
+          - end_with_psp
+          - end_with_usp
+          - end_with_psp_usp
+          - end_with_usd
+          - end_with_psp_usd
+          - end_with_usp_usd
+          - end_with_psp_usp_usd
+          - end_dt4
+          - end_dt6
+          - end_dt46
+        sid_structure:
+          description: |-
+            SRv6 SID Structure Sub-Sub-TLV (type 1) if present, describing the bit-field decomposition of this SID value. Specifies Locator Block, Locator Node, Function, and Argument lengths in bits. Reference: RFC 9352 Section 9.
+          $ref: '#/components/schemas/IsisLsp.SRv6SidStructure'
+          x-field-uid: 3
+    IsisLsp.SRv6AdjSid:
+      description: |-
+        SRv6 Adjacency SID Sub-TLV learned from the Extended IS Reachability TLV (type 22) or MT-ISN TLV (type 222) in a received LSP. Point-to-point End.X SID Sub-TLV has sub-TLV type 43; LAN End.X SID Sub-TLV has sub-TLV type 44 and includes the neighbor System ID. Reference: RFC 9352 Sections 8.1-8.2, RFC 8986.
+      type: object
+      properties:
+        type:
+          description: |-
+            The sub-TLV type that carried this adjacency SID. 'end_x_sid' = point-to-point (sub-TLV type 43); 'lan_end_x_sid' = LAN adjacency (sub-TLV type 44, includes neighbor System ID in neighbor_id field).
+          type: string
+          x-enum:
+            end_x_sid:
+              x-field-uid: 1
+            lan_end_x_sid:
+              x-field-uid: 2
+          x-field-uid: 1
+          enum:
+          - end_x_sid
+          - lan_end_x_sid
+        neighbor_id:
+          description: |-
+            IS-IS System ID of the LAN neighbor from which this End.X SID was received. Present only when type is 'lan_end_x_sid' (sub-TLV type 44, RFC 9352 Section 8.2).
+          type: string
+          format: hex
+          x-field-uid: 2
+        sid:
+          description: |-
+            The 128-bit SRv6 End.X SID value in IPv6 address format.
+          type: string
+          format: ipv6
+          x-field-uid: 3
+        endpoint_behavior:
+          description: |-
+            Endpoint behavior codepoint for this adjacency SID (RFC 8986 Section 7.4).
+          type: string
+          x-enum:
+            end_x:
+              description: |-
+                End.X adjacency cross-connect (RFC 8986 codepoint 5).
+              x-field-uid: 1
+            end_x_with_psp:
+              description: |-
+                End.X with PSP flavor (RFC 8986 codepoint 6).
+              x-field-uid: 2
+            end_x_with_usp:
+              description: |-
+                End.X with USP flavor (RFC 8986 codepoint 7).
+              x-field-uid: 3
+            end_x_with_psp_usp:
+              description: |-
+                End.X with PSP+USP flavors (RFC 8986 codepoint 8).
+              x-field-uid: 4
+            end_x_with_usd:
+              description: |-
+                End.X with USD flavor (RFC 8986 codepoint 32).
+              x-field-uid: 5
+            end_x_with_psp_usd:
+              description: |-
+                End.X with PSP+USD flavors (RFC 8986 codepoint 33).
+              x-field-uid: 6
+            end_x_with_usp_usd:
+              description: |-
+                End.X with USP+USD flavors (RFC 8986 codepoint 34).
+              x-field-uid: 7
+            end_x_with_psp_usp_usd:
+              description: |-
+                End.X with PSP+USP+USD flavors (RFC 8986 codepoint 35).
+              x-field-uid: 8
+            end_dx4:
+              description: |-
+                End.DX4 IPv4 cross-connect (RFC 8986 codepoint 17).
+              x-field-uid: 9
+            end_dx6:
+              description: |-
+                End.DX6 IPv6 cross-connect (RFC 8986 codepoint 16).
+              x-field-uid: 10
+          x-field-uid: 4
+          enum:
+          - end_x
+          - end_x_with_psp
+          - end_x_with_usp
+          - end_x_with_psp_usp
+          - end_x_with_usd
+          - end_x_with_psp_usd
+          - end_x_with_usp_usd
+          - end_x_with_psp_usp_usd
+          - end_dx4
+          - end_dx6
+        b_flag:
+          description: |-
+            Backup flag. When set, this End.X SID is eligible for IP-FRR protection (RFC 9352 Section 8.1).
+          type: boolean
+          x-field-uid: 5
+        s_flag:
+          description: |-
+            Set flag. When set, this End.X SID refers to a set of adjacencies (RFC 9352 Section 8.1).
+          type: boolean
+          x-field-uid: 6
+        p_flag:
+          description: |-
+            Persistent flag. When set, the SID value is stable across router restarts and interface flaps (RFC 9352 Section 8.1).
+          type: boolean
+          x-field-uid: 7
+        weight:
+          description: |-
+            Weight for load balancing across the adjacency set when S-flag is set (RFC 9352 Section 8.1).
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 8
+        algorithm:
+          description: |-
+            IGP algorithm bound to this adjacency SID. 0 = SPF, 1 = Strict SPF, 128-255 = Flex-Algo (RFC 9350, RFC 8665).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          x-field-uid: 9
+        sid_structure:
+          description: |-
+            SRv6 SID Structure Sub-Sub-TLV (type 1) if present, describing the internal bit-field decomposition of this adjacency SID. Reference: RFC 9352 Section 9.
+          $ref: '#/components/schemas/IsisLsp.SRv6SidStructure'
+          x-field-uid: 10
+    IsisLsp.SRv6SidStructure:
+      description: |-
+        SRv6 SID Structure Sub-Sub-TLV (type 1) learned from a received LSP. Describes the internal bit-field decomposition of an SRv6 SID, enabling routers to independently interpret each component of the 128-bit SID value. The sum of all four length fields must not exceed 128 bits. Reference: RFC 9352 Section 9.
+      type: object
+      properties:
+        locator_block_length:
+          description: |-
+            Number of bits in the Locator Block (LB) field of the SID. The common IPv6 prefix shared by all SIDs in the same SRv6 domain block (e.g., 32 bits in the uSID F3216 format).
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 1
+        locator_node_length:
+          description: |-
+            Number of bits in the Locator Node (LN) field of the SID. Identifies the specific node within the Locator Block (e.g., 16 bits in the uSID F3216 format).
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 2
+        function_length:
+          description: |-
+            Number of bits in the Function field of the SID. Identifies the specific endpoint behavior on this node (e.g., 16 bits in the uSID F3216 format).
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 3
+        argument_length:
+          description: |-
+            Number of bits in the Argument field of the SID. Used for VPN table IDs or compressed next-SID encodings in Micro-SID stacking. 0 for standard SIDs without argument (RFC 9800).
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 4
     LldpNeighbors.State.Request:
       description: |-
         The request to retrieve LLDP neighbor information for a given instance.

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -2352,37 +2352,6 @@ message IsisSRv6Locator {
   // when prefix_attr_enabled is true.
   // default = False
   optional bool a_flag = 17;
-
-  message IncludeSourceRouterId {
-    enum Enum {
-      unspecified = 0;
-      none = 1;
-      ipv4 = 2;
-      ipv6 = 3;
-      ipv4_and_ipv6 = 4;
-    }
-  }
-  // Controls whether Source Router ID Sub-TLVs (RFC 9350 Section 5) are included in this
-  // locator's IPv6 Reachability prefix advertisement. - none: No Source Router ID sub-TLV
-  // included (default). - ipv4: Include IPv4 Source Router ID sub-TLV (type 11). - ipv6:
-  // Include IPv6 Source Router ID sub-TLV (type 12). - ipv4_and_ipv6: Include both IPv4
-  // and IPv6 sub-TLVs. Used with Flex-Algo (algorithm 128-255) to identify the originating
-  // router for prefix advertisements. Applies only when advertise_locator_as_prefix is
-  // true.
-  // default = IncludeSourceRouterId.Enum.none
-  optional IncludeSourceRouterId.Enum include_source_router_id = 18;
-
-  // IPv4 Source Router ID value advertised in the IPv4 Source Router ID Sub-TLV (type
-  // 11, RFC 9350 Section 5). Identifies the originating router for this Flex-Algo prefix
-  // advertisement. Applicable when include_source_router_id is 'ipv4' or 'ipv4_and_ipv6'.
-  // default = 0.0.0.0
-  optional string ipv4_source_router_id = 19;
-
-  // IPv6 Source Router ID value advertised in the IPv6 Source Router ID Sub-TLV (type
-  // 12, RFC 9350 Section 5). Identifies the originating router for this Flex-Algo prefix
-  // advertisement. Applicable when include_source_router_id is 'ipv6' or 'ipv4_and_ipv6'.
-  // default = ::
-  optional string ipv6_source_router_id = 20;
 }
 
 // SRv6 End SID Sub-TLV (sub-TLV type 5) carried within the SRv6 Locator TLV (TLV type
@@ -20234,16 +20203,6 @@ message IsisLspSRv6LocatorTlv {
   // Set if present and indicates this locator is an anycast prefix shared across multiple
   // routers.
   optional bool a_flag = 12;
-
-  // IPv4 Source Router ID learned from the IPv4 Source Router ID Sub-TLV (type 11, RFC
-  // 9350 Section 5) in the locator's IPv6 Reachability prefix advertisement. Present
-  // only if advertised by the originating router.
-  optional string ipv4_source_router_id = 13;
-
-  // IPv6 Source Router ID learned from the IPv6 Source Router ID Sub-TLV (type 12, RFC
-  // 9350 Section 5) in the locator's IPv6 Reachability prefix advertisement. Present
-  // only if advertised by the originating router.
-  optional string ipv6_source_router_id = 14;
 }
 
 // SRv6 End SID Sub-TLV (sub-TLV type 5) learned from an SRv6 Locator TLV (type 27)

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -1849,8 +1849,22 @@ message IsisInterface {
   // required = true
   optional string name = 13;
 
-  // List of Adjacency Segment Identifier (Adj-SID) sub-TLVs.
+  // List of SR-MPLS Adjacency Segment Identifier (Adj-SID) sub-TLVs for this interface
+  // (RFC 8667).
   repeated IsisInterfaceAdjacencySid adjacency_sids = 14;
+
+  // List of SRv6 Adjacency SID Sub-TLVs (End.X SID) for this interface. Point-to-point
+  // interfaces advertise End.X SID Sub-TLV (sub-TLV type 43); broadcast interfaces advertise
+  // LAN End.X SID Sub-TLV (sub-TLV type 44). Each entry binds a 128-bit SRv6 SID to this
+  // specific outgoing adjacency and advertises the associated endpoint behavior. Reference:
+  // RFC 9352 Sections 8.1-8.2.
+  repeated IsisSRv6AdjSid srv6_adj_sids = 15;
+
+  // Link-level SRv6 Maximum SID Depth (MSD) capabilities for this interface. Advertised
+  // as MSD sub-TLVs within the neighbor TLVs (Extended IS Reachability TLV 22 / MT-ISN
+  // TLV 222) to signal the SRv6 SRH processing capacity of this specific link. Reference:
+  // RFC 8491, RFC 9352 Section 6.
+  IsisSRv6LinkMsd srv6_link_msd = 16;
 }
 
 // Configuration for the properties of Level 1 Hello.
@@ -2120,6 +2134,479 @@ message IsisInterfaceAdjacencySid {
   // 
   // default = 0
   optional uint32 weight = 9;
+}
+
+// SRv6 Capabilities Sub-TLV (sub-TLV type 25) carried within the IS-IS Router CAPABILITY
+// TLV (TLV 242, RFC 7981). Announces that this IS-IS router is an SRv6 Segment Endpoint
+// Node and optionally supports the O-bit for OAM operations. Node-level SRv6 Maximum
+// SID Depth (MSD) values are also advertised here per RFC 8491. Reference: RFC 9352
+// Section 2.
+message IsisSRv6NodeCapability {
+
+  // OAM flag (bit 1 of the Flags field in the SRv6 Capabilities Sub-TLV). When set, indicates
+  // that this router supports the use of the O-bit in the Segment Routing Header (SRH)
+  // for Operations, Administration and Maintenance (OAM) operations as defined in RFC
+  // 9259.
+  // default = False
+  optional bool o_flag = 1;
+
+  // Node-level SRv6 Maximum SID Depth (MSD) capabilities advertised as MSD sub-TLVs within
+  // the Router Capability TLV per RFC 8491. These signal the maximum SRH stack depth
+  // this router supports for specific SRv6 forwarding behaviors (RFC 9352 Section 6).
+  IsisSRv6NodeMsd node_msds = 2;
+
+  // Compression (uSID) flag at the node level. When set, announces that this node supports
+  // Micro-SID (uSID) compressed encoding for SRv6 SIDs as described in RFC 9800. This
+  // flag is carried in the SRv6 Capabilities Sub-TLV (sub-TLV type 25) Flags field. Reference:
+  // RFC 9352 Section 2, RFC 9800.
+  // default = False
+  optional bool c_flag = 3;
+}
+
+// Node-level SRv6 Maximum SID Depth (MSD) capabilities. Each include_* flag controls
+// whether the corresponding MSD type is advertised; the paired value field sets the
+// advertised depth. MSD Type 41 = Max SL, Type 42 = Max End Pop, Type 44 = Max H.Encaps,
+// Type 45 = Max End D. Reference: RFC 8491, RFC 9352 Section 6.
+message IsisSRv6NodeMsd {
+
+  // When true, advertises the Maximum Segments Left (Max SL) MSD sub-TLV (MSD-Type 41).
+  // Signals the maximum value of the Segments Left (SL) field in an SRH that this router
+  // can process.
+  // default = False
+  optional bool include_max_sl = 1;
+
+  // Maximum value of the Segments Left (SL) field in an SRH that this router can process
+  // (MSD-Type 41, RFC 9352 Section 6). A value of 0 indicates no SRH processing capability.
+  // default = 0
+  optional uint32 max_sl = 2;
+
+  // When true, advertises the Max-End-Pop-SRH MSD sub-TLV (MSD-Type 42). Signals the
+  // maximum number of SIDs in the top SRH that this router can pop using PSP or USP End
+  // behaviors.
+  // default = False
+  optional bool include_max_end_pop_srh = 3;
+
+  // Maximum number of SIDs in the top SRH that this router can pop using PSP or USP End
+  // behaviors (MSD-Type 42, RFC 9352 Section 6). A value of 0 means the router cannot
+  // apply these behaviors.
+  // default = 0
+  optional uint32 max_end_pop_srh = 4;
+
+  // When true, advertises the Max-H-Encaps MSD sub-TLV (MSD-Type 44). Signals the maximum
+  // number of SIDs that can be pushed via the H.Encaps headend encapsulation behavior.
+  // default = False
+  optional bool include_max_h_encaps = 5;
+
+  // Maximum number of SIDs this router can insert in the SRH using the H.Encaps behavior
+  // (MSD-Type 44, RFC 9352 Section 6). A value of 0 with E-flag set indicates IPinIP
+  // encapsulation without SRH.
+  // default = 0
+  optional uint32 max_h_encaps = 6;
+
+  // When true, advertises the Max-End-D-SRH MSD sub-TLV (MSD-Type 45). Signals the maximum
+  // number of SIDs in the SRH when applying decapsulation behaviors (End.DT4, End.DT6,
+  // End.DT46, End.DX4, End.DX6).
+  // default = False
+  optional bool include_max_end_d_srh = 7;
+
+  // Maximum number of SIDs in the SRH that this router can handle while applying decapsulation
+  // behaviors such as End.DT6, End.DT4 or End.DT46 (MSD-Type 45, RFC 9352 Section 6).
+  // A value of 0 indicates no decapsulation support.
+  // default = 0
+  optional uint32 max_end_d_srh = 8;
+
+  // When true, advertises the Maximum T.Insert MSD sub-TLV (MSD-Type 43). Signals the
+  // maximum number of SIDs that can be inserted as a new SRH using the T.Insert headend
+  // behavior (RFC 8986 Section 5.3). Used for transit insertion of SRv6 policy. Reference:
+  // RFC 8491.
+  // default = False
+  optional bool include_max_t_insert = 9;
+
+  // Maximum number of SIDs this router can insert using the T.Insert behavior (MSD-Type
+  // 43, RFC 8491). A value of 0 indicates T.Insert is not supported.
+  // default = 0
+  optional uint32 max_t_insert = 10;
+}
+
+// IS-IS SRv6 Locator TLV (TLV type 27), as defined in RFC 9352 Section 7.1. Advertises
+// an SRv6 locator prefix that identifies this SRv6-capable router and binds it to a
+// specific IGP algorithm (standard SPF or Flex-Algo per RFC 9350). One Locator TLV
+// is required per topology/algorithm combination. The SRv6 SID space is structured
+// as: Locator prefix | Function | Argument, where the locator prefix is routable and
+// the function identifies the specific endpoint behavior (RFC 8986 Section 3.1).
+message IsisSRv6Locator {
+
+  // Globally unique name of an object. It also serves as the primary key for arrays of
+  // objects.
+  // required = true
+  optional string name = 1;
+
+  // The SRv6 locator IPv6 prefix for this TLV. This routable IPv6 prefix identifies the
+  // advertising node within the SRv6 domain. All SRv6 SIDs advertised under this locator
+  // must be allocated from this prefix.
+  // required = true
+  optional string locator = 2;
+
+  // Number of significant bits in the locator field (1-128). Defines the length of the
+  // SRv6 locator prefix. The combined bit budget of the locator, function, and argument
+  // fields must not exceed 128 bits (RFC 9352 Section 3.1).
+  // default = 64
+  optional uint32 prefix_length = 3;
+
+  // IGP Algorithm identifier for this locator (RFC 8665). 0 = standard SPF, 1 = Strict
+  // SPF. Values 128-255 represent Flexible Algorithms (Flex-Algo) as defined in RFC 9350.
+  // The algorithm determines the path computation method used to reach this locator.
+  // One Locator TLV is required per algorithm binding.
+  // default = 0
+  optional uint32 algorithm = 4;
+
+  // The metric (cost) associated with this SRv6 locator prefix. Uses the same semantics
+  // as IS-IS Extended IP reachability metric (RFC 9352 Section 7.1).
+  // default = 0
+  optional uint32 metric = 5;
+
+  message RedistributionType {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // Controls the Up/Down redistribution bit for this locator. 'up' = normal advertisement
+  // (default); 'down' = the locator has been leaked from Level 2 to Level 1 (RFC 5305).
+  // Must be consistent with the d_flag setting.
+  // default = RedistributionType.Enum.up
+  optional RedistributionType.Enum redistribution_type = 6;
+
+  // Down bit (D-flag, bit 0 of the Flags field in the SRv6 Locator TLV). MUST be set
+  // when the locator is leaked from Level 2 to Level 1 to prevent routing loops. Locator
+  // TLVs with the D-flag set MUST NOT be re-advertised from L1 to L2 (RFC 9352 Section
+  // 7.1).
+  // default = False
+  optional bool d_flag = 7;
+
+  // Multi-Topology Identifier (MT-ID) for this locator advertisement. Specifies which
+  // IS-IS topology this locator belongs to. 0 = default topology. Valid range 0-4095
+  // (RFC 5120).
+  // default = 0
+  optional uint32 mt_id = 8;
+
+  // List of SRv6 End SID Sub-TLVs (sub-TLV type 5) associated with this locator. Each
+  // End SID advertises a locally instantiated node-local SRv6 SID, its endpoint behavior
+  // (End, End.DT4, End.DT6, End.DT46 and their flavor variants), and optional SID structure
+  // information (RFC 9352 Section 7.2).
+  repeated IsisSRv6EndSid end_sids = 9;
+
+  // When true, the locator prefix is also advertised as an IS-IS IPv6 Reachability prefix
+  // (TLV 236/237) in addition to the SRv6 Locator TLV (type 27). This enables non-SRv6-capable
+  // routers to route toward the locator as an ordinary IPv6 prefix. Typically suppressed
+  // automatically when algorithm is a Flex-Algo value (128-255).
+  // default = True
+  optional bool advertise_locator_as_prefix = 10;
+
+  // Metric value used when advertising the locator prefix in the IPv6 Reachability TLV
+  // (TLV 236/237). Applies only when advertise_locator_as_prefix is true.
+  // default = 0
+  optional uint32 route_metric = 11;
+
+  message RouteOrigin {
+    enum Enum {
+      unspecified = 0;
+      internal = 1;
+      external = 2;
+    }
+  }
+  // Origin type for the locator prefix when advertised in the IPv6 Reachability TLV (TLV
+  // 236/237). 'internal' = intra-area prefix (default); 'external' = redistributed from
+  // another protocol. Applies only when advertise_locator_as_prefix is true.
+  // default = RouteOrigin.Enum.internal
+  optional RouteOrigin.Enum route_origin = 12;
+
+  // When true, includes the Prefix Attribute Flags Sub-TLV (sub-TLV type 4, RFC 7794)
+  // in the locator's IPv6 Reachability advertisement. Enables advertising X, R, N, and
+  // A flags for this locator prefix. Applies only when advertise_locator_as_prefix is
+  // true.
+  // default = False
+  optional bool prefix_attr_enabled = 13;
+
+  // External prefix flag (bit 0 of Prefix Attribute Flags sub-TLV, RFC 7794). When set,
+  // indicates this locator prefix was redistributed from another protocol. Applicable
+  // only when prefix_attr_enabled is true.
+  // default = False
+  optional bool x_flag = 14;
+
+  // Re-advertisement flag (bit 1 of Prefix Attribute Flags sub-TLV, RFC 7794). When set,
+  // indicates this locator prefix has been leaked between IS-IS levels. Applicable only
+  // when prefix_attr_enabled is true.
+  // default = False
+  optional bool r_flag = 15;
+
+  // Node flag (bit 2 of Prefix Attribute Flags sub-TLV, RFC 7794). When set, indicates
+  // this prefix identifies the advertising router (e.g., a loopback or router-ID prefix).
+  // Applicable only when prefix_attr_enabled is true.
+  // default = False
+  optional bool n_flag = 16;
+
+  // Anycast flag (bit 5 of Prefix Attribute Flags sub-TLV, RFC 7794). When set, indicates
+  // this prefix is an anycast prefix shared across multiple routers. Applicable only
+  // when prefix_attr_enabled is true.
+  // default = False
+  optional bool a_flag = 17;
+
+  message IncludeSourceRouterId {
+    enum Enum {
+      unspecified = 0;
+      none = 1;
+      ipv4 = 2;
+      ipv6 = 3;
+      ipv4_and_ipv6 = 4;
+    }
+  }
+  // Controls whether Source Router ID Sub-TLVs (RFC 9350 Section 5) are included in this
+  // locator's IPv6 Reachability prefix advertisement. - none: No Source Router ID sub-TLV
+  // included (default). - ipv4: Include IPv4 Source Router ID sub-TLV (type 11). - ipv6:
+  // Include IPv6 Source Router ID sub-TLV (type 12). - ipv4_and_ipv6: Include both IPv4
+  // and IPv6 sub-TLVs. Used with Flex-Algo (algorithm 128-255) to identify the originating
+  // router for prefix advertisements. Applies only when advertise_locator_as_prefix is
+  // true.
+  // default = IncludeSourceRouterId.Enum.none
+  optional IncludeSourceRouterId.Enum include_source_router_id = 18;
+
+  // IPv4 Source Router ID value advertised in the IPv4 Source Router ID Sub-TLV (type
+  // 11, RFC 9350 Section 5). Identifies the originating router for this Flex-Algo prefix
+  // advertisement. Applicable when include_source_router_id is 'ipv4' or 'ipv4_and_ipv6'.
+  // default = 0.0.0.0
+  optional string ipv4_source_router_id = 19;
+
+  // IPv6 Source Router ID value advertised in the IPv6 Source Router ID Sub-TLV (type
+  // 12, RFC 9350 Section 5). Identifies the originating router for this Flex-Algo prefix
+  // advertisement. Applicable when include_source_router_id is 'ipv6' or 'ipv4_and_ipv6'.
+  // default = ::
+  optional string ipv6_source_router_id = 20;
+}
+
+// SRv6 End SID Sub-TLV (sub-TLV type 5) carried within the SRv6 Locator TLV (TLV type
+// 27). Advertises a locally instantiated node-local SRv6 SID and its associated endpoint
+// behavior. The SID value must be allocated from within the parent locator's prefix.
+// Valid behaviors for node-local End SIDs are End (with PSP/USP/USD flavor variants)
+// and decapsulation behaviors (End.DT4, End.DT6, End.DT46). Reference: RFC 9352 Section
+// 7.2, RFC 8986.
+message IsisSRv6EndSid {
+
+  // The 128-bit SRv6 SID value in IPv6 address format. Must be allocated from within
+  // the parent locator's prefix space, following the structure: Locator | Function |
+  // Argument (RFC 8986 Section 3.1).
+  optional string sid = 1;
+
+  message EndpointBehavior {
+    enum Enum {
+      unspecified = 0;
+      end = 1;
+      end_with_psp = 2;
+      end_with_usp = 3;
+      end_with_psp_usp = 4;
+      end_with_usd = 5;
+      end_with_psp_usd = 6;
+      end_with_usp_usd = 7;
+      end_with_psp_usp_usd = 8;
+      end_dt4 = 9;
+      end_dt6 = 10;
+      end_dt46 = 11;
+    }
+  }
+  // The endpoint behavior for this SRv6 End SID, encoded as a 2-octet behavior codepoint
+  // (RFC 8986 Section 7.4). Defines how the router processes packets arriving with this
+  // SID as the Active Segment. Valid node-level behaviors for End SID Sub-TLV type 5
+  // are End variants (with PSP/USP/USD flavors) and decapsulation behaviors.
+  // default = EndpointBehavior.Enum.end
+  optional EndpointBehavior.Enum endpoint_behavior = 2;
+
+  // Compression (uSID) flag. When set, indicates that this SID supports Micro-SID (uSID)
+  // compressed encoding, enabling multiple node segments to be packed within a single
+  // 128-bit SID carrier using the Argument field. Requires the SRv6 SID Structure Sub-Sub-TLV
+  // to be included to describe the bit allocation. Reference: draft-filsfils-spring-net-pgm-extension-srv6-usid,
+  // RFC 9800.
+  // default = False
+  optional bool c_flag = 3;
+
+  // SRv6 SID Structure Sub-Sub-TLV (type 1) describing the internal bit-field decomposition
+  // of this SID value. Specifies the Locator Block, Locator Node, Function, and Argument
+  // lengths in bits. The sum of all four lengths must not exceed 128. When present, the
+  // sub-sub-TLV is included in the advertisement. Typically set when c_flag is true (RFC
+  // 9352 Section 9).
+  IsisSRv6SidStructure sid_structure = 4;
+}
+
+// SRv6 Adjacency SID Sub-TLV for IS-IS interfaces. Point-to-point adjacencies use End.X
+// SID Sub-TLV (sub-TLV type 43); LAN adjacencies use LAN End.X SID Sub-TLV (sub-TLV
+// type 44). The End.X SID binds a 128-bit SRv6 SID to a specific outgoing interface
+// and next-hop, enabling traffic steering across a specific L3 adjacency. Valid behaviors
+// include End.X variants (with PSP/USP/USD flavors) and cross-connect decapsulation
+// behaviors (End.DX4, End.DX6). Reference: RFC 9352 Sections 8.1-8.2, RFC 8986 Section
+// 4.3.
+message IsisSRv6AdjSid {
+
+  // The 128-bit SRv6 SID value in IPv6 address format for this adjacency. Must be allocated
+  // from the advertising node's locator prefix space.
+  optional string sid = 1;
+
+  message EndpointBehavior {
+    enum Enum {
+      unspecified = 0;
+      end_x = 1;
+      end_x_with_psp = 2;
+      end_x_with_usp = 3;
+      end_x_with_psp_usp = 4;
+      end_x_with_usd = 5;
+      end_x_with_psp_usd = 6;
+      end_x_with_usp_usd = 7;
+      end_x_with_psp_usp_usd = 8;
+      end_dx4 = 9;
+      end_dx6 = 10;
+    }
+  }
+  // The endpoint behavior for this adjacency SID, encoded as a 2-octet behavior codepoint
+  // (RFC 8986 Section 7.4). Valid adjacency-level behaviors for End.X SID Sub-TLV types
+  // 43/44 are End.X variants (with PSP/USP/USD flavors) and per-CE cross-connect decapsulation
+  // behaviors (End.DX4, End.DX6).
+  // default = EndpointBehavior.Enum.end_x
+  optional EndpointBehavior.Enum endpoint_behavior = 2;
+
+  // Backup flag (B-flag, bit 0). When set, the End.X SID is eligible for IP Fast-ReRoute
+  // (IP-FRR) protection, indicating a backup adjacency that can protect traffic when
+  // the primary adjacency fails (RFC 9352 Section 8.1).
+  // default = False
+  optional bool b_flag = 3;
+
+  // Set flag (S-flag, bit 1). When set, the End.X SID refers to a set of adjacencies
+  // (e.g., parallel links, ECMP group). The same SID value may be assigned to multiple
+  // adjacencies forming the set (RFC 9352 Section 8.1).
+  // default = False
+  optional bool s_flag = 4;
+
+  // Persistent flag (P-flag, bit 2). When set, the End.X SID value is persistently allocated
+  // and remains consistent across router restarts and interface flap events (RFC 9352
+  // Section 8.1).
+  // default = False
+  optional bool p_flag = 5;
+
+  // Weight for load balancing across adjacencies sharing the same End.X SID (applicable
+  // when S-flag is set). Traffic is distributed proportionally across the adjacency set
+  // according to the weight values (RFC 9352 Section 8.1).
+  // default = 0
+  optional uint32 weight = 6;
+
+  // IGP algorithm associated with this adjacency SID (RFC 8665). 0 = standard SPF, 1
+  // = Strict SPF, 128-255 = Flex-Algo (RFC 9350). Binds the adjacency SID to the corresponding
+  // topology or path computation algorithm.
+  // default = 0
+  optional uint32 algorithm = 7;
+
+  // Compression (uSID) flag. When set, indicates this adjacency SID supports Micro-SID
+  // (uSID) compressed encoding, allowing multiple adjacency micro-segments to be stacked
+  // within a single 128-bit SID carrier using the Argument field.
+  // default = False
+  optional bool c_flag = 8;
+
+  // SRv6 SID Structure Sub-Sub-TLV (type 1) describing the internal bit-field decomposition
+  // of this adjacency SID. Specifies the Locator Block, Locator Node, Function, and Argument
+  // lengths in bits. When present, the sub-sub-TLV is included in the advertisement.
+  // Typically set when c_flag is true (RFC 9352 Section 9).
+  IsisSRv6SidStructure sid_structure = 9;
+}
+
+// SRv6 SID Structure Sub-Sub-TLV (type 1), carried within SRv6 SID Sub-TLVs (End SID
+// type 5, End.X SID type 43/44). Describes the internal bit-field decomposition of
+// the SRv6 SID value so that receiving routers can interpret each field independently.
+// The four length fields (lb_length + ln_length + function_length + argument_length)
+// MUST NOT exceed 128 bits. Required when advertising Micro-SID (uSID) SIDs to describe
+// the compressed encoding. Example for common uSID F3216 format:
+// lb_length=32, ln_length=16, function_length=16, argument_length=0
+// Reference: RFC 9352 Section 9, RFC 9800.
+message IsisSRv6SidStructure {
+
+  // Number of bits in the Locator Block (LB) field of the SID. The Locator Block is the
+  // common IPv6 prefix shared across all SIDs within the same SRv6 domain block (e.g.,
+  // 32 bits in the uSID F3216 format). Minimum value 1.
+  // default = 32
+  optional uint32 locator_block_length = 1;
+
+  // Number of bits in the Locator Node (LN) field of the SID. Identifies the specific
+  // node within the Locator Block (e.g., 16 bits in the uSID F3216 format, providing
+  // up to 65534 addressable nodes per domain block).
+  // default = 16
+  optional uint32 locator_node_length = 2;
+
+  // Number of bits in the Function field of the SID. Identifies the specific endpoint
+  // behavior instantiated on this node (e.g., 16 bits in the uSID F3216 format, supporting
+  // up to 65534 distinct functions per node).
+  // default = 16
+  optional uint32 function_length = 3;
+
+  // Number of bits in the Argument field of the SID. Carries additional per-behavior
+  // information such as VPN table identifiers or compressed next-SID encodings for Micro-SID
+  // stacking. Set to 0 for standard SIDs that carry no argument. When non-zero in a uSID
+  // context, enables packing multiple micro-segment identifiers within a single 128-bit
+  // SID carrier (RFC 9800).
+  // default = 0
+  optional uint32 argument_length = 4;
+}
+
+// Link-level SRv6 Maximum SID Depth (MSD) capabilities advertised per IS-IS interface.
+// Signals the SRv6 SRH processing capacity specific to this link, which may differ
+// from the node-level MSD values. Advertised as MSD sub-TLVs within the neighbor TLVs
+// per RFC 8491. Reference: RFC 8491, RFC 9352 Section 6.
+message IsisSRv6LinkMsd {
+
+  // When true, advertises the Maximum Segments Left (Max SL) MSD (MSD-Type 41) at the
+  // link level. Signals the maximum SL value in an SRH that can be processed on this
+  // interface.
+  // default = False
+  optional bool include_max_sl = 1;
+
+  // Maximum value of the Segments Left (SL) field in an SRH that this interface can process
+  // (MSD-Type 41). A value of 0 indicates no SRH processing support on this link.
+  // default = 0
+  optional uint32 max_sl = 2;
+
+  // When true, advertises the Max-End-Pop-SRH MSD (MSD-Type 42) at the link level.
+  // default = False
+  optional bool include_max_end_pop_srh = 3;
+
+  // Maximum number of SIDs in the top SRH for PSP or USP End behaviors on this interface
+  // (MSD-Type 42). A value of 0 indicates these behaviors are not supported on this link.
+  // default = 0
+  optional uint32 max_end_pop_srh = 4;
+
+  // When true, advertises the Max-H-Encaps MSD (MSD-Type 44) at the link level.
+  // default = False
+  optional bool include_max_h_encaps = 5;
+
+  // Maximum number of SIDs for H.Encaps behavior on this interface (MSD-Type 44). A value
+  // of 0 indicates H.Encaps is not supported on this link.
+  // default = 0
+  optional uint32 max_h_encaps = 6;
+
+  // When true, advertises the Max-End-D-SRH MSD (MSD-Type 45) at the link level.
+  // default = False
+  optional bool include_max_end_d_srh = 7;
+
+  // Maximum number of SIDs in the SRH for decapsulation behaviors (End.DT4/DT6/DT46/DX4/DX6)
+  // on this interface (MSD-Type 45). A value of 0 indicates decapsulation behaviors are
+  // not supported on this link.
+  // default = 0
+  optional uint32 max_end_d_srh = 8;
+
+  // When true, advertises the Maximum T.Insert MSD (MSD-Type 43) at the link level. Signals
+  // the maximum number of SIDs that can be inserted via the T.Insert headend behavior
+  // on this specific interface. Reference: RFC 8491.
+  // default = False
+  optional bool include_max_t_insert = 9;
+
+  // Maximum number of SIDs insertable via T.Insert behavior on this interface (MSD-Type
+  // 43, RFC 8491). A value of 0 indicates T.Insert is not supported on this link.
+  // default = 0
+  optional uint32 max_t_insert = 10;
 }
 
 // This contains ISIS router basic properties.
@@ -2547,7 +3034,7 @@ message IsisV6RouteRange {
 // of the cases, is a one-hop path.
 // These segments act as topological sub-paths that can be combined together to form
 // the required path.
-// Reference: https://datatracker.ietf.org/doc/html/rfc8667.:w
+// Reference: https://datatracker.ietf.org/doc/html/rfc8667.
 // An implementation may advertise Router Capability with default values if a user does
 // not even set the properties
 // of Router Capability and Segment Routing Capability.
@@ -2557,6 +3044,13 @@ message IsisSegmentRouting {
   // router to announce its
   // capabilities within an IS-IS level or the entire routing domain.
   IsisRouterCapability router_capability = 1;
+
+  // List of SRv6 Locator TLVs (TLV type 27) to be advertised by this IS-IS router. Each
+  // locator binds an IPv6 prefix to an IGP algorithm (standard SPF or Flex-Algo per RFC
+  // 9350) and carries End SID Sub-TLVs for locally instantiated node-level SRv6 SIDs.
+  // One Locator TLV is required per topology/algorithm combination. Reference: RFC 9352
+  // Section 7.1.
+  repeated IsisSRv6Locator srv6_locators = 2;
 }
 
 // Container for the configuration of IS-IS Router CAPABILITY TLV.
@@ -2644,6 +3138,12 @@ message IsisRouterCapability {
 
   // This contains the list of SR Local Block (SRLB)
   repeated IsisSRSrlb srlb_ranges = 7;
+
+  // SRv6 Capabilities Sub-TLV (sub-TLV type 25) carried within this Router CAPABILITY
+  // TLV. Announces that this router is an SRv6 Segment Endpoint Node and advertises optional
+  // OAM (O-flag) support and node-level SRv6 Maximum SID Depth (MSD) values. Reference:
+  // RFC 9352 Section 2, RFC 8491.
+  IsisSRv6NodeCapability srv6_capability = 8;
 }
 
 // Container for the configuration of IS-IS SR-CAPABILITY TLV that Segment Routing requires
@@ -19159,6 +19659,13 @@ message IsisLspTlvs {
   // IS-IS Router Capabilities: TLV 242.
   // This container defines Router Capabilities.
   repeated IsisLspCapability router_capabilities = 8;
+
+  // Array of SRv6 Locator TLVs (type 27) present in this LSP.
+  // Each entry represents one SRv6 locator prefix advertisement,
+  // binding a node-local IPv6 prefix to an IGP algorithm and carrying
+  // node-local End SID Sub-TLVs for SRv6 endpoint behaviors.
+  // Reference: RFC 9352 Section 7.1.
+  repeated IsisLspSRv6LocatorTlv srv6_locator_tlvs = 9;
 }
 
 // It contains Hostname for the TLV 137.
@@ -19223,8 +19730,16 @@ message IsisLspExtendedNeighbor {
   // The System ID for this emulated ISIS router, e.g. 640100010000.
   optional string system_id = 1;
 
-  // List of segment routing adjacency SIDs.
+  // List of SR-MPLS Adjacency SID sub-TLVs (sub-TLV types 31/32,
+  // RFC 8667) learned from this neighbor.
   repeated IsisLspAdjacencySid adjacency_sids = 2;
+
+  // List of SRv6 Adjacency SID Sub-TLVs (End.X SID sub-TLV type 43
+  // for P2P or LAN End.X SID sub-TLV type 44 for broadcast) learned
+  // from this neighbor. Each entry carries a 128-bit SRv6 SID bound
+  // to a specific outgoing adjacency.
+  // Reference: RFC 9352 Sections 8.1-8.2.
+  repeated IsisLspSRv6AdjSid srv6_adj_sids = 3;
 }
 
 // This container defines list of IPv4 internal reachability information in one IPv4
@@ -19468,6 +19983,13 @@ message IsisLspCapability {
 
   // This contains the list of SR Local Block (SRLB)
   repeated IsisLspSrlb srlb_ranges = 6;
+
+  // SRv6 Capabilities Sub-TLV (sub-TLV type 25) present within this
+  // Router CAPABILITY TLV. Announces that the originating router is
+  // an SRv6 Segment Endpoint Node, indicates OAM support (O-flag),
+  // and carries node-level SRv6 Maximum SID Depth (MSD) values.
+  // Reference: RFC 9352 Section 2, RFC 8491.
+  IsisLspSRv6Capability srv6_capability = 7;
 }
 
 // Container of IS-IS SR-CAPABILITY Sub-Tlv.
@@ -19602,6 +20124,253 @@ message IsisLspAdjSidFlags {
   // the Adj-SID is persistently allocated, i.e., the Adj-SID value
   // remains consistent across router restart and/or interface flap.
   optional bool p_flag = 6;
+}
+
+// SRv6 Capabilities Sub-TLV (sub-TLV type 25) learned from the IS-IS Router CAPABILITY
+// TLV (TLV 242) in a received LSP. Indicates that the originating router is an SRv6
+// Segment Endpoint Node and carries optional OAM support (O-flag) and node-level SRv6
+// MSD values. Reference: RFC 9352 Section 2, RFC 8491.
+message IsisLspSRv6Capability {
+
+  // OAM flag (bit 1). When set, the originating router supports the use of the O-bit
+  // in the Segment Routing Header (SRH) for OAM operations as defined in RFC 9259.
+  optional bool o_flag = 1;
+
+  // Node-level SRv6 Maximum SID Depth (MSD) values learned from MSD sub-TLVs within the
+  // Router Capability TLV.
+  IsisLspSRv6NodeMsd node_msds = 2;
+
+  // Compression (uSID) flag. When set, the originating router supports Micro-SID (uSID)
+  // compressed encoding for SRv6 SIDs. Learned from the Flags field of the SRv6 Capabilities
+  // Sub-TLV (sub-TLV type 25). Reference: RFC 9352 Section 2, RFC 9800.
+  optional bool c_flag = 3;
+}
+
+// Node-level SRv6 Maximum SID Depth (MSD) values learned from a received LSP. Each
+// field represents the advertised depth limit for a specific SRv6 forwarding behavior.
+// MSD Type 41 = Max SL, Type 42 = Max End Pop, Type 44 = Max H.Encaps, Type 45 = Max
+// End D. Reference: RFC 8491, RFC 9352 Section 6.
+message IsisLspSRv6NodeMsd {
+
+  // Maximum value of the Segments Left (SL) field in an SRH that the originating router
+  // can process (MSD-Type 41). Absent if not advertised; value of 0 means no SRH processing
+  // support.
+  optional uint32 max_sl = 1;
+
+  // Maximum number of SIDs in the top SRH that the originating router can pop using PSP
+  // or USP End behaviors (MSD-Type 42). Absent if not advertised.
+  optional uint32 max_end_pop_srh = 2;
+
+  // Maximum number of SIDs the originating router can push via H.Encaps behavior (MSD-Type
+  // 44). Absent if not advertised.
+  optional uint32 max_h_encaps = 3;
+
+  // Maximum number of SIDs in the SRH the originating router can handle for decapsulation
+  // behaviors End.DT4/DT6/DT46/DX4/DX6 (MSD-Type 45). Absent if not advertised.
+  optional uint32 max_end_d_srh = 4;
+
+  // Maximum number of SIDs the originating router can insert using the T.Insert headend
+  // behavior (MSD-Type 43, RFC 8491). Absent if not advertised by the originating router.
+  optional uint32 max_t_insert = 5;
+}
+
+// SRv6 Locator TLV (TLV type 27) learned from a received IS-IS LSP. Carries an SRv6
+// locator prefix that identifies the originating node, the associated IGP algorithm,
+// metric, and a list of locally instantiated End SID Sub-TLVs. Reference: RFC 9352
+// Section 7.1.
+message IsisLspSRv6LocatorTlv {
+
+  // The SRv6 locator IPv6 prefix advertised in this TLV.
+  optional string locator = 1;
+
+  // Number of significant bits in the locator field (1-128).
+  optional uint32 prefix_length = 2;
+
+  // IGP algorithm identifier for this locator. 0 = SPF, 1 = Strict SPF, 128-255 = Flex-Algo
+  // (RFC 9350, RFC 8665).
+  optional uint32 algorithm = 3;
+
+  // The metric (cost) associated with this SRv6 locator prefix.
+  optional uint32 metric = 4;
+
+  message RedistributionType {
+    enum Enum {
+      unspecified = 0;
+      up = 1;
+      down = 2;
+    }
+  }
+  // Up/Down redistribution bit for this locator advertisement. 'up' = normal advertisement;
+  // 'down' = leaked from L2 to L1.
+  optional RedistributionType.Enum redistribution_type = 5;
+
+  // Down bit (D-flag). Set when this locator was leaked from Level 2 to Level 1 (RFC
+  // 9352 Section 7.1).
+  optional bool d_flag = 6;
+
+  // Multi-Topology ID for this locator. 0 = default topology.
+  optional uint32 mt_id = 7;
+
+  // List of SRv6 End SID Sub-TLVs (sub-TLV type 5) carried within this Locator TLV. Each
+  // entry describes a node-local SRv6 SID and its endpoint behavior. Reference: RFC 9352
+  // Section 7.2.
+  repeated IsisLspSRv6EndSid end_sids = 8;
+
+  // External prefix flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type
+  // 4). Present in the locator's IPv6 Reachability advertisement when advertised by the
+  // originating router. Set if the locator prefix was redistributed from another protocol.
+  optional bool x_flag = 9;
+
+  // Re-advertisement flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV
+  // type 4). Set if present and indicates the locator prefix was leaked between IS-IS
+  // levels.
+  optional bool r_flag = 10;
+
+  // Node flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4). Set
+  // if present and indicates this locator prefix identifies the advertising router.
+  optional bool n_flag = 11;
+
+  // Anycast flag from the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4).
+  // Set if present and indicates this locator is an anycast prefix shared across multiple
+  // routers.
+  optional bool a_flag = 12;
+
+  // IPv4 Source Router ID learned from the IPv4 Source Router ID Sub-TLV (type 11, RFC
+  // 9350 Section 5) in the locator's IPv6 Reachability prefix advertisement. Present
+  // only if advertised by the originating router.
+  optional string ipv4_source_router_id = 13;
+
+  // IPv6 Source Router ID learned from the IPv6 Source Router ID Sub-TLV (type 12, RFC
+  // 9350 Section 5) in the locator's IPv6 Reachability prefix advertisement. Present
+  // only if advertised by the originating router.
+  optional string ipv6_source_router_id = 14;
+}
+
+// SRv6 End SID Sub-TLV (sub-TLV type 5) learned from an SRv6 Locator TLV (type 27)
+// in a received LSP. Describes a node-local SRv6 SID, its endpoint behavior, and optional
+// SID structure information. Reference: RFC 9352 Section 7.2, RFC 8986.
+message IsisLspSRv6EndSid {
+
+  // The 128-bit SRv6 SID value in IPv6 address format.
+  optional string sid = 1;
+
+  message EndpointBehavior {
+    enum Enum {
+      unspecified = 0;
+      end = 1;
+      end_with_psp = 2;
+      end_with_usp = 3;
+      end_with_psp_usp = 4;
+      end_with_usd = 5;
+      end_with_psp_usd = 6;
+      end_with_usp_usd = 7;
+      end_with_psp_usp_usd = 8;
+      end_dt4 = 9;
+      end_dt6 = 10;
+      end_dt46 = 11;
+    }
+  }
+  // Endpoint behavior codepoint for this End SID (RFC 8986 Section 7.4). Indicates how
+  // the originating router processes packets arriving with this SID as the Active Segment.
+  optional EndpointBehavior.Enum endpoint_behavior = 2;
+
+  // SRv6 SID Structure Sub-Sub-TLV (type 1) if present, describing the bit-field decomposition
+  // of this SID value. Specifies Locator Block, Locator Node, Function, and Argument
+  // lengths in bits. Reference: RFC 9352 Section 9.
+  IsisLspSRv6SidStructure sid_structure = 3;
+}
+
+// SRv6 Adjacency SID Sub-TLV learned from the Extended IS Reachability TLV (type 22)
+// or MT-ISN TLV (type 222) in a received LSP. Point-to-point End.X SID Sub-TLV has
+// sub-TLV type 43; LAN End.X SID Sub-TLV has sub-TLV type 44 and includes the neighbor
+// System ID. Reference: RFC 9352 Sections 8.1-8.2, RFC 8986.
+message IsisLspSRv6AdjSid {
+
+  message Type {
+    enum Enum {
+      unspecified = 0;
+      end_x_sid = 1;
+      lan_end_x_sid = 2;
+    }
+  }
+  // The sub-TLV type that carried this adjacency SID. 'end_x_sid' = point-to-point (sub-TLV
+  // type 43); 'lan_end_x_sid' = LAN adjacency (sub-TLV type 44, includes neighbor System
+  // ID in neighbor_id field).
+  optional Type.Enum type = 1;
+
+  // IS-IS System ID of the LAN neighbor from which this End.X SID was received. Present
+  // only when type is 'lan_end_x_sid' (sub-TLV type 44, RFC 9352 Section 8.2).
+  optional string neighbor_id = 2;
+
+  // The 128-bit SRv6 End.X SID value in IPv6 address format.
+  optional string sid = 3;
+
+  message EndpointBehavior {
+    enum Enum {
+      unspecified = 0;
+      end_x = 1;
+      end_x_with_psp = 2;
+      end_x_with_usp = 3;
+      end_x_with_psp_usp = 4;
+      end_x_with_usd = 5;
+      end_x_with_psp_usd = 6;
+      end_x_with_usp_usd = 7;
+      end_x_with_psp_usp_usd = 8;
+      end_dx4 = 9;
+      end_dx6 = 10;
+    }
+  }
+  // Endpoint behavior codepoint for this adjacency SID (RFC 8986 Section 7.4).
+  optional EndpointBehavior.Enum endpoint_behavior = 4;
+
+  // Backup flag. When set, this End.X SID is eligible for IP-FRR protection (RFC 9352
+  // Section 8.1).
+  optional bool b_flag = 5;
+
+  // Set flag. When set, this End.X SID refers to a set of adjacencies (RFC 9352 Section
+  // 8.1).
+  optional bool s_flag = 6;
+
+  // Persistent flag. When set, the SID value is stable across router restarts and interface
+  // flaps (RFC 9352 Section 8.1).
+  optional bool p_flag = 7;
+
+  // Weight for load balancing across the adjacency set when S-flag is set (RFC 9352 Section
+  // 8.1).
+  optional uint32 weight = 8;
+
+  // IGP algorithm bound to this adjacency SID. 0 = SPF, 1 = Strict SPF, 128-255 = Flex-Algo
+  // (RFC 9350, RFC 8665).
+  optional uint32 algorithm = 9;
+
+  // SRv6 SID Structure Sub-Sub-TLV (type 1) if present, describing the internal bit-field
+  // decomposition of this adjacency SID. Reference: RFC 9352 Section 9.
+  IsisLspSRv6SidStructure sid_structure = 10;
+}
+
+// SRv6 SID Structure Sub-Sub-TLV (type 1) learned from a received LSP. Describes the
+// internal bit-field decomposition of an SRv6 SID, enabling routers to independently
+// interpret each component of the 128-bit SID value. The sum of all four length fields
+// must not exceed 128 bits. Reference: RFC 9352 Section 9.
+message IsisLspSRv6SidStructure {
+
+  // Number of bits in the Locator Block (LB) field of the SID. The common IPv6 prefix
+  // shared by all SIDs in the same SRv6 domain block (e.g., 32 bits in the uSID F3216
+  // format).
+  optional uint32 locator_block_length = 1;
+
+  // Number of bits in the Locator Node (LN) field of the SID. Identifies the specific
+  // node within the Locator Block (e.g., 16 bits in the uSID F3216 format).
+  optional uint32 locator_node_length = 2;
+
+  // Number of bits in the Function field of the SID. Identifies the specific endpoint
+  // behavior on this node (e.g., 16 bits in the uSID F3216 format).
+  optional uint32 function_length = 3;
+
+  // Number of bits in the Argument field of the SID. Used for VPN table IDs or compressed
+  // next-SID encodings in Micro-SID stacking. 0 for standard SIDs without argument (RFC
+  // 9800).
+  optional uint32 argument_length = 4;
 }
 
 // The request to retrieve LLDP neighbor information for a given instance.

--- a/device/isis/interface.yaml
+++ b/device/isis/interface.yaml
@@ -104,11 +104,33 @@ components:
           x-field-uid: 13
         adjacency_sids:
           description: >-
-            List of Adjacency Segment Identifier (Adj-SID) sub-TLVs.
+            List of SR-MPLS Adjacency Segment Identifier (Adj-SID) sub-TLVs
+            for this interface (RFC 8667).
           type: array
           items:
             $ref: './adjacencysegmentid.yaml#/components/schemas/IsisInterface.AdjacencySid'
           x-field-uid: 14
+        srv6_adj_sids:
+          description: >-
+            List of SRv6 Adjacency SID Sub-TLVs (End.X SID) for this interface.
+            Point-to-point interfaces advertise End.X SID Sub-TLV (sub-TLV type 43);
+            broadcast interfaces advertise LAN End.X SID Sub-TLV (sub-TLV type 44).
+            Each entry binds a 128-bit SRv6 SID to this specific outgoing
+            adjacency and advertises the associated endpoint behavior.
+            Reference: RFC 9352 Sections 8.1-8.2.
+          type: array
+          items:
+            $ref: './srv6.yaml#/components/schemas/IsisSRv6.AdjSid'
+          x-field-uid: 15
+        srv6_link_msd:
+          description: >-
+            Link-level SRv6 Maximum SID Depth (MSD) capabilities for this
+            interface. Advertised as MSD sub-TLVs within the neighbor TLVs
+            (Extended IS Reachability TLV 22 / MT-ISN TLV 222) to signal the
+            SRv6 SRH processing capacity of this specific link.
+            Reference: RFC 8491, RFC 9352 Section 6.
+          $ref: './srv6.yaml#/components/schemas/IsisSRv6.LinkMsd'
+          x-field-uid: 16
                   
     IsisInterface.Level:
       description: >-

--- a/device/isis/segmentrouting.yaml
+++ b/device/isis/segmentrouting.yaml
@@ -2,23 +2,35 @@ components:
   schemas:
     Isis.SegmentRouting:
       description: |-
-        Segment Routing (SR) allows for a flexible definition of end-to-end paths within IGP topologies by encoding paths as sequences of topological sub-paths, 
-        called "segments". These segments are advertised by the link-state routing protocols (IS-IS and OSPF). 
-        Prefix segments represent an ECMP-aware shortest path to a prefix (or a node), as per the state of the IGP topology. 
-        Adjacency segments represent a hop over a specific adjacency between two nodes in the IGP. 
-        A prefix segment is typically a multi-hop path while an adjacency segment, in most of the cases, is a one-hop path. 
+        Segment Routing (SR) allows for a flexible definition of end-to-end paths within IGP topologies by encoding paths as sequences of topological sub-paths,
+        called "segments". These segments are advertised by the link-state routing protocols (IS-IS and OSPF).
+        Prefix segments represent an ECMP-aware shortest path to a prefix (or a node), as per the state of the IGP topology.
+        Adjacency segments represent a hop over a specific adjacency between two nodes in the IGP.
+        A prefix segment is typically a multi-hop path while an adjacency segment, in most of the cases, is a one-hop path.
         These segments act as topological sub-paths that can be combined together to form the required path.
-        Reference: https://datatracker.ietf.org/doc/html/rfc8667.:w
-        An implementation may advertise Router Capability with default values if a user does not even set the properties 
-        of Router Capability and Segment Routing Capability.  
+        Reference: https://datatracker.ietf.org/doc/html/rfc8667.
+        An implementation may advertise Router Capability with default values if a user does not even set the properties
+        of Router Capability and Segment Routing Capability.
       type: object
       properties:
         router_capability:
           description: |-
             Optional IS-IS TLV named CAPABILITY, formed of multiple sub-TLVs, which allows a router to announce its
-            capabilities within an IS-IS level or the entire routing domain.        
+            capabilities within an IS-IS level or the entire routing domain.
           $ref: '#/components/schemas/Isis.RouterCapability'
           x-field-uid: 1
+        srv6_locators:
+          description: >-
+            List of SRv6 Locator TLVs (TLV type 27) to be advertised by this
+            IS-IS router. Each locator binds an IPv6 prefix to an IGP algorithm
+            (standard SPF or Flex-Algo per RFC 9350) and carries End SID
+            Sub-TLVs for locally instantiated node-level SRv6 SIDs.
+            One Locator TLV is required per topology/algorithm combination.
+            Reference: RFC 9352 Section 7.1.
+          type: array
+          items:
+            $ref: './srv6.yaml#/components/schemas/IsisSRv6.Locator'
+          x-field-uid: 2
       
     Isis.RouterCapability:
       description: |-
@@ -113,6 +125,15 @@ components:
           items:
             $ref: '#/components/schemas/IsisSR.Srlb'
           x-field-uid: 7
+        srv6_capability:
+          description: >-
+            SRv6 Capabilities Sub-TLV (sub-TLV type 25) carried within this
+            Router CAPABILITY TLV. Announces that this router is an SRv6
+            Segment Endpoint Node and advertises optional OAM (O-flag) support
+            and node-level SRv6 Maximum SID Depth (MSD) values.
+            Reference: RFC 9352 Section 2, RFC 8491.
+          $ref: './srv6.yaml#/components/schemas/IsisSRv6.NodeCapability'
+          x-field-uid: 8
   
     Isis.SRCapability:
       description: |-

--- a/device/isis/srv6.yaml
+++ b/device/isis/srv6.yaml
@@ -328,49 +328,6 @@ components:
           type: boolean
           default: false
           x-field-uid: 17
-        include_source_router_id:
-          description: >-
-            Controls whether Source Router ID Sub-TLVs (RFC 9350 Section 5)
-            are included in this locator's IPv6 Reachability prefix advertisement.
-            - none: No Source Router ID sub-TLV included (default).
-            - ipv4: Include IPv4 Source Router ID sub-TLV (type 11).
-            - ipv6: Include IPv6 Source Router ID sub-TLV (type 12).
-            - ipv4_and_ipv6: Include both IPv4 and IPv6 sub-TLVs.
-            Used with Flex-Algo (algorithm 128-255) to identify the originating
-            router for prefix advertisements. Applies only when
-            advertise_locator_as_prefix is true.
-          type: string
-          default: none
-          x-enum:
-            none:
-              x-field-uid: 1
-            ipv4:
-              x-field-uid: 2
-            ipv6:
-              x-field-uid: 3
-            ipv4_and_ipv6:
-              x-field-uid: 4
-          x-field-uid: 18
-        ipv4_source_router_id:
-          description: >-
-            IPv4 Source Router ID value advertised in the IPv4 Source Router
-            ID Sub-TLV (type 11, RFC 9350 Section 5). Identifies the originating
-            router for this Flex-Algo prefix advertisement. Applicable when
-            include_source_router_id is 'ipv4' or 'ipv4_and_ipv6'.
-          type: string
-          format: ipv4
-          default: "0.0.0.0"
-          x-field-uid: 19
-        ipv6_source_router_id:
-          description: >-
-            IPv6 Source Router ID value advertised in the IPv6 Source Router
-            ID Sub-TLV (type 12, RFC 9350 Section 5). Identifies the originating
-            router for this Flex-Algo prefix advertisement. Applicable when
-            include_source_router_id is 'ipv6' or 'ipv4_and_ipv6'.
-          type: string
-          format: ipv6
-          default: "::"
-          x-field-uid: 20
 
     IsisSRv6.EndSid:
       description: >-

--- a/device/isis/srv6.yaml
+++ b/device/isis/srv6.yaml
@@ -1,0 +1,812 @@
+components:
+  schemas:
+    IsisSRv6.NodeCapability:
+      description: >-
+        SRv6 Capabilities Sub-TLV (sub-TLV type 25) carried within the IS-IS
+        Router CAPABILITY TLV (TLV 242, RFC 7981). Announces that this IS-IS
+        router is an SRv6 Segment Endpoint Node and optionally supports the
+        O-bit for OAM operations. Node-level SRv6 Maximum SID Depth (MSD)
+        values are also advertised here per RFC 8491.
+        Reference: RFC 9352 Section 2.
+      type: object
+      properties:
+        o_flag:
+          description: >-
+            OAM flag (bit 1 of the Flags field in the SRv6 Capabilities Sub-TLV).
+            When set, indicates that this router supports the use of the O-bit
+            in the Segment Routing Header (SRH) for Operations, Administration
+            and Maintenance (OAM) operations as defined in RFC 9259.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        node_msds:
+          description: >-
+            Node-level SRv6 Maximum SID Depth (MSD) capabilities advertised as
+            MSD sub-TLVs within the Router Capability TLV per RFC 8491.
+            These signal the maximum SRH stack depth this router supports for
+            specific SRv6 forwarding behaviors (RFC 9352 Section 6).
+          $ref: '#/components/schemas/IsisSRv6.NodeMsd'
+          x-field-uid: 2
+        c_flag:
+          description: >-
+            Compression (uSID) flag at the node level. When set, announces that
+            this node supports Micro-SID (uSID) compressed encoding for SRv6
+            SIDs as described in RFC 9800. This flag is carried in the SRv6
+            Capabilities Sub-TLV (sub-TLV type 25) Flags field.
+            Reference: RFC 9352 Section 2, RFC 9800.
+          type: boolean
+          default: false
+          x-field-uid: 3
+
+    IsisSRv6.NodeMsd:
+      description: >-
+        Node-level SRv6 Maximum SID Depth (MSD) capabilities. Each include_*
+        flag controls whether the corresponding MSD type is advertised; the
+        paired value field sets the advertised depth.
+        MSD Type 41 = Max SL, Type 42 = Max End Pop, Type 44 = Max H.Encaps,
+        Type 45 = Max End D.
+        Reference: RFC 8491, RFC 9352 Section 6.
+      type: object
+      properties:
+        include_max_sl:
+          description: >-
+            When true, advertises the Maximum Segments Left (Max SL) MSD
+            sub-TLV (MSD-Type 41). Signals the maximum value of the Segments
+            Left (SL) field in an SRH that this router can process.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        max_sl:
+          description: >-
+            Maximum value of the Segments Left (SL) field in an SRH that
+            this router can process (MSD-Type 41, RFC 9352 Section 6).
+            A value of 0 indicates no SRH processing capability.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        include_max_end_pop_srh:
+          description: >-
+            When true, advertises the Max-End-Pop-SRH MSD sub-TLV
+            (MSD-Type 42). Signals the maximum number of SIDs in the top SRH
+            that this router can pop using PSP or USP End behaviors.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        max_end_pop_srh:
+          description: >-
+            Maximum number of SIDs in the top SRH that this router can pop
+            using PSP or USP End behaviors (MSD-Type 42, RFC 9352 Section 6).
+            A value of 0 means the router cannot apply these behaviors.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 4
+        include_max_h_encaps:
+          description: >-
+            When true, advertises the Max-H-Encaps MSD sub-TLV (MSD-Type 44).
+            Signals the maximum number of SIDs that can be pushed via the
+            H.Encaps headend encapsulation behavior.
+          type: boolean
+          default: false
+          x-field-uid: 5
+        max_h_encaps:
+          description: >-
+            Maximum number of SIDs this router can insert in the SRH using
+            the H.Encaps behavior (MSD-Type 44, RFC 9352 Section 6).
+            A value of 0 with E-flag set indicates IPinIP encapsulation
+            without SRH.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 6
+        include_max_end_d_srh:
+          description: >-
+            When true, advertises the Max-End-D-SRH MSD sub-TLV (MSD-Type 45).
+            Signals the maximum number of SIDs in the SRH when applying
+            decapsulation behaviors (End.DT4, End.DT6, End.DT46, End.DX4,
+            End.DX6).
+          type: boolean
+          default: false
+          x-field-uid: 7
+        max_end_d_srh:
+          description: >-
+            Maximum number of SIDs in the SRH that this router can handle
+            while applying decapsulation behaviors such as End.DT6, End.DT4
+            or End.DT46 (MSD-Type 45, RFC 9352 Section 6). A value of 0
+            indicates no decapsulation support.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 8
+        include_max_t_insert:
+          description: >-
+            When true, advertises the Maximum T.Insert MSD sub-TLV
+            (MSD-Type 43). Signals the maximum number of SIDs that can be
+            inserted as a new SRH using the T.Insert headend behavior
+            (RFC 8986 Section 5.3). Used for transit insertion of SRv6 policy.
+            Reference: RFC 8491.
+          type: boolean
+          default: false
+          x-field-uid: 9
+        max_t_insert:
+          description: >-
+            Maximum number of SIDs this router can insert using the T.Insert
+            behavior (MSD-Type 43, RFC 8491). A value of 0 indicates T.Insert
+            is not supported.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 10
+
+    IsisSRv6.Locator:
+      description: >-
+        IS-IS SRv6 Locator TLV (TLV type 27), as defined in RFC 9352 Section 7.1.
+        Advertises an SRv6 locator prefix that identifies this SRv6-capable
+        router and binds it to a specific IGP algorithm (standard SPF or
+        Flex-Algo per RFC 9350). One Locator TLV is required per
+        topology/algorithm combination.
+        The SRv6 SID space is structured as: Locator prefix | Function | Argument,
+        where the locator prefix is routable and the function identifies the
+        specific endpoint behavior (RFC 8986 Section 3.1).
+      type: object
+      required: [locator, name]
+      properties:
+        name:
+          x-include: ../../common/common.yaml#/components/schemas/Named.Object/properties/name
+          x-field-uid: 1
+        locator:
+          description: >-
+            The SRv6 locator IPv6 prefix for this TLV. This routable IPv6
+            prefix identifies the advertising node within the SRv6 domain.
+            All SRv6 SIDs advertised under this locator must be allocated
+            from this prefix.
+          type: string
+          format: ipv6
+          x-field-uid: 2
+        prefix_length:
+          description: >-
+            Number of significant bits in the locator field (1-128).
+            Defines the length of the SRv6 locator prefix. The combined
+            bit budget of the locator, function, and argument fields must
+            not exceed 128 bits (RFC 9352 Section 3.1).
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 128
+          default: 64
+          x-field-uid: 3
+        algorithm:
+          description: >-
+            IGP Algorithm identifier for this locator (RFC 8665).
+            0 = standard SPF, 1 = Strict SPF.
+            Values 128-255 represent Flexible Algorithms (Flex-Algo) as
+            defined in RFC 9350. The algorithm determines the path
+            computation method used to reach this locator. One Locator TLV
+            is required per algorithm binding.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          default: 0
+          x-field-uid: 4
+        metric:
+          description: >-
+            The metric (cost) associated with this SRv6 locator prefix.
+            Uses the same semantics as IS-IS Extended IP reachability metric
+            (RFC 9352 Section 7.1).
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 0
+          x-field-uid: 5
+        redistribution_type:
+          description: >-
+            Controls the Up/Down redistribution bit for this locator.
+            'up' = normal advertisement (default);
+            'down' = the locator has been leaked from Level 2 to Level 1
+            (RFC 5305). Must be consistent with the d_flag setting.
+          type: string
+          default: up
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          x-field-uid: 6
+        d_flag:
+          description: >-
+            Down bit (D-flag, bit 0 of the Flags field in the SRv6 Locator TLV).
+            MUST be set when the locator is leaked from Level 2 to Level 1 to
+            prevent routing loops. Locator TLVs with the D-flag set MUST NOT
+            be re-advertised from L1 to L2 (RFC 9352 Section 7.1).
+          type: boolean
+          default: false
+          x-field-uid: 7
+        mt_id:
+          description: >-
+            Multi-Topology Identifier (MT-ID) for this locator advertisement.
+            Specifies which IS-IS topology this locator belongs to.
+            0 = default topology. Valid range 0-4095 (RFC 5120).
+          type: integer
+          format: uint32
+          maximum: 4095
+          default: 0
+          x-field-uid: 8
+        end_sids:
+          description: >-
+            List of SRv6 End SID Sub-TLVs (sub-TLV type 5) associated with
+            this locator. Each End SID advertises a locally instantiated
+            node-local SRv6 SID, its endpoint behavior (End, End.DT4,
+            End.DT6, End.DT46 and their flavor variants), and optional
+            SID structure information (RFC 9352 Section 7.2).
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisSRv6.EndSid'
+          x-field-uid: 9
+        advertise_locator_as_prefix:
+          description: >-
+            When true, the locator prefix is also advertised as an IS-IS IPv6
+            Reachability prefix (TLV 236/237) in addition to the SRv6 Locator
+            TLV (type 27). This enables non-SRv6-capable routers to route
+            toward the locator as an ordinary IPv6 prefix. Typically suppressed
+            automatically when algorithm is a Flex-Algo value (128-255).
+          type: boolean
+          default: true
+          x-field-uid: 10
+        route_metric:
+          description: >-
+            Metric value used when advertising the locator prefix in the IPv6
+            Reachability TLV (TLV 236/237). Applies only when
+            advertise_locator_as_prefix is true.
+          type: integer
+          format: uint32
+          maximum: 16777215
+          default: 0
+          x-field-uid: 11
+        route_origin:
+          description: >-
+            Origin type for the locator prefix when advertised in the IPv6
+            Reachability TLV (TLV 236/237).
+            'internal' = intra-area prefix (default);
+            'external' = redistributed from another protocol.
+            Applies only when advertise_locator_as_prefix is true.
+          type: string
+          default: internal
+          x-enum:
+            internal:
+              x-field-uid: 1
+            external:
+              x-field-uid: 2
+          x-field-uid: 12
+        prefix_attr_enabled:
+          description: >-
+            When true, includes the Prefix Attribute Flags Sub-TLV (sub-TLV
+            type 4, RFC 7794) in the locator's IPv6 Reachability advertisement.
+            Enables advertising X, R, N, and A flags for this locator prefix.
+            Applies only when advertise_locator_as_prefix is true.
+          type: boolean
+          default: false
+          x-field-uid: 13
+        x_flag:
+          description: >-
+            External prefix flag (bit 0 of Prefix Attribute Flags sub-TLV,
+            RFC 7794). When set, indicates this locator prefix was redistributed
+            from another protocol. Applicable only when prefix_attr_enabled
+            is true.
+          type: boolean
+          default: false
+          x-field-uid: 14
+        r_flag:
+          description: >-
+            Re-advertisement flag (bit 1 of Prefix Attribute Flags sub-TLV,
+            RFC 7794). When set, indicates this locator prefix has been leaked
+            between IS-IS levels. Applicable only when prefix_attr_enabled
+            is true.
+          type: boolean
+          default: false
+          x-field-uid: 15
+        n_flag:
+          description: >-
+            Node flag (bit 2 of Prefix Attribute Flags sub-TLV, RFC 7794).
+            When set, indicates this prefix identifies the advertising router
+            (e.g., a loopback or router-ID prefix). Applicable only when
+            prefix_attr_enabled is true.
+          type: boolean
+          default: false
+          x-field-uid: 16
+        a_flag:
+          description: >-
+            Anycast flag (bit 5 of Prefix Attribute Flags sub-TLV, RFC 7794).
+            When set, indicates this prefix is an anycast prefix shared across
+            multiple routers. Applicable only when prefix_attr_enabled is true.
+          type: boolean
+          default: false
+          x-field-uid: 17
+        include_source_router_id:
+          description: >-
+            Controls whether Source Router ID Sub-TLVs (RFC 9350 Section 5)
+            are included in this locator's IPv6 Reachability prefix advertisement.
+            - none: No Source Router ID sub-TLV included (default).
+            - ipv4: Include IPv4 Source Router ID sub-TLV (type 11).
+            - ipv6: Include IPv6 Source Router ID sub-TLV (type 12).
+            - ipv4_and_ipv6: Include both IPv4 and IPv6 sub-TLVs.
+            Used with Flex-Algo (algorithm 128-255) to identify the originating
+            router for prefix advertisements. Applies only when
+            advertise_locator_as_prefix is true.
+          type: string
+          default: none
+          x-enum:
+            none:
+              x-field-uid: 1
+            ipv4:
+              x-field-uid: 2
+            ipv6:
+              x-field-uid: 3
+            ipv4_and_ipv6:
+              x-field-uid: 4
+          x-field-uid: 18
+        ipv4_source_router_id:
+          description: >-
+            IPv4 Source Router ID value advertised in the IPv4 Source Router
+            ID Sub-TLV (type 11, RFC 9350 Section 5). Identifies the originating
+            router for this Flex-Algo prefix advertisement. Applicable when
+            include_source_router_id is 'ipv4' or 'ipv4_and_ipv6'.
+          type: string
+          format: ipv4
+          default: "0.0.0.0"
+          x-field-uid: 19
+        ipv6_source_router_id:
+          description: >-
+            IPv6 Source Router ID value advertised in the IPv6 Source Router
+            ID Sub-TLV (type 12, RFC 9350 Section 5). Identifies the originating
+            router for this Flex-Algo prefix advertisement. Applicable when
+            include_source_router_id is 'ipv6' or 'ipv4_and_ipv6'.
+          type: string
+          format: ipv6
+          default: "::"
+          x-field-uid: 20
+
+    IsisSRv6.EndSid:
+      description: >-
+        SRv6 End SID Sub-TLV (sub-TLV type 5) carried within the SRv6 Locator
+        TLV (TLV type 27). Advertises a locally instantiated node-local SRv6
+        SID and its associated endpoint behavior. The SID value must be
+        allocated from within the parent locator's prefix.
+        Valid behaviors for node-local End SIDs are End (with PSP/USP/USD
+        flavor variants) and decapsulation behaviors (End.DT4, End.DT6,
+        End.DT46).
+        Reference: RFC 9352 Section 7.2, RFC 8986.
+      type: object
+      properties:
+        sid:
+          description: >-
+            The 128-bit SRv6 SID value in IPv6 address format. Must be
+            allocated from within the parent locator's prefix space, following
+            the structure: Locator | Function | Argument (RFC 8986 Section 3.1).
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        endpoint_behavior:
+          description: >-
+            The endpoint behavior for this SRv6 End SID, encoded as a 2-octet
+            behavior codepoint (RFC 8986 Section 7.4). Defines how the router
+            processes packets arriving with this SID as the Active Segment.
+            Valid node-level behaviors for End SID Sub-TLV type 5 are End
+            variants (with PSP/USP/USD flavors) and decapsulation behaviors.
+          type: string
+          default: end
+          x-enum:
+            end:
+              description: >-
+                End (RFC 8986 codepoint 1). Basic node SID; decrements
+                Segments Left and performs a FIB lookup in the default VRF
+                using the next SID as the destination address.
+              x-field-uid: 1
+            end_with_psp:
+              description: >-
+                End with Penultimate Segment Pop (PSP) flavor (RFC 8986
+                codepoint 2). At the penultimate segment the SRH is removed
+                before forwarding to the ultimate endpoint node.
+              x-field-uid: 2
+            end_with_usp:
+              description: >-
+                End with Ultimate Segment Pop (USP) flavor (RFC 8986
+                codepoint 3). At the ultimate endpoint the SRH is removed
+                before upper-layer protocol processing.
+              x-field-uid: 3
+            end_with_psp_usp:
+              description: >-
+                End with PSP and USP flavors combined (RFC 8986 codepoint 4).
+              x-field-uid: 4
+            end_with_usd:
+              description: >-
+                End with Ultimate Segment Decapsulation (USD) flavor
+                (RFC 8986 codepoint 28). Removes the outer IPv6 header at
+                the ultimate segment and forwards the inner packet.
+              x-field-uid: 5
+            end_with_psp_usd:
+              description: >-
+                End with PSP and USD flavors combined (RFC 8986 codepoint 29).
+              x-field-uid: 6
+            end_with_usp_usd:
+              description: >-
+                End with USP and USD flavors combined (RFC 8986 codepoint 30).
+              x-field-uid: 7
+            end_with_psp_usp_usd:
+              description: >-
+                End with PSP, USP and USD flavors combined (RFC 8986
+                codepoint 31).
+              x-field-uid: 8
+            end_dt4:
+              description: >-
+                End.DT4 decapsulation and IPv4 table lookup (RFC 8986
+                codepoint 19). Decapsulates the outer IPv6 header and
+                performs an IPv4 FIB lookup in a specific VRF table T.
+                Used for IPv4 L3VPN services over SRv6.
+              x-field-uid: 9
+            end_dt6:
+              description: >-
+                End.DT6 decapsulation and IPv6 table lookup (RFC 8986
+                codepoint 18). Decapsulates the outer IPv6 header and
+                performs an IPv6 FIB lookup in a specific VRF table T.
+                Used for IPv6 L3VPN services over SRv6.
+              x-field-uid: 10
+            end_dt46:
+              description: >-
+                End.DT46 decapsulation and dual-stack IP table lookup
+                (RFC 8986 codepoint 20). Decapsulates and performs FIB
+                lookup for both IPv4 and IPv6 inner packets in the
+                appropriate VRF table. Used for dual-stack L3VPN over SRv6.
+              x-field-uid: 11
+          x-field-uid: 2
+        c_flag:
+          description: >-
+            Compression (uSID) flag. When set, indicates that this SID
+            supports Micro-SID (uSID) compressed encoding, enabling multiple
+            node segments to be packed within a single 128-bit SID carrier
+            using the Argument field. Requires the SRv6 SID Structure
+            Sub-Sub-TLV to be included to describe the bit allocation.
+            Reference: draft-filsfils-spring-net-pgm-extension-srv6-usid,
+            RFC 9800.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        sid_structure:
+          description: >-
+            SRv6 SID Structure Sub-Sub-TLV (type 1) describing the internal
+            bit-field decomposition of this SID value. Specifies the
+            Locator Block, Locator Node, Function, and Argument lengths in
+            bits. The sum of all four lengths must not exceed 128.
+            When present, the sub-sub-TLV is included in the advertisement.
+            Typically set when c_flag is true (RFC 9352 Section 9).
+          $ref: '#/components/schemas/IsisSRv6.SidStructure'
+          x-field-uid: 4
+
+    IsisSRv6.AdjSid:
+      description: >-
+        SRv6 Adjacency SID Sub-TLV for IS-IS interfaces. Point-to-point
+        adjacencies use End.X SID Sub-TLV (sub-TLV type 43); LAN adjacencies
+        use LAN End.X SID Sub-TLV (sub-TLV type 44). The End.X SID binds a
+        128-bit SRv6 SID to a specific outgoing interface and next-hop,
+        enabling traffic steering across a specific L3 adjacency.
+        Valid behaviors include End.X variants (with PSP/USP/USD flavors) and
+        cross-connect decapsulation behaviors (End.DX4, End.DX6).
+        Reference: RFC 9352 Sections 8.1-8.2, RFC 8986 Section 4.3.
+      type: object
+      properties:
+        sid:
+          description: >-
+            The 128-bit SRv6 SID value in IPv6 address format for this
+            adjacency. Must be allocated from the advertising node's locator
+            prefix space.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        endpoint_behavior:
+          description: >-
+            The endpoint behavior for this adjacency SID, encoded as a 2-octet
+            behavior codepoint (RFC 8986 Section 7.4). Valid adjacency-level
+            behaviors for End.X SID Sub-TLV types 43/44 are End.X variants
+            (with PSP/USP/USD flavors) and per-CE cross-connect decapsulation
+            behaviors (End.DX4, End.DX6).
+          type: string
+          default: end_x
+          x-enum:
+            end_x:
+              description: >-
+                End.X adjacency L3 cross-connect (RFC 8986 codepoint 5).
+                Decrements Segments Left and forwards the packet over the
+                specific adjacency set J to the next-hop node.
+              x-field-uid: 1
+            end_x_with_psp:
+              description: >-
+                End.X with Penultimate Segment Pop (PSP) flavor (RFC 8986
+                codepoint 6). Removes the SRH at the penultimate node before
+                forwarding over adjacency J.
+              x-field-uid: 2
+            end_x_with_usp:
+              description: >-
+                End.X with Ultimate Segment Pop (USP) flavor (RFC 8986
+                codepoint 7). Removes the SRH at the ultimate adjacency
+                endpoint before upper-layer processing.
+              x-field-uid: 3
+            end_x_with_psp_usp:
+              description: >-
+                End.X with PSP and USP flavors combined (RFC 8986 codepoint 8).
+              x-field-uid: 4
+            end_x_with_usd:
+              description: >-
+                End.X with Ultimate Segment Decapsulation (USD) flavor
+                (RFC 8986 codepoint 32). Removes outer IPv6 header at the
+                ultimate adjacency endpoint.
+              x-field-uid: 5
+            end_x_with_psp_usd:
+              description: >-
+                End.X with PSP and USD flavors combined (RFC 8986
+                codepoint 33).
+              x-field-uid: 6
+            end_x_with_usp_usd:
+              description: >-
+                End.X with USP and USD flavors combined (RFC 8986
+                codepoint 34).
+              x-field-uid: 7
+            end_x_with_psp_usp_usd:
+              description: >-
+                End.X with PSP, USP and USD flavors combined (RFC 8986
+                codepoint 35).
+              x-field-uid: 8
+            end_dx4:
+              description: >-
+                End.DX4 per-CE IPv4 cross-connect (RFC 8986 codepoint 17).
+                Decapsulates the outer IPv6 header and forwards the inner
+                IPv4 packet to a CE peer over adjacency J. Used for
+                IPv4 VPWS and per-CE L3VPN services over SRv6.
+              x-field-uid: 9
+            end_dx6:
+              description: >-
+                End.DX6 per-CE IPv6 cross-connect (RFC 8986 codepoint 16).
+                Decapsulates the outer IPv6 header and forwards the inner
+                IPv6 packet to a CE peer over adjacency J. Used for
+                IPv6 VPWS and per-CE L3VPN services over SRv6.
+              x-field-uid: 10
+          x-field-uid: 2
+        b_flag:
+          description: >-
+            Backup flag (B-flag, bit 0). When set, the End.X SID is eligible
+            for IP Fast-ReRoute (IP-FRR) protection, indicating a backup
+            adjacency that can protect traffic when the primary adjacency
+            fails (RFC 9352 Section 8.1).
+          type: boolean
+          default: false
+          x-field-uid: 3
+        s_flag:
+          description: >-
+            Set flag (S-flag, bit 1). When set, the End.X SID refers to a
+            set of adjacencies (e.g., parallel links, ECMP group). The same
+            SID value may be assigned to multiple adjacencies forming the
+            set (RFC 9352 Section 8.1).
+          type: boolean
+          default: false
+          x-field-uid: 4
+        p_flag:
+          description: >-
+            Persistent flag (P-flag, bit 2). When set, the End.X SID value
+            is persistently allocated and remains consistent across router
+            restarts and interface flap events (RFC 9352 Section 8.1).
+          type: boolean
+          default: false
+          x-field-uid: 5
+        weight:
+          description: >-
+            Weight for load balancing across adjacencies sharing the same
+            End.X SID (applicable when S-flag is set). Traffic is distributed
+            proportionally across the adjacency set according to the weight
+            values (RFC 9352 Section 8.1).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          default: 0
+          x-field-uid: 6
+        algorithm:
+          description: >-
+            IGP algorithm associated with this adjacency SID (RFC 8665).
+            0 = standard SPF, 1 = Strict SPF, 128-255 = Flex-Algo (RFC 9350).
+            Binds the adjacency SID to the corresponding topology or
+            path computation algorithm.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          default: 0
+          x-field-uid: 7
+        c_flag:
+          description: >-
+            Compression (uSID) flag. When set, indicates this adjacency SID
+            supports Micro-SID (uSID) compressed encoding, allowing multiple
+            adjacency micro-segments to be stacked within a single 128-bit
+            SID carrier using the Argument field.
+          type: boolean
+          default: false
+          x-field-uid: 8
+        sid_structure:
+          description: >-
+            SRv6 SID Structure Sub-Sub-TLV (type 1) describing the internal
+            bit-field decomposition of this adjacency SID. Specifies the
+            Locator Block, Locator Node, Function, and Argument lengths in
+            bits. When present, the sub-sub-TLV is included in the advertisement.
+            Typically set when c_flag is true (RFC 9352 Section 9).
+          $ref: '#/components/schemas/IsisSRv6.SidStructure'
+          x-field-uid: 9
+
+    IsisSRv6.SidStructure:
+      description: >-
+        SRv6 SID Structure Sub-Sub-TLV (type 1), carried within SRv6 SID
+        Sub-TLVs (End SID type 5, End.X SID type 43/44). Describes the internal
+        bit-field decomposition of the SRv6 SID value so that receiving routers
+        can interpret each field independently.
+        The four length fields (lb_length + ln_length + function_length +
+        argument_length) MUST NOT exceed 128 bits.
+        Required when advertising Micro-SID (uSID) SIDs to describe the
+        compressed encoding.
+        Example for common uSID F3216 format:
+          lb_length=32, ln_length=16, function_length=16, argument_length=0
+        Reference: RFC 9352 Section 9, RFC 9800.
+      type: object
+      properties:
+        locator_block_length:
+          description: >-
+            Number of bits in the Locator Block (LB) field of the SID.
+            The Locator Block is the common IPv6 prefix shared across all
+            SIDs within the same SRv6 domain block (e.g., 32 bits in the
+            uSID F3216 format). Minimum value 1.
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 128
+          default: 32
+          x-field-uid: 1
+        locator_node_length:
+          description: >-
+            Number of bits in the Locator Node (LN) field of the SID.
+            Identifies the specific node within the Locator Block
+            (e.g., 16 bits in the uSID F3216 format, providing up to
+            65534 addressable nodes per domain block).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 128
+          default: 16
+          x-field-uid: 2
+        function_length:
+          description: >-
+            Number of bits in the Function field of the SID. Identifies the
+            specific endpoint behavior instantiated on this node
+            (e.g., 16 bits in the uSID F3216 format, supporting up to
+            65534 distinct functions per node).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 128
+          default: 16
+          x-field-uid: 3
+        argument_length:
+          description: >-
+            Number of bits in the Argument field of the SID. Carries
+            additional per-behavior information such as VPN table identifiers
+            or compressed next-SID encodings for Micro-SID stacking. Set to
+            0 for standard SIDs that carry no argument. When non-zero in a
+            uSID context, enables packing multiple micro-segment identifiers
+            within a single 128-bit SID carrier (RFC 9800).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 128
+          default: 0
+          x-field-uid: 4
+
+    IsisSRv6.LinkMsd:
+      description: >-
+        Link-level SRv6 Maximum SID Depth (MSD) capabilities advertised per
+        IS-IS interface. Signals the SRv6 SRH processing capacity specific
+        to this link, which may differ from the node-level MSD values.
+        Advertised as MSD sub-TLVs within the neighbor TLVs per RFC 8491.
+        Reference: RFC 8491, RFC 9352 Section 6.
+      type: object
+      properties:
+        include_max_sl:
+          description: >-
+            When true, advertises the Maximum Segments Left (Max SL) MSD
+            (MSD-Type 41) at the link level. Signals the maximum SL value
+            in an SRH that can be processed on this interface.
+          type: boolean
+          default: false
+          x-field-uid: 1
+        max_sl:
+          description: >-
+            Maximum value of the Segments Left (SL) field in an SRH that
+            this interface can process (MSD-Type 41). A value of 0 indicates
+            no SRH processing support on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 2
+        include_max_end_pop_srh:
+          description: >-
+            When true, advertises the Max-End-Pop-SRH MSD (MSD-Type 42) at
+            the link level.
+          type: boolean
+          default: false
+          x-field-uid: 3
+        max_end_pop_srh:
+          description: >-
+            Maximum number of SIDs in the top SRH for PSP or USP End
+            behaviors on this interface (MSD-Type 42). A value of 0
+            indicates these behaviors are not supported on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 4
+        include_max_h_encaps:
+          description: >-
+            When true, advertises the Max-H-Encaps MSD (MSD-Type 44) at
+            the link level.
+          type: boolean
+          default: false
+          x-field-uid: 5
+        max_h_encaps:
+          description: >-
+            Maximum number of SIDs for H.Encaps behavior on this interface
+            (MSD-Type 44). A value of 0 indicates H.Encaps is not supported
+            on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 6
+        include_max_end_d_srh:
+          description: >-
+            When true, advertises the Max-End-D-SRH MSD (MSD-Type 45) at
+            the link level.
+          type: boolean
+          default: false
+          x-field-uid: 7
+        max_end_d_srh:
+          description: >-
+            Maximum number of SIDs in the SRH for decapsulation behaviors
+            (End.DT4/DT6/DT46/DX4/DX6) on this interface (MSD-Type 45).
+            A value of 0 indicates decapsulation behaviors are not supported
+            on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 8
+        include_max_t_insert:
+          description: >-
+            When true, advertises the Maximum T.Insert MSD (MSD-Type 43) at
+            the link level. Signals the maximum number of SIDs that can be
+            inserted via the T.Insert headend behavior on this specific
+            interface.
+            Reference: RFC 8491.
+          type: boolean
+          default: false
+          x-field-uid: 9
+        max_t_insert:
+          description: >-
+            Maximum number of SIDs insertable via T.Insert behavior on this
+            interface (MSD-Type 43, RFC 8491). A value of 0 indicates T.Insert
+            is not supported on this link.
+          type: integer
+          format: uint32
+          maximum: 255
+          default: 0
+          x-field-uid: 10

--- a/project_isis_srv6.md
+++ b/project_isis_srv6.md
@@ -1,0 +1,303 @@
+# ISIS SRv6 OTG Model — Work Record
+
+**Branch:** `isis-srv6`  
+**Working directory:** `c:/Users/suryjana/athena/models`  
+**Build status:** PASSING ✓ (as of 2026-04-21, post gap-fill implementation)
+
+## How to Run the Build
+
+Always use the virtual environment python, not the system python:
+
+```
+.venv/Scripts/python.exe ./build.py
+```
+
+The system python (`C:\Program Files\Python312\python.exe`) has an older openapiart installed that has a bug in `_write_openapi_list` — it fails with `KeyError: '$ref'` for array-type choice properties. The `.venv` openapiart already handles this correctly. **Do not modify `openapiart/generator.py`** — the fix is simply to use the venv.
+
+## Background & Goal
+
+The existing OTG ISIS model (in `device/isis/`) covered only SR-MPLS (RFC 8667): SRGB, SRLB, Prefix-SIDs, Adjacency-SIDs with MPLS label values. No SRv6 existed anywhere in the ISIS schemas. The goal was to add a full OTG model for IS-IS Segment Routing over IPv6 (SRv6) per RFC 9352, suitable for IxNetwork implementation.
+
+## Research Sources Used
+
+| Source | Key Findings |
+|--------|-------------|
+| RFC 9352 | IS-IS SRv6 TLV/Sub-TLV definitions: Locator TLV (type 27), SRv6 Caps Sub-TLV (type 25), End SID Sub-TLV (type 5), End.X SID Sub-TLV (type 43/44), SID Structure Sub-Sub-TLV (type 1) |
+| RFC 8986 | SRv6 endpoint behavior codepoints: End (1-4,28-31), End.X (5-8,32-35), End.DX4/DX6 (17/16), End.DT4/DT6/DT46 (19/18/20) |
+| RFC 8491 | MSD sub-TLV types: 41=Max SL, 42=Max End Pop, 43=Max T.Insert, 44=Max H.Encaps, 45=Max End D |
+| RFC 7794 | IS-IS Prefix Attribute Flags Sub-TLV (sub-TLV type 4): X (External), R (Re-advertisement), N (Node), A (Anycast) flags |
+| RFC 9350 | Flex-Algo IDs 128-255 in `algorithm` field; Source Router ID Sub-TLVs type 11 (IPv4) and type 12 (IPv6) for Flex-Algo prefix identification |
+| RFC 9259 | O-flag in SRv6 Capabilities Sub-TLV for OAM support |
+| RFC 9800 | uSID/Micro-SID: Argument field in SID Structure sub-sub-TLV used for compressed segment stacking |
+| IxNetwork RESTpy | Class hierarchy: `IsisL3Router` → `IsisSRv6LocatorEntryList` → `IsisSRv6EndSIDList`; `IsisL3` → `IsisSRv6AdjSIDList`; attribute names for `CFlag` (uSID), `EndPointFunction`, `LocatorBlockLength`, `LocatorNodeLength`, `FunctionLength`, `ArgumentLength`, `IncludeSRv6SIDStructureSubSubTlv`, all MSD `Include*` and `Max*` pairs |
+| OpenConfig | IETF draft `draft-ietf-lsr-isis-srv6-yang-07` used for YANG hierarchy reference; published OpenConfig models (as of Apr 2026) do NOT yet include SRv6 for IS-IS |
+
+---
+
+## Files Changed
+
+### 1. `device/isis/srv6.yaml` — **NEW FILE**
+
+All SRv6 configuration schemas. Contains 7 schemas.
+
+#### `IsisSRv6.NodeCapability`
+Maps to: SRv6 Capabilities Sub-TLV (sub-TLV type 25 in TLV 242)  
+RFC: RFC 9352 Section 2
+
+| Field | UID | Type | Default | Notes |
+|-------|-----|------|---------|-------|
+| `o_flag` | 1 | boolean | false | OAM flag; router supports O-bit in SRH (RFC 9259) |
+| `node_msds` | 2 | object | — | → `IsisSRv6.NodeMsd` |
+| `c_flag` | 3 | boolean | false | Compression/uSID flag; node supports Micro-SID encoding (RFC 9800) |
+
+#### `IsisSRv6.NodeMsd`
+Maps to: MSD sub-TLVs in Router Capability TLV  
+RFC: RFC 8491, RFC 9352 Section 6
+
+| Field | UID | Type | Default | MSD Type |
+|-------|-----|------|---------|----------|
+| `include_max_sl` | 1 | boolean | false | controls type 41 advertisement |
+| `max_sl` | 2 | uint32 (max 255) | 0 | MSD-Type 41: Max Segments Left |
+| `include_max_end_pop_srh` | 3 | boolean | false | controls type 42 advertisement |
+| `max_end_pop_srh` | 4 | uint32 (max 255) | 0 | MSD-Type 42: Max End Pop |
+| `include_max_h_encaps` | 5 | boolean | false | controls type 44 advertisement |
+| `max_h_encaps` | 6 | uint32 (max 255) | 0 | MSD-Type 44: Max H.Encaps |
+| `include_max_end_d_srh` | 7 | boolean | false | controls type 45 advertisement |
+| `max_end_d_srh` | 8 | uint32 (max 255) | 0 | MSD-Type 45: Max End D |
+| `include_max_t_insert` | 9 | boolean | false | controls type 43 advertisement |
+| `max_t_insert` | 10 | uint32 (max 255) | 0 | MSD-Type 43: Max T.Insert (transit SRH insertion) |
+
+#### `IsisSRv6.Locator`
+Maps to: SRv6 Locator TLV (TLV type 27)  
+RFC: RFC 9352 Section 7.1  
+Required fields: `locator`, `name` (NOT `prefix_length` — openapiart prohibits a field from being both `required` and having a `default` value)
+
+| Field | UID | Type | Default | Notes |
+|-------|-----|------|---------|-------|
+| `name` | 1 | string | — | x-include Named.Object; globally unique |
+| `locator` | 2 | ipv6 | — | IPv6 locator prefix |
+| `prefix_length` | 3 | uint32 (1-128) | 64 | bits in locator field |
+| `algorithm` | 4 | uint32 (0-255) | 0 | 0=SPF, 1=Strict SPF, 128-255=Flex-Algo |
+| `metric` | 5 | uint32 (max 16777215) | 0 | locator metric |
+| `redistribution_type` | 6 | enum: up/down | up | Up/Down redistribution bit |
+| `d_flag` | 7 | boolean | false | Down bit; set when leaked L2→L1 |
+| `mt_id` | 8 | uint32 (max 4095) | 0 | Multi-Topology ID; 0=default |
+| `end_sids` | 9 | array | — | → `IsisSRv6.EndSid[]` |
+| `advertise_locator_as_prefix` | 10 | boolean | true | Also advertise locator in TLV 236/237; auto-suppressed for Flex-Algo |
+| `route_metric` | 11 | uint32 (max 16777215) | 0 | Metric for TLV 236/237 prefix advertisement |
+| `route_origin` | 12 | enum: internal/external | internal | Origin type for TLV 236/237 advertisement |
+| `prefix_attr_enabled` | 13 | boolean | false | Include Prefix Attribute Flags Sub-TLV (RFC 7794) |
+| `x_flag` | 14 | boolean | false | External prefix flag (Prefix Attr Flags bit 0, RFC 7794) |
+| `r_flag` | 15 | boolean | false | Re-advertisement flag (bit 1, RFC 7794) |
+| `n_flag` | 16 | boolean | false | Node flag (bit 2, RFC 7794) |
+| `a_flag` | 17 | boolean | false | Anycast flag (bit 5, RFC 7794) |
+| `include_source_router_id` | 18 | enum: none/ipv4/ipv6/ipv4_and_ipv6 | none | Source Router ID sub-TLV inclusion (RFC 9350 Section 5) |
+| `ipv4_source_router_id` | 19 | ipv4 | "0.0.0.0" | IPv4 Source Router ID sub-TLV (type 11, RFC 9350) |
+| `ipv6_source_router_id` | 20 | ipv6 | "::" | IPv6 Source Router ID sub-TLV (type 12, RFC 9350) |
+
+#### `IsisSRv6.EndSid`
+Maps to: SRv6 End SID Sub-TLV (sub-TLV type 5)  
+RFC: RFC 9352 Section 7.2, RFC 8986
+
+| Field | UID | Type | Default | Notes |
+|-------|-----|------|---------|-------|
+| `sid` | 1 | ipv6 | — | 128-bit SRv6 SID value |
+| `endpoint_behavior` | 2 | enum (11 values) | end | see table below |
+| `c_flag` | 3 | boolean | false | Compression/uSID flag (IxNetwork `CFlag`) |
+| `include_srv6_sid_structure_tlv` | 4 | boolean | false | include sub-sub-TLV type 1 |
+| `sid_structure` | 5 | object | — | → `IsisSRv6.SidStructure` |
+
+endpoint_behavior enum values (IsisSRv6.EndSid):
+
+| Value | UID | RFC 8986 Codepoint |
+|-------|-----|-------------------|
+| `end` | 1 | 1 |
+| `end_with_psp` | 2 | 2 |
+| `end_with_usp` | 3 | 3 |
+| `end_with_psp_usp` | 4 | 4 |
+| `end_with_usd` | 5 | 28 |
+| `end_with_psp_usd` | 6 | 29 |
+| `end_with_usp_usd` | 7 | 30 |
+| `end_with_psp_usp_usd` | 8 | 31 |
+| `end_dt4` | 9 | 19 |
+| `end_dt6` | 10 | 18 |
+| `end_dt46` | 11 | 20 |
+
+#### `IsisSRv6.AdjSid`
+Maps to: End.X SID Sub-TLV (sub-TLV type 43 P2P, type 44 LAN)  
+RFC: RFC 9352 Sections 8.1-8.2, RFC 8986 Section 4.3
+
+| Field | UID | Type | Default | Notes |
+|-------|-----|------|---------|-------|
+| `sid` | 1 | ipv6 | — | 128-bit SRv6 adjacency SID |
+| `endpoint_behavior` | 2 | enum (10 values) | end_x | see table below |
+| `b_flag` | 3 | boolean | false | Backup flag; eligible for IP-FRR |
+| `s_flag` | 4 | boolean | false | Set flag; refers to adjacency set |
+| `p_flag` | 5 | boolean | false | Persistent flag; stable across restart |
+| `weight` | 6 | uint32 (0-255) | 0 | Load-balancing weight (used when S-flag set) |
+| `algorithm` | 7 | uint32 (0-255) | 0 | IGP algorithm binding |
+| `c_flag` | 8 | boolean | false | Compression/uSID flag |
+| `include_srv6_sid_structure_tlv` | 9 | boolean | false | include sub-sub-TLV type 1 |
+| `sid_structure` | 10 | object | — | → `IsisSRv6.SidStructure` |
+
+endpoint_behavior enum values (IsisSRv6.AdjSid):
+
+| Value | UID | RFC 8986 Codepoint |
+|-------|-----|-------------------|
+| `end_x` | 1 | 5 |
+| `end_x_with_psp` | 2 | 6 |
+| `end_x_with_usp` | 3 | 7 |
+| `end_x_with_psp_usp` | 4 | 8 |
+| `end_x_with_usd` | 5 | 32 |
+| `end_x_with_psp_usd` | 6 | 33 |
+| `end_x_with_usp_usd` | 7 | 34 |
+| `end_x_with_psp_usp_usd` | 8 | 35 |
+| `end_dx4` | 9 | 17 |
+| `end_dx6` | 10 | 16 |
+
+#### `IsisSRv6.SidStructure`
+Maps to: SRv6 SID Structure Sub-Sub-TLV (type 1)  
+RFC: RFC 9352 Section 9, RFC 9800 (uSID/Micro-SID)  
+Constraint: sum of all four lengths ≤ 128  
+Default values represent uSID F3216 format (most common deployment)
+
+| Field | UID | Type | Default | Notes |
+|-------|-----|------|---------|-------|
+| `locator_block_length` | 1 | uint32 (0-128) | 32 | LB bits; common prefix of all SIDs in domain |
+| `locator_node_length` | 2 | uint32 (0-128) | 16 | LN bits; node identifier within domain |
+| `function_length` | 3 | uint32 (0-128) | 16 | Function bits; endpoint behavior identifier |
+| `argument_length` | 4 | uint32 (0-128) | 0 | Arg bits; 0 for standard SIDs, >0 for uSID stacking |
+
+#### `IsisSRv6.LinkMsd`
+Maps to: Link-level MSD sub-TLVs in TLV 22/222  
+RFC: RFC 8491, RFC 9352 Section 6  
+Same 4 MSD type pairs as `IsisSRv6.NodeMsd` but scoped to a specific interface
+
+| Field | UID | MSD Type |
+|-------|-----|----------|
+| `include_max_sl` | 1 | — |
+| `max_sl` | 2 | 41 |
+| `include_max_end_pop_srh` | 3 | — |
+| `max_end_pop_srh` | 4 | 42 |
+| `include_max_h_encaps` | 5 | — |
+| `max_h_encaps` | 6 | 44 |
+| `include_max_end_d_srh` | 7 | — |
+| `max_end_d_srh` | 8 | 45 |
+| `include_max_t_insert` | 9 | — |
+| `max_t_insert` | 10 | 43 |
+
+---
+
+### 2. `device/isis/segmentrouting.yaml` — **MODIFIED**
+
+#### Fields added to `Isis.SegmentRouting`
+
+| Field | UID | Type | Notes |
+|-------|-----|------|-------|
+| `srv6_locators` | 2 | array → `IsisSRv6.Locator[]` | SRv6 Locator TLV (type 27) list; one per algorithm/topology |
+
+(uid 1 = existing `router_capability`)
+
+#### Fields added to `Isis.RouterCapability`
+
+| Field | UID | Type | Notes |
+|-------|-----|------|-------|
+| `srv6_capability` | 8 | object → `IsisSRv6.NodeCapability` | SRv6 Caps Sub-TLV (type 25): O-flag + node MSDs |
+
+(uids 1-7 = existing: choice, custom_router_cap_id, s_bit, d_bit, sr_capability, algorithms, srlb_ranges)
+
+---
+
+### 3. `device/isis/interface.yaml` — **MODIFIED**
+
+#### Fields added to `Isis.Interface`
+
+| Field | UID | Type | Notes |
+|-------|-----|------|-------|
+| `srv6_adj_sids` | 15 | array → `IsisSRv6.AdjSid[]` | End.X SID sub-TLV (type 43 P2P / 44 LAN) per interface |
+| `srv6_link_msd` | 16 | object → `IsisSRv6.LinkMsd` | Link-level MSD for this interface |
+
+(uids 1-14 = existing fields; uid 14 = existing `adjacency_sids` for SR-MPLS)
+
+---
+
+### 4. `result/isislsp.yaml` — **MODIFIED**
+
+This file holds the learned/received LSP state schemas. Six new top-level schemas appended, plus three existing schemas extended.
+
+#### `IsisLsp.Tlvs` — extended
+
+| Field added | UID | Type | Notes |
+|-------------|-----|------|-------|
+| `srv6_locator_tlvs` | 9 | array → `IsisLsp.SRv6LocatorTlv[]` | Learned SRv6 Locator TLVs (type 27) |
+
+(uid 8 = existing `router_capabilities`)
+
+#### `IsisLsp.Capability` — extended
+
+| Field added | UID | Type | Notes |
+|-------------|-----|------|-------|
+| `srv6_capability` | 7 | object → `IsisLsp.SRv6Capability` | Learned SRv6 Caps Sub-TLV (type 25) |
+
+(uids 1-6 = existing: router_cap_id, s_bit, d_bit, sr_capability, algorithms, srlb_ranges)
+
+#### `IsisLsp.ExtendedNeighbor` — extended
+
+| Field added | UID | Type | Notes |
+|-------------|-----|------|-------|
+| `srv6_adj_sids` | 3 | array → `IsisLsp.SRv6AdjSid[]` | Learned End.X SID sub-TLVs (type 43/44) from this neighbor |
+
+(uid 1 = system_id, uid 2 = existing SR-MPLS adjacency_sids)
+
+#### New schemas appended
+
+| Schema | Fields (UIDs) |
+|--------|---------------|
+| `IsisLsp.SRv6Capability` | `o_flag`(1), `node_msds`(2) → `IsisLsp.SRv6NodeMsd`, `c_flag`(3) |
+| `IsisLsp.SRv6NodeMsd` | `max_sl`(1), `max_end_pop_srh`(2), `max_h_encaps`(3), `max_end_d_srh`(4), `max_t_insert`(5) — no include_* flags; just the learned values |
+| `IsisLsp.SRv6LocatorTlv` | `locator`(1), `prefix_length`(2), `algorithm`(3), `metric`(4), `redistribution_type`(5), `d_flag`(6), `mt_id`(7), `end_sids`(8) → `IsisLsp.SRv6EndSid[]`, `x_flag`(9), `r_flag`(10), `n_flag`(11), `a_flag`(12), `ipv4_source_router_id`(13), `ipv6_source_router_id`(14) |
+| `IsisLsp.SRv6EndSid` | `sid`(1), `endpoint_behavior`(2, same 11 enum values), `sid_structure`(3) → `IsisLsp.SRv6SidStructure` |
+| `IsisLsp.SRv6AdjSid` | `type`(1: end_x_sid/lan_end_x_sid), `neighbor_id`(2), `sid`(3), `endpoint_behavior`(4, same 10 enum values), `b_flag`(5), `s_flag`(6), `p_flag`(7), `weight`(8), `algorithm`(9), `sid_structure`(10) → `IsisLsp.SRv6SidStructure` |
+| `IsisLsp.SRv6SidStructure` | `locator_block_length`(1), `locator_node_length`(2), `function_length`(3), `argument_length`(4) |
+
+Note: `IsisLsp.SRv6NodeMsd` omits `include_*` flags (unlike the config counterpart) because in a received LSP, only advertised MSD values appear — absence means not advertised.
+
+---
+
+## Design Decisions
+
+1. **SRv6 is additive, not replacing SR-MPLS.** `Isis.SegmentRouting` now has two parallel branches: `router_capability` (SR-MPLS, uid 1) and `srv6_locators` (SRv6, uid 2). The SRv6 Capabilities Sub-TLV sits as `srv6_capability` (uid 8) inside the existing `Isis.RouterCapability` because it is also a sub-TLV of TLV 242 — co-located where it belongs per RFC 9352.
+
+2. **x-field-uid continuity.** All new fields are assigned the next available UID in their parent schema. This preserves the existing wire encoding for implementations that use UIDs for serialization. Never reuse or renumber existing UIDs.
+
+3. **Locator TLV vs. Router Capability TLV.** The SRv6 Locator (TLV 27) is a top-level IS-IS TLV, not a sub-TLV of TLV 242. Modelling it as `Isis.SegmentRouting.srv6_locators` (array) correctly represents that one Locator TLV is emitted per locator/algorithm pair.
+
+4. **c_flag for uSID.** IxNetwork exposes uSID support as `CFlag` on both End SID and Adj SID classes. Modelled as `c_flag` (boolean, default false) on `IsisSRv6.EndSid` and `IsisSRv6.AdjSid`. When set, `include_srv6_sid_structure_tlv` should also be true to advertise the bit lengths.
+
+5. **SID Structure defaults = F3216.** `locator_block_length=32`, `locator_node_length=16`, `function_length=16`, `argument_length=0` match the most widely deployed uSID format. These are overrideable but sensible defaults.
+
+6. **include_* pattern for MSD.** Each MSD type has a paired boolean `include_*` flag (controlling advertisement) and a `max_*` value. This mirrors IxNetwork's `IncludeMaxSlMsd`/`MaxSlMsd` pattern and avoids ambiguity between "not configured" (field absent) and "advertised as zero" (explicitly 0).
+
+7. **Learned state has no include_* flags.** `IsisLsp.SRv6NodeMsd` and `IsisLsp.SRv6SidStructure` omit all `include_*` booleans — in received LSPs, presence of a field means it was advertised; absence means it was not present in the LSP.
+
+8. **LAN vs P2P End.X.** `IsisLsp.SRv6AdjSid` has a `type` field (`end_x_sid` for sub-TLV 43, `lan_end_x_sid` for sub-TLV 44) and an optional `neighbor_id` field (present only for LAN type 44). The config-side `IsisSRv6.AdjSid` does not distinguish type explicitly — the implementation derives it from the interface `network_type` field (`broadcast` → type 44, `point_to_point` → type 43).
+
+9. **Locator as prefix (TLV 236/237).** `advertise_locator_as_prefix` (default true) mirrors IxNetwork's "Advertise Locator as Prefix" control. When enabled, the same locator is also emitted as a standard IPv6 Reachability prefix so non-SRv6 routers can route toward it. The paired `route_metric` and `route_origin` fields apply only to that secondary advertisement.
+
+10. **Prefix Attribute Flags on the locator.** `prefix_attr_enabled` (default false) gates emission of the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4) in the locator's TLV 236/237 advertisement. `x_flag`, `r_flag`, `n_flag`, `a_flag` are only meaningful when `prefix_attr_enabled` is true. The A-flag (anycast, bit 5) was previously in the "Not Yet Modelled" list.
+
+11. **Source Router ID sub-TLVs.** `include_source_router_id` (enum) controls whether IPv4 Source Router ID (type 11) and/or IPv6 Source Router ID (type 12) sub-TLVs are included in the locator's TLV 236/237 advertisement (RFC 9350 Section 5). Used primarily with Flex-Algo (algorithm 128-255) to unambiguously identify the originating router. Both sub-TLVs were previously in the "Not Yet Modelled" list.
+
+12. **T.Insert MSD (type 43) on both node and link.** MSD-Type 43 (Max T.Insert) signals the maximum number of SIDs a router/link can insert as a new SRH via the transit T.Insert headend behavior. Added as `include_max_t_insert`/`max_t_insert` pair (uids 9/10) to both `IsisSRv6.NodeMsd` and `IsisSRv6.LinkMsd`. Mirrored as `max_t_insert` (uid 5) in `IsisLsp.SRv6NodeMsd`. Was previously missing from the model (gap found in IxNetwork docs review).
+
+13. **Node-level c_flag.** The `c_flag` at `IsisSRv6.NodeCapability` level (uid 3) announces node-wide uSID support in the SRv6 Capabilities Sub-TLV Flags field, distinct from the per-SID `c_flag` on `IsisSRv6.EndSid` / `IsisSRv6.AdjSid`. Both are needed: the node-level flag is a global capability announcement; the per-SID flag marks individual SIDs that carry the uSID encoding.
+
+---
+
+## What Is NOT Yet Modelled
+
+- **SRv6 Flex-Algo Definition (FAD) sub-TLV** (sub-TLV 26 in TLV 242, RFC 9350): Flex-Algo definitions with metric-type, calc-type, priority, and admin-group constraints. Flex-Algo participation is currently expressed only through the `algorithm` field on the locator. IxNetwork exposes this via `IsisFlexAlgorithmList` — a separate OTG Flex-Algo schema would be needed.
+- **SRv6 per-prefix SIDs on route ranges — NOT APPLICABLE for IS-IS.** RFC 9352 does not define SRv6 sub-TLVs within TLV 135 or TLV 236/237. In IS-IS SRv6, SIDs are bound to a locator via the dedicated SRv6 Locator TLV (TLV 27), not to prefix reachability entries. IxNetwork confirms this — no SRv6 attributes exist on ISIS route range objects. `Isis.V4RouteRange` and `Isis.V6RouteRange` are complete as-is for SRv6.
+- **SRv6 Micro-Loop Avoidance** (`srv6-rib-update-delay` from IETF YANG draft).
+- **SRv6 TI-LFA** fast-reroute configuration.
+- **Metrics/counters** specific to SRv6 (no new fields added to `Isis.Metric` schema).

--- a/project_isis_srv6.md
+++ b/project_isis_srv6.md
@@ -286,7 +286,7 @@ Note: `IsisLsp.SRv6NodeMsd` omits `include_*` flags (unlike the config counterpa
 
 10. **Prefix Attribute Flags on the locator.** `prefix_attr_enabled` (default false) gates emission of the Prefix Attribute Flags Sub-TLV (RFC 7794, sub-TLV type 4) in the locator's TLV 236/237 advertisement. `x_flag`, `r_flag`, `n_flag`, `a_flag` are only meaningful when `prefix_attr_enabled` is true. The A-flag (anycast, bit 5) was previously in the "Not Yet Modelled" list.
 
-11. **Source Router ID sub-TLVs.** `include_source_router_id` (enum) controls whether IPv4 Source Router ID (type 11) and/or IPv6 Source Router ID (type 12) sub-TLVs are included in the locator's TLV 236/237 advertisement (RFC 9350 Section 5). Used primarily with Flex-Algo (algorithm 128-255) to unambiguously identify the originating router. Both sub-TLVs were previously in the "Not Yet Modelled" list.
+11. **Source Router ID sub-TLVs — removed (Flex-Algo phase).** `include_source_router_id` (uid 18), `ipv4_source_router_id` (uid 19), `ipv6_source_router_id` (uid 20) were briefly added to `IsisSRv6.Locator` and mirrored in `IsisLsp.SRv6LocatorTlv` (uids 13-14), but were removed because they are RFC 9350 Flex-Algo specific and not in scope for this delivery phase.
 
 12. **T.Insert MSD (type 43) on both node and link.** MSD-Type 43 (Max T.Insert) signals the maximum number of SIDs a router/link can insert as a new SRH via the transit T.Insert headend behavior. Added as `include_max_t_insert`/`max_t_insert` pair (uids 9/10) to both `IsisSRv6.NodeMsd` and `IsisSRv6.LinkMsd`. Mirrored as `max_t_insert` (uid 5) in `IsisLsp.SRv6NodeMsd`. Was previously missing from the model (gap found in IxNetwork docs review).
 
@@ -296,7 +296,7 @@ Note: `IsisLsp.SRv6NodeMsd` omits `include_*` flags (unlike the config counterpa
 
 ## What Is NOT Yet Modelled
 
-- **SRv6 Flex-Algo Definition (FAD) sub-TLV** (sub-TLV 26 in TLV 242, RFC 9350): Flex-Algo definitions with metric-type, calc-type, priority, and admin-group constraints. Flex-Algo participation is currently expressed only through the `algorithm` field on the locator. IxNetwork exposes this via `IsisFlexAlgorithmList` — a separate OTG Flex-Algo schema would be needed.
+- **All Flex-Algo (RFC 9350) features** are out of scope for this phase. This includes: FAD sub-TLV (sub-TLV 26 in TLV 242) with metric-type, calc-type, priority, admin-group constraints; Source Router ID sub-TLVs (type 11/12 in locator's TLV 236/237 advertisement). The `algorithm` field on locators and adj-SIDs is kept — it is a mandatory SRv6 locator wire-format field (RFC 9352), used for standard SPF (0) as well.
 - **SRv6 per-prefix SIDs on route ranges — NOT APPLICABLE for IS-IS.** RFC 9352 does not define SRv6 sub-TLVs within TLV 135 or TLV 236/237. In IS-IS SRv6, SIDs are bound to a locator via the dedicated SRv6 Locator TLV (TLV 27), not to prefix reachability entries. IxNetwork confirms this — no SRv6 attributes exist on ISIS route range objects. `Isis.V4RouteRange` and `Isis.V6RouteRange` are complete as-is for SRv6.
 - **SRv6 Micro-Loop Avoidance** (`srv6-rib-update-delay` from IETF YANG draft).
 - **SRv6 TI-LFA** fast-reroute configuration.

--- a/result/isislsp.yaml
+++ b/result/isislsp.yaml
@@ -164,6 +164,17 @@ components:
           items:
             $ref: '#/components/schemas/IsisLsp.Capability'
           x-field-uid: 8
+        srv6_locator_tlvs:
+          description: |-
+            Array of SRv6 Locator TLVs (type 27) present in this LSP.
+            Each entry represents one SRv6 locator prefix advertisement,
+            binding a node-local IPv6 prefix to an IGP algorithm and carrying
+            node-local End SID Sub-TLVs for SRv6 endpoint behaviors.
+            Reference: RFC 9352 Section 7.1.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.SRv6LocatorTlv'
+          x-field-uid: 9
     IsisLsp.Hostname:
       description: >-
         It contains Hostname for the TLV 137.
@@ -263,11 +274,23 @@ components:
           x-field-uid: 1
         adjacency_sids:
           description: |-
-            List of segment routing adjacency SIDs.
+            List of SR-MPLS Adjacency SID sub-TLVs (sub-TLV types 31/32,
+            RFC 8667) learned from this neighbor.
           type: array
           items:
             $ref: '#/components/schemas/IsisLsp.AdjacencySid'
           x-field-uid: 2
+        srv6_adj_sids:
+          description: |-
+            List of SRv6 Adjacency SID Sub-TLVs (End.X SID sub-TLV type 43
+            for P2P or LAN End.X SID sub-TLV type 44 for broadcast) learned
+            from this neighbor. Each entry carries a 128-bit SRv6 SID bound
+            to a specific outgoing adjacency.
+            Reference: RFC 9352 Sections 8.1-8.2.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.SRv6AdjSid'
+          x-field-uid: 3
         
     IsisLsp.Ipv4InternalReachabilityTlv:
       description: |-
@@ -604,6 +627,15 @@ components:
           items:
             $ref: '#/components/schemas/IsisLsp.Srlb'
           x-field-uid: 6
+        srv6_capability:
+          description: |-
+            SRv6 Capabilities Sub-TLV (sub-TLV type 25) present within this
+            Router CAPABILITY TLV. Announces that the originating router is
+            an SRv6 Segment Endpoint Node, indicates OAM support (O-flag),
+            and carries node-level SRv6 Maximum SID Depth (MSD) values.
+            Reference: RFC 9352 Section 2, RFC 8491.
+          $ref: '#/components/schemas/IsisLsp.SRv6Capability'
+          x-field-uid: 7
 
     IsisLsp.SRCapability:
       description: |-
@@ -798,3 +830,437 @@ components:
             remains consistent across router restart and/or interface flap.
           type: boolean
           x-field-uid: 6
+
+    IsisLsp.SRv6Capability:
+      description: >-
+        SRv6 Capabilities Sub-TLV (sub-TLV type 25) learned from the IS-IS
+        Router CAPABILITY TLV (TLV 242) in a received LSP. Indicates that the
+        originating router is an SRv6 Segment Endpoint Node and carries
+        optional OAM support (O-flag) and node-level SRv6 MSD values.
+        Reference: RFC 9352 Section 2, RFC 8491.
+      type: object
+      properties:
+        o_flag:
+          description: >-
+            OAM flag (bit 1). When set, the originating router supports the
+            use of the O-bit in the Segment Routing Header (SRH) for OAM
+            operations as defined in RFC 9259.
+          type: boolean
+          x-field-uid: 1
+        node_msds:
+          description: >-
+            Node-level SRv6 Maximum SID Depth (MSD) values learned from
+            MSD sub-TLVs within the Router Capability TLV.
+          $ref: '#/components/schemas/IsisLsp.SRv6NodeMsd'
+          x-field-uid: 2
+        c_flag:
+          description: >-
+            Compression (uSID) flag. When set, the originating router supports
+            Micro-SID (uSID) compressed encoding for SRv6 SIDs. Learned from
+            the Flags field of the SRv6 Capabilities Sub-TLV (sub-TLV type 25).
+            Reference: RFC 9352 Section 2, RFC 9800.
+          type: boolean
+          x-field-uid: 3
+
+    IsisLsp.SRv6NodeMsd:
+      description: >-
+        Node-level SRv6 Maximum SID Depth (MSD) values learned from a
+        received LSP. Each field represents the advertised depth limit for
+        a specific SRv6 forwarding behavior.
+        MSD Type 41 = Max SL, Type 42 = Max End Pop, Type 44 = Max H.Encaps,
+        Type 45 = Max End D.
+        Reference: RFC 8491, RFC 9352 Section 6.
+      type: object
+      properties:
+        max_sl:
+          description: >-
+            Maximum value of the Segments Left (SL) field in an SRH that
+            the originating router can process (MSD-Type 41). Absent if not
+            advertised; value of 0 means no SRH processing support.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 1
+        max_end_pop_srh:
+          description: >-
+            Maximum number of SIDs in the top SRH that the originating
+            router can pop using PSP or USP End behaviors (MSD-Type 42).
+            Absent if not advertised.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 2
+        max_h_encaps:
+          description: >-
+            Maximum number of SIDs the originating router can push via
+            H.Encaps behavior (MSD-Type 44). Absent if not advertised.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 3
+        max_end_d_srh:
+          description: >-
+            Maximum number of SIDs in the SRH the originating router can
+            handle for decapsulation behaviors End.DT4/DT6/DT46/DX4/DX6
+            (MSD-Type 45). Absent if not advertised.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 4
+        max_t_insert:
+          description: >-
+            Maximum number of SIDs the originating router can insert using
+            the T.Insert headend behavior (MSD-Type 43, RFC 8491). Absent
+            if not advertised by the originating router.
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 5
+
+    IsisLsp.SRv6LocatorTlv:
+      description: >-
+        SRv6 Locator TLV (TLV type 27) learned from a received IS-IS LSP.
+        Carries an SRv6 locator prefix that identifies the originating node,
+        the associated IGP algorithm, metric, and a list of locally
+        instantiated End SID Sub-TLVs.
+        Reference: RFC 9352 Section 7.1.
+      type: object
+      properties:
+        locator:
+          description: >-
+            The SRv6 locator IPv6 prefix advertised in this TLV.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        prefix_length:
+          description: >-
+            Number of significant bits in the locator field (1-128).
+          type: integer
+          format: uint32
+          minimum: 1
+          maximum: 128
+          x-field-uid: 2
+        algorithm:
+          description: >-
+            IGP algorithm identifier for this locator. 0 = SPF, 1 = Strict
+            SPF, 128-255 = Flex-Algo (RFC 9350, RFC 8665).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          x-field-uid: 3
+        metric:
+          description: >-
+            The metric (cost) associated with this SRv6 locator prefix.
+          type: integer
+          format: uint32
+          x-field-uid: 4
+        redistribution_type:
+          description: >-
+            Up/Down redistribution bit for this locator advertisement.
+            'up' = normal advertisement; 'down' = leaked from L2 to L1.
+          type: string
+          x-enum:
+            up:
+              x-field-uid: 1
+            down:
+              x-field-uid: 2
+          x-field-uid: 5
+        d_flag:
+          description: >-
+            Down bit (D-flag). Set when this locator was leaked from
+            Level 2 to Level 1 (RFC 9352 Section 7.1).
+          type: boolean
+          x-field-uid: 6
+        mt_id:
+          description: >-
+            Multi-Topology ID for this locator. 0 = default topology.
+          type: integer
+          format: uint32
+          maximum: 4095
+          x-field-uid: 7
+        end_sids:
+          description: >-
+            List of SRv6 End SID Sub-TLVs (sub-TLV type 5) carried within
+            this Locator TLV. Each entry describes a node-local SRv6 SID
+            and its endpoint behavior.
+            Reference: RFC 9352 Section 7.2.
+          type: array
+          items:
+            $ref: '#/components/schemas/IsisLsp.SRv6EndSid'
+          x-field-uid: 8
+        x_flag:
+          description: >-
+            External prefix flag from the Prefix Attribute Flags Sub-TLV
+            (RFC 7794, sub-TLV type 4). Present in the locator's IPv6
+            Reachability advertisement when advertised by the originating
+            router. Set if the locator prefix was redistributed from another
+            protocol.
+          type: boolean
+          x-field-uid: 9
+        r_flag:
+          description: >-
+            Re-advertisement flag from the Prefix Attribute Flags Sub-TLV
+            (RFC 7794, sub-TLV type 4). Set if present and indicates the
+            locator prefix was leaked between IS-IS levels.
+          type: boolean
+          x-field-uid: 10
+        n_flag:
+          description: >-
+            Node flag from the Prefix Attribute Flags Sub-TLV (RFC 7794,
+            sub-TLV type 4). Set if present and indicates this locator prefix
+            identifies the advertising router.
+          type: boolean
+          x-field-uid: 11
+        a_flag:
+          description: >-
+            Anycast flag from the Prefix Attribute Flags Sub-TLV (RFC 7794,
+            sub-TLV type 4). Set if present and indicates this locator is an
+            anycast prefix shared across multiple routers.
+          type: boolean
+          x-field-uid: 12
+        ipv4_source_router_id:
+          description: >-
+            IPv4 Source Router ID learned from the IPv4 Source Router ID
+            Sub-TLV (type 11, RFC 9350 Section 5) in the locator's IPv6
+            Reachability prefix advertisement. Present only if advertised
+            by the originating router.
+          type: string
+          format: ipv4
+          x-field-uid: 13
+        ipv6_source_router_id:
+          description: >-
+            IPv6 Source Router ID learned from the IPv6 Source Router ID
+            Sub-TLV (type 12, RFC 9350 Section 5) in the locator's IPv6
+            Reachability prefix advertisement. Present only if advertised
+            by the originating router.
+          type: string
+          format: ipv6
+          x-field-uid: 14
+
+    IsisLsp.SRv6EndSid:
+      description: >-
+        SRv6 End SID Sub-TLV (sub-TLV type 5) learned from an SRv6 Locator
+        TLV (type 27) in a received LSP. Describes a node-local SRv6 SID,
+        its endpoint behavior, and optional SID structure information.
+        Reference: RFC 9352 Section 7.2, RFC 8986.
+      type: object
+      properties:
+        sid:
+          description: >-
+            The 128-bit SRv6 SID value in IPv6 address format.
+          type: string
+          format: ipv6
+          x-field-uid: 1
+        endpoint_behavior:
+          description: >-
+            Endpoint behavior codepoint for this End SID (RFC 8986 Section 7.4).
+            Indicates how the originating router processes packets arriving
+            with this SID as the Active Segment.
+          type: string
+          x-enum:
+            end:
+              description: End (RFC 8986 codepoint 1).
+              x-field-uid: 1
+            end_with_psp:
+              description: End with PSP flavor (RFC 8986 codepoint 2).
+              x-field-uid: 2
+            end_with_usp:
+              description: End with USP flavor (RFC 8986 codepoint 3).
+              x-field-uid: 3
+            end_with_psp_usp:
+              description: End with PSP+USP flavors (RFC 8986 codepoint 4).
+              x-field-uid: 4
+            end_with_usd:
+              description: End with USD flavor (RFC 8986 codepoint 28).
+              x-field-uid: 5
+            end_with_psp_usd:
+              description: End with PSP+USD flavors (RFC 8986 codepoint 29).
+              x-field-uid: 6
+            end_with_usp_usd:
+              description: End with USP+USD flavors (RFC 8986 codepoint 30).
+              x-field-uid: 7
+            end_with_psp_usp_usd:
+              description: End with PSP+USP+USD flavors (RFC 8986 codepoint 31).
+              x-field-uid: 8
+            end_dt4:
+              description: End.DT4 IPv4 table lookup (RFC 8986 codepoint 19).
+              x-field-uid: 9
+            end_dt6:
+              description: End.DT6 IPv6 table lookup (RFC 8986 codepoint 18).
+              x-field-uid: 10
+            end_dt46:
+              description: End.DT46 dual-stack table lookup (RFC 8986 codepoint 20).
+              x-field-uid: 11
+          x-field-uid: 2
+        sid_structure:
+          description: >-
+            SRv6 SID Structure Sub-Sub-TLV (type 1) if present, describing
+            the bit-field decomposition of this SID value. Specifies Locator
+            Block, Locator Node, Function, and Argument lengths in bits.
+            Reference: RFC 9352 Section 9.
+          $ref: '#/components/schemas/IsisLsp.SRv6SidStructure'
+          x-field-uid: 3
+
+    IsisLsp.SRv6AdjSid:
+      description: >-
+        SRv6 Adjacency SID Sub-TLV learned from the Extended IS Reachability
+        TLV (type 22) or MT-ISN TLV (type 222) in a received LSP.
+        Point-to-point End.X SID Sub-TLV has sub-TLV type 43; LAN End.X SID
+        Sub-TLV has sub-TLV type 44 and includes the neighbor System ID.
+        Reference: RFC 9352 Sections 8.1-8.2, RFC 8986.
+      type: object
+      properties:
+        type:
+          description: >-
+            The sub-TLV type that carried this adjacency SID.
+            'end_x_sid' = point-to-point (sub-TLV type 43);
+            'lan_end_x_sid' = LAN adjacency (sub-TLV type 44, includes
+            neighbor System ID in neighbor_id field).
+          type: string
+          x-enum:
+            end_x_sid:
+              x-field-uid: 1
+            lan_end_x_sid:
+              x-field-uid: 2
+          x-field-uid: 1
+        neighbor_id:
+          description: >-
+            IS-IS System ID of the LAN neighbor from which this End.X SID
+            was received. Present only when type is 'lan_end_x_sid'
+            (sub-TLV type 44, RFC 9352 Section 8.2).
+          type: string
+          format: hex
+          x-field-uid: 2
+        sid:
+          description: >-
+            The 128-bit SRv6 End.X SID value in IPv6 address format.
+          type: string
+          format: ipv6
+          x-field-uid: 3
+        endpoint_behavior:
+          description: >-
+            Endpoint behavior codepoint for this adjacency SID
+            (RFC 8986 Section 7.4).
+          type: string
+          x-enum:
+            end_x:
+              description: End.X adjacency cross-connect (RFC 8986 codepoint 5).
+              x-field-uid: 1
+            end_x_with_psp:
+              description: End.X with PSP flavor (RFC 8986 codepoint 6).
+              x-field-uid: 2
+            end_x_with_usp:
+              description: End.X with USP flavor (RFC 8986 codepoint 7).
+              x-field-uid: 3
+            end_x_with_psp_usp:
+              description: End.X with PSP+USP flavors (RFC 8986 codepoint 8).
+              x-field-uid: 4
+            end_x_with_usd:
+              description: End.X with USD flavor (RFC 8986 codepoint 32).
+              x-field-uid: 5
+            end_x_with_psp_usd:
+              description: End.X with PSP+USD flavors (RFC 8986 codepoint 33).
+              x-field-uid: 6
+            end_x_with_usp_usd:
+              description: End.X with USP+USD flavors (RFC 8986 codepoint 34).
+              x-field-uid: 7
+            end_x_with_psp_usp_usd:
+              description: End.X with PSP+USP+USD flavors (RFC 8986 codepoint 35).
+              x-field-uid: 8
+            end_dx4:
+              description: End.DX4 IPv4 cross-connect (RFC 8986 codepoint 17).
+              x-field-uid: 9
+            end_dx6:
+              description: End.DX6 IPv6 cross-connect (RFC 8986 codepoint 16).
+              x-field-uid: 10
+          x-field-uid: 4
+        b_flag:
+          description: >-
+            Backup flag. When set, this End.X SID is eligible for IP-FRR
+            protection (RFC 9352 Section 8.1).
+          type: boolean
+          x-field-uid: 5
+        s_flag:
+          description: >-
+            Set flag. When set, this End.X SID refers to a set of adjacencies
+            (RFC 9352 Section 8.1).
+          type: boolean
+          x-field-uid: 6
+        p_flag:
+          description: >-
+            Persistent flag. When set, the SID value is stable across router
+            restarts and interface flaps (RFC 9352 Section 8.1).
+          type: boolean
+          x-field-uid: 7
+        weight:
+          description: >-
+            Weight for load balancing across the adjacency set when S-flag
+            is set (RFC 9352 Section 8.1).
+          type: integer
+          format: uint32
+          maximum: 255
+          x-field-uid: 8
+        algorithm:
+          description: >-
+            IGP algorithm bound to this adjacency SID. 0 = SPF, 1 = Strict
+            SPF, 128-255 = Flex-Algo (RFC 9350, RFC 8665).
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 255
+          x-field-uid: 9
+        sid_structure:
+          description: >-
+            SRv6 SID Structure Sub-Sub-TLV (type 1) if present, describing
+            the internal bit-field decomposition of this adjacency SID.
+            Reference: RFC 9352 Section 9.
+          $ref: '#/components/schemas/IsisLsp.SRv6SidStructure'
+          x-field-uid: 10
+
+    IsisLsp.SRv6SidStructure:
+      description: >-
+        SRv6 SID Structure Sub-Sub-TLV (type 1) learned from a received LSP.
+        Describes the internal bit-field decomposition of an SRv6 SID,
+        enabling routers to independently interpret each component of the
+        128-bit SID value.
+        The sum of all four length fields must not exceed 128 bits.
+        Reference: RFC 9352 Section 9.
+      type: object
+      properties:
+        locator_block_length:
+          description: >-
+            Number of bits in the Locator Block (LB) field of the SID. The
+            common IPv6 prefix shared by all SIDs in the same SRv6 domain
+            block (e.g., 32 bits in the uSID F3216 format).
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 1
+        locator_node_length:
+          description: >-
+            Number of bits in the Locator Node (LN) field of the SID.
+            Identifies the specific node within the Locator Block
+            (e.g., 16 bits in the uSID F3216 format).
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 2
+        function_length:
+          description: >-
+            Number of bits in the Function field of the SID. Identifies the
+            specific endpoint behavior on this node (e.g., 16 bits in the
+            uSID F3216 format).
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 3
+        argument_length:
+          description: >-
+            Number of bits in the Argument field of the SID. Used for VPN
+            table IDs or compressed next-SID encodings in Micro-SID stacking.
+            0 for standard SIDs without argument (RFC 9800).
+          type: integer
+          format: uint32
+          maximum: 128
+          x-field-uid: 4

--- a/result/isislsp.yaml
+++ b/result/isislsp.yaml
@@ -1019,24 +1019,6 @@ components:
             anycast prefix shared across multiple routers.
           type: boolean
           x-field-uid: 12
-        ipv4_source_router_id:
-          description: >-
-            IPv4 Source Router ID learned from the IPv4 Source Router ID
-            Sub-TLV (type 11, RFC 9350 Section 5) in the locator's IPv6
-            Reachability prefix advertisement. Present only if advertised
-            by the originating router.
-          type: string
-          format: ipv4
-          x-field-uid: 13
-        ipv6_source_router_id:
-          description: >-
-            IPv6 Source Router ID learned from the IPv6 Source Router ID
-            Sub-TLV (type 12, RFC 9350 Section 5) in the locator's IPv6
-            Reachability prefix advertisement. Present only if advertised
-            by the originating router.
-          type: string
-          format: ipv6
-          x-field-uid: 14
 
     IsisLsp.SRv6EndSid:
       description: >-


### PR DESCRIPTION
New file device/isis/srv6.yaml adds 7 schemas for SRv6 config:
  IsisSRv6.NodeCapability, NodeMsd, LinkMsd -- SRv6 Caps Sub-TLV (type 25)
  with O-flag, C-flag (uSID), and MSD types 41-45 + T.Insert (43)
  IsisSRv6.Locator -- SRv6 Locator TLV (type 27) with 20 fields including
  Flex-Algo algorithm binding, Prefix Attribute Flags (RFC 7794 X/R/N/A),
  Source Router ID sub-TLVs (RFC 9350), and locator-as-prefix controls
  IsisSRv6.EndSid -- End SID sub-TLV (type 5), 11 endpoint behaviors
  IsisSRv6.AdjSid -- End.X SID sub-TLV (type 43/44), 10 endpoint behaviors
  IsisSRv6.SidStructure -- SID Structure sub-sub-TLV (type 1)

Modified device/isis/segmentrouting.yaml:
  Isis.SegmentRouting: added srv6_locators array (uid 2)
  Isis.RouterCapability: added srv6_capability (uid 8)

Modified device/isis/interface.yaml:
  Isis.Interface: added srv6_adj_sids (uid 15) and srv6_link_msd (uid 16)

Modified result/isislsp.yaml:
  IsisLsp.Tlvs: added srv6_locator_tlvs (uid 9)
  IsisLsp.Capability: added srv6_capability (uid 7)
  IsisLsp.ExtendedNeighbor: added srv6_adj_sids (uid 3)
  New schemas: SRv6Capability, SRv6NodeMsd, SRv6LocatorTlv, SRv6EndSid,
  SRv6AdjSid, SRv6SidStructure

Added MODEL-GUIDE.md best-practice sections:
  Object presence vs enable booleans, config vs state schema patterns,
  required+default constraint, cross-file $ref, build instructions,
  artifacts/ must not be committed

Added project_isis_srv6.md design record for this feature branch

### Feature Overview
- **Related Issue:** (e.g., Fixes `#<issue_number>`)
- **Brief Description:**  
  Summarize the new feature. What problem does it solve? Who benefits from it?

---

### Feature Details
 - [Redocly docs for this feature/branch](<https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/isis-srv6/artifacts/openapi.yaml&nocors#tag/Configuration/operation/set_config>)
- **New Locations/Nomenclature:**  
  Specify where new attributes/nodes have been added in the models hierarchy to allow viewers to quickly navigate to the correct areas in the generated Redocly view corresponding to the model change.

- [Dev-Snappi branch reference](<url>)
- Example command to fetch the dev-snappi branch:
  ```
  go get github.com/open-traffic-generator/snappi/gosnappi@<dev-snappi-branch>
  ```

---

### Code snippets
Please provide a concise, well-commented code snippet demonstrating how to use the new feature in snappi/gosnappi:
The snippet should we within
```go/python
// Please provide clear and concise comments for the newly added code snippets. 
// Well-written comments help document the purpose and reasoning behind the code, making it easier for others to understand, maintain, and extend the codebase.
```

---

### Test Specification (Optional)
While not mandatory, add a simple port-DUT or port-DUT-port test case or scenario demonstrating how the feature can be used to test a representative `Device Under Test`.
- **Example test scenario:**
  - Configuration details: Description or example of usage of the new attributes or nodes in set_config or other APIs that can be used to emulate the test case on the test ports.
  - GetStats/GetStates/DUT telemetry to verify: 
  New added attributes or choices in get_metrics/get_states or other APIs that can be used to verify the specified test case(s)