### PR TITLE
Add BGP peer and route flap control operations

### DIFF
--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -20162,40 +20162,6 @@ components:
           enum:
           - withdraw
           - advertise
-        flap:
-          x-status:
-            status: under_review
-            information: This is subject to change.
-          $ref: '#/components/schemas/State.Protocol.Route.Flap'
-          x-field-uid: 3
-          description: |-
-            Under Review: This is subject to change.
-
-            Description TBD
-    State.Protocol.Route.Flap:
-      description: |-
-        Flaps the selected routes on the fly by continuously withdrawing and re-advertising them.
-      type: object
-      required:
-      - enable
-      properties:
-        enable:
-          description: |-
-            Enables or disables flapping of the selected routes.
-          type: boolean
-          x-field-uid: 1
-        up_time:
-          description: |-
-            The duration (in seconds) for which each route stays advertised in a flap cycle.
-          type: integer
-          format: uint32
-          x-field-uid: 2
-        down_time:
-          description: |-
-            The duration (in seconds) for which each route stays withdrawn in a flap cycle.
-          type: integer
-          format: uint32
-          x-field-uid: 3
     State.Protocol.Lacp:
       description: |-
         Sets state of configured LACP
@@ -20998,11 +20964,14 @@ components:
               x-field-uid: 2
             peer:
               x-field-uid: 3
+            route:
+              x-field-uid: 4
           x-field-uid: 1
           enum:
           - notification
           - initiate_graceful_restart
           - peer
+          - route
         notification:
           $ref: '#/components/schemas/Action.Protocol.Bgp.Notification'
           x-field-uid: 2
@@ -21015,6 +20984,16 @@ components:
             information: This is subject to change.
           $ref: '#/components/schemas/Action.Protocol.Bgp.Peer'
           x-field-uid: 4
+          description: |-
+            Under Review: This is subject to change.
+
+            Description TBD
+        route:
+          x-status:
+            status: under_review
+            information: This is subject to change.
+          $ref: '#/components/schemas/Action.Protocol.Bgp.Route'
+          x-field-uid: 5
           description: |-
             Under Review: This is subject to change.
 
@@ -21075,6 +21054,85 @@ components:
           type: integer
           format: uint32
           x-field-uid: 4
+    Action.Protocol.Bgp.Route:
+      description: |-
+        Actions associated with configured BGP routes.
+      type: object
+      required:
+      - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            flap:
+              x-field-uid: 1
+          x-field-uid: 1
+          enum:
+          - flap
+        flap:
+          $ref: '#/components/schemas/Action.Protocol.Bgp.Route.Flap'
+          x-field-uid: 2
+    Action.Protocol.Bgp.Route.Flap:
+      description: |-
+        Flaps the selected BGP route ranges on the fly by continuously withdrawing and re-advertising them.
+      type: object
+      required:
+      - enable
+      properties:
+        route_names:
+          description: |
+            The names of BGP route ranges to flap. An empty or null list will flap all configured BGP route ranges.
+
+            x-constraint:
+            - /components/schemas/Bgp.V4RouteRange/properties/name
+            - /components/schemas/Bgp.V6RouteRange/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Bgp.V4RouteRange/properties/name
+          - /components/schemas/Bgp.V6RouteRange/properties/name
+          x-field-uid: 1
+        enable:
+          description: |-
+            Enables or disables flapping of the selected BGP route ranges.
+          type: boolean
+          x-field-uid: 2
+        up_time:
+          description: |-
+            The duration (in seconds) for which each route stays advertised in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 3
+        down_time:
+          description: |-
+            The duration (in seconds) for which each route stays withdrawn in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 4
+        delay:
+          description: |-
+            The delay (in seconds) before flapping begins after it is enabled.
+          type: integer
+          format: uint32
+          x-field-uid: 5
+        partial_flap:
+          description: |-
+            Enables flapping of only a subset of the routes within each selected route range, bounded by flap_from_route_index and flap_to_route_index. When disabled, all routes in the range are flapped.
+          type: boolean
+          x-field-uid: 6
+        flap_from_route_index:
+          description: |-
+            The starting route index (inclusive) of the subset to flap when partial_flap is enabled.
+          type: integer
+          format: uint32
+          x-field-uid: 7
+        flap_to_route_index:
+          description: |-
+            The ending route index (inclusive) of the subset to flap when partial_flap is enabled.
+          type: integer
+          format: uint32
+          x-field-uid: 8
     Action.Protocol.Bgp.Notification:
       description: "A NOTIFICATION message is sent when an error is detected with\
         \ the BGP session, such as hold timer expiring, misconfigured AS number  or\

--- a/artifacts/openapi.yaml
+++ b/artifacts/openapi.yaml
@@ -20126,8 +20126,6 @@ components:
       description: |-
         Sets the state of configured routes
       type: object
-      required:
-      - state
       properties:
         names:
           description: |
@@ -20164,6 +20162,40 @@ components:
           enum:
           - withdraw
           - advertise
+        flap:
+          x-status:
+            status: under_review
+            information: This is subject to change.
+          $ref: '#/components/schemas/State.Protocol.Route.Flap'
+          x-field-uid: 3
+          description: |-
+            Under Review: This is subject to change.
+
+            Description TBD
+    State.Protocol.Route.Flap:
+      description: |-
+        Flaps the selected routes on the fly by continuously withdrawing and re-advertising them.
+      type: object
+      required:
+      - enable
+      properties:
+        enable:
+          description: |-
+            Enables or disables flapping of the selected routes.
+          type: boolean
+          x-field-uid: 1
+        up_time:
+          description: |-
+            The duration (in seconds) for which each route stays advertised in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 2
+        down_time:
+          description: |-
+            The duration (in seconds) for which each route stays withdrawn in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 3
     State.Protocol.Lacp:
       description: |-
         Sets state of configured LACP
@@ -20964,16 +20996,85 @@ components:
               x-field-uid: 1
             initiate_graceful_restart:
               x-field-uid: 2
+            peer:
+              x-field-uid: 3
           x-field-uid: 1
           enum:
           - notification
           - initiate_graceful_restart
+          - peer
         notification:
           $ref: '#/components/schemas/Action.Protocol.Bgp.Notification'
           x-field-uid: 2
         initiate_graceful_restart:
           $ref: '#/components/schemas/Action.Protocol.Bgp.InitiateGracefulRestart'
           x-field-uid: 3
+        peer:
+          x-status:
+            status: under_review
+            information: This is subject to change.
+          $ref: '#/components/schemas/Action.Protocol.Bgp.Peer'
+          x-field-uid: 4
+          description: |-
+            Under Review: This is subject to change.
+
+            Description TBD
+    Action.Protocol.Bgp.Peer:
+      description: |-
+        Actions associated with configured BGP peers.
+      type: object
+      required:
+      - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            flap:
+              x-field-uid: 1
+          x-field-uid: 1
+          enum:
+          - flap
+        flap:
+          $ref: '#/components/schemas/Action.Protocol.Bgp.Peer.Flap'
+          x-field-uid: 2
+    Action.Protocol.Bgp.Peer.Flap:
+      description: |-
+        Flaps the selected BGP peer sessions on the fly by continuously bringing them down and up.
+      type: object
+      required:
+      - enable
+      properties:
+        peer_names:
+          description: |
+            The names of BGP peers to flap. An empty or null list will flap all configured BGP peers.
+
+            x-constraint:
+            - /components/schemas/Bgp.V4Peer/properties/name
+            - /components/schemas/Bgp.V6Peer/properties/name
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - /components/schemas/Bgp.V4Peer/properties/name
+          - /components/schemas/Bgp.V6Peer/properties/name
+          x-field-uid: 1
+        enable:
+          description: |-
+            Enables or disables flapping of the selected BGP peer sessions.
+          type: boolean
+          x-field-uid: 2
+        up_time:
+          description: |-
+            The duration (in seconds) for which each BGP session stays up in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 3
+        down_time:
+          description: |-
+            The duration (in seconds) for which each BGP session stays down in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 4
     Action.Protocol.Bgp.Notification:
       description: "A NOTIFICATION message is sent when an error is detected with\
         \ the BGP session, such as hold timer expiring, misconfigured AS number  or\

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -15507,26 +15507,6 @@ message StateProtocolRoute {
   }
   // Route states
   optional State.Enum state = 2;
-
-  // Under Review: This is subject to change.
-  // 
-  // Description TBD
-  StateProtocolRouteFlap flap = 3;
-}
-
-// Flaps the selected routes on the fly by continuously withdrawing and re-advertising
-// them.
-message StateProtocolRouteFlap {
-
-  // Enables or disables flapping of the selected routes.
-  // required = true
-  optional bool enable = 1;
-
-  // The duration (in seconds) for which each route stays advertised in a flap cycle.
-  optional uint32 up_time = 2;
-
-  // The duration (in seconds) for which each route stays withdrawn in a flap cycle.
-  optional uint32 down_time = 3;
 }
 
 // Sets state of configured LACP
@@ -16180,6 +16160,7 @@ message ActionProtocolBgp {
       notification = 1;
       initiate_graceful_restart = 2;
       peer = 3;
+      route = 4;
     }
   }
   // Description missing in models
@@ -16196,6 +16177,11 @@ message ActionProtocolBgp {
   // 
   // Description TBD
   ActionProtocolBgpPeer peer = 4;
+
+  // Under Review: This is subject to change.
+  // 
+  // Description TBD
+  ActionProtocolBgpRoute route = 5;
 }
 
 // Actions associated with configured BGP peers.
@@ -16237,6 +16223,61 @@ message ActionProtocolBgpPeerFlap {
 
   // The duration (in seconds) for which each BGP session stays down in a flap cycle.
   optional uint32 down_time = 4;
+}
+
+// Actions associated with configured BGP routes.
+message ActionProtocolBgpRoute {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      flap = 1;
+    }
+  }
+  // Description missing in models
+  // required = true
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  ActionProtocolBgpRouteFlap flap = 2;
+}
+
+// Flaps the selected BGP route ranges on the fly by continuously withdrawing and re-advertising
+// them.
+message ActionProtocolBgpRouteFlap {
+
+  // The names of BGP route ranges to flap. An empty or null list will flap all configured
+  // BGP route ranges.
+  // 
+  // x-constraint:
+  // - /components/schemas/Bgp.V4RouteRange/properties/name
+  // - /components/schemas/Bgp.V6RouteRange/properties/name
+  // 
+  repeated string route_names = 1;
+
+  // Enables or disables flapping of the selected BGP route ranges.
+  // required = true
+  optional bool enable = 2;
+
+  // The duration (in seconds) for which each route stays advertised in a flap cycle.
+  optional uint32 up_time = 3;
+
+  // The duration (in seconds) for which each route stays withdrawn in a flap cycle.
+  optional uint32 down_time = 4;
+
+  // The delay (in seconds) before flapping begins after it is enabled.
+  optional uint32 delay = 5;
+
+  // Enables flapping of only a subset of the routes within each selected route range,
+  // bounded by flap_from_route_index and flap_to_route_index. When disabled, all routes
+  // in the range are flapped.
+  optional bool partial_flap = 6;
+
+  // The starting route index (inclusive) of the subset to flap when partial_flap is enabled.
+  optional uint32 flap_from_route_index = 7;
+
+  // The ending route index (inclusive) of the subset to flap when partial_flap is enabled.
+  optional uint32 flap_to_route_index = 8;
 }
 
 // A NOTIFICATION message is sent when an error is detected with the BGP session, such

--- a/artifacts/otg.proto
+++ b/artifacts/otg.proto
@@ -15506,8 +15506,27 @@ message StateProtocolRoute {
     }
   }
   // Route states
-  // required = true
   optional State.Enum state = 2;
+
+  // Under Review: This is subject to change.
+  // 
+  // Description TBD
+  StateProtocolRouteFlap flap = 3;
+}
+
+// Flaps the selected routes on the fly by continuously withdrawing and re-advertising
+// them.
+message StateProtocolRouteFlap {
+
+  // Enables or disables flapping of the selected routes.
+  // required = true
+  optional bool enable = 1;
+
+  // The duration (in seconds) for which each route stays advertised in a flap cycle.
+  optional uint32 up_time = 2;
+
+  // The duration (in seconds) for which each route stays withdrawn in a flap cycle.
+  optional uint32 down_time = 3;
 }
 
 // Sets state of configured LACP
@@ -16160,6 +16179,7 @@ message ActionProtocolBgp {
       unspecified = 0;
       notification = 1;
       initiate_graceful_restart = 2;
+      peer = 3;
     }
   }
   // Description missing in models
@@ -16171,6 +16191,52 @@ message ActionProtocolBgp {
 
   // Description missing in models
   ActionProtocolBgpInitiateGracefulRestart initiate_graceful_restart = 3;
+
+  // Under Review: This is subject to change.
+  // 
+  // Description TBD
+  ActionProtocolBgpPeer peer = 4;
+}
+
+// Actions associated with configured BGP peers.
+message ActionProtocolBgpPeer {
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      flap = 1;
+    }
+  }
+  // Description missing in models
+  // required = true
+  optional Choice.Enum choice = 1;
+
+  // Description missing in models
+  ActionProtocolBgpPeerFlap flap = 2;
+}
+
+// Flaps the selected BGP peer sessions on the fly by continuously bringing them down
+// and up.
+message ActionProtocolBgpPeerFlap {
+
+  // The names of BGP peers to flap. An empty or null list will flap all configured BGP
+  // peers.
+  // 
+  // x-constraint:
+  // - /components/schemas/Bgp.V4Peer/properties/name
+  // - /components/schemas/Bgp.V6Peer/properties/name
+  // 
+  repeated string peer_names = 1;
+
+  // Enables or disables flapping of the selected BGP peer sessions.
+  // required = true
+  optional bool enable = 2;
+
+  // The duration (in seconds) for which each BGP session stays up in a flap cycle.
+  optional uint32 up_time = 3;
+
+  // The duration (in seconds) for which each BGP session stays down in a flap cycle.
+  optional uint32 down_time = 4;
 }
 
 // A NOTIFICATION message is sent when an error is detected with the BGP session, such

--- a/control/bgp.yaml
+++ b/control/bgp.yaml
@@ -20,6 +20,8 @@ components:
               x-field-uid: 1
             initiate_graceful_restart:
               x-field-uid: 2
+            peer:
+              x-field-uid: 3
           x-field-uid: 1
         notification:
           $ref: "#/components/schemas/Action.Protocol.Bgp.Notification"
@@ -27,7 +29,66 @@ components:
         initiate_graceful_restart:
           $ref: "#/components/schemas/Action.Protocol.Bgp.InitiateGracefulRestart"
           x-field-uid: 3
-      
+        peer:
+          x-status:
+            status: under_review
+            information: This is subject to change.
+          $ref: "#/components/schemas/Action.Protocol.Bgp.Peer"
+          x-field-uid: 4
+
+    Action.Protocol.Bgp.Peer:
+      description: >-
+        Actions associated with configured BGP peers.
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            flap:
+              x-field-uid: 1
+          x-field-uid: 1
+        flap:
+          $ref: "#/components/schemas/Action.Protocol.Bgp.Peer.Flap"
+          x-field-uid: 2
+
+    Action.Protocol.Bgp.Peer.Flap:
+      description: >-
+        Flaps the selected BGP peer sessions on the fly by continuously bringing them down and up.
+      type: object
+      required:
+        - enable
+      properties:
+        peer_names:
+          description: >-
+            The names of BGP peers to flap.
+            An empty or null list will flap all configured BGP peers.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - "/components/schemas/Bgp.V4Peer/properties/name"
+          - "/components/schemas/Bgp.V6Peer/properties/name"
+          x-field-uid: 1
+        enable:
+          description: >-
+            Enables or disables flapping of the selected BGP peer sessions.
+          type: boolean
+          x-field-uid: 2
+        up_time:
+          description: >-
+            The duration (in seconds) for which each BGP session stays up in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 3
+        down_time:
+          description: >-
+            The duration (in seconds) for which each BGP session stays down in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 4
+
     Action.Protocol.Bgp.Notification:
       description: >-
         A NOTIFICATION message is sent when an error is detected with the BGP session, such as hold timer expiring, misconfigured AS number 

--- a/control/bgp.yaml
+++ b/control/bgp.yaml
@@ -22,6 +22,8 @@ components:
               x-field-uid: 2
             peer:
               x-field-uid: 3
+            route:
+              x-field-uid: 4
           x-field-uid: 1
         notification:
           $ref: "#/components/schemas/Action.Protocol.Bgp.Notification"
@@ -35,6 +37,12 @@ components:
             information: This is subject to change.
           $ref: "#/components/schemas/Action.Protocol.Bgp.Peer"
           x-field-uid: 4
+        route:
+          x-status:
+            status: under_review
+            information: This is subject to change.
+          $ref: "#/components/schemas/Action.Protocol.Bgp.Route"
+          x-field-uid: 5
 
     Action.Protocol.Bgp.Peer:
       description: >-
@@ -88,6 +96,84 @@ components:
           type: integer
           format: uint32
           x-field-uid: 4
+
+    Action.Protocol.Bgp.Route:
+      description: >-
+        Actions associated with configured BGP routes.
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          x-enum:
+            flap:
+              x-field-uid: 1
+          x-field-uid: 1
+        flap:
+          $ref: "#/components/schemas/Action.Protocol.Bgp.Route.Flap"
+          x-field-uid: 2
+
+    Action.Protocol.Bgp.Route.Flap:
+      description: >-
+        Flaps the selected BGP route ranges on the fly by continuously withdrawing and re-advertising them.
+      type: object
+      required:
+        - enable
+      properties:
+        route_names:
+          description: >-
+            The names of BGP route ranges to flap.
+            An empty or null list will flap all configured BGP route ranges.
+          type: array
+          items:
+            type: string
+          x-constraint:
+          - "/components/schemas/Bgp.V4RouteRange/properties/name"
+          - "/components/schemas/Bgp.V6RouteRange/properties/name"
+          x-field-uid: 1
+        enable:
+          description: >-
+            Enables or disables flapping of the selected BGP route ranges.
+          type: boolean
+          x-field-uid: 2
+        up_time:
+          description: >-
+            The duration (in seconds) for which each route stays advertised in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 3
+        down_time:
+          description: >-
+            The duration (in seconds) for which each route stays withdrawn in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 4
+        delay:
+          description: >-
+            The delay (in seconds) before flapping begins after it is enabled.
+          type: integer
+          format: uint32
+          x-field-uid: 5
+        partial_flap:
+          description: >-
+            Enables flapping of only a subset of the routes within each selected route range,
+            bounded by flap_from_route_index and flap_to_route_index.
+            When disabled, all routes in the range are flapped.
+          type: boolean
+          x-field-uid: 6
+        flap_from_route_index:
+          description: >-
+            The starting route index (inclusive) of the subset to flap when partial_flap is enabled.
+          type: integer
+          format: uint32
+          x-field-uid: 7
+        flap_to_route_index:
+          description: >-
+            The ending route index (inclusive) of the subset to flap when partial_flap is enabled.
+          type: integer
+          format: uint32
+          x-field-uid: 8
 
     Action.Protocol.Bgp.Notification:
       description: >-

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -31,8 +31,6 @@ components:
       description: >-
         Sets the state of configured routes
       type: object
-      required:
-        - state
       properties:
         names:
           description: >-
@@ -60,6 +58,36 @@ components:
               x-field-uid: 1
             advertise:
               x-field-uid: 2
+        flap:
+          x-status:
+            status: under_review
+            information: This is subject to change.
+          $ref: '#/components/schemas/State.Protocol.Route.Flap'
+          x-field-uid: 3
+    State.Protocol.Route.Flap:
+      description: >-
+        Flaps the selected routes on the fly by continuously withdrawing and re-advertising them.
+      type: object
+      required:
+        - enable
+      properties:
+        enable:
+          description: >-
+            Enables or disables flapping of the selected routes.
+          type: boolean
+          x-field-uid: 1
+        up_time:
+          description: >-
+            The duration (in seconds) for which each route stays advertised in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 2
+        down_time:
+          description: >-
+            The duration (in seconds) for which each route stays withdrawn in a flap cycle.
+          type: integer
+          format: uint32
+          x-field-uid: 3
     State.Protocol.Lacp:
       description: >-
         Sets state of configured LACP

--- a/control/protocol.yaml
+++ b/control/protocol.yaml
@@ -58,36 +58,6 @@ components:
               x-field-uid: 1
             advertise:
               x-field-uid: 2
-        flap:
-          x-status:
-            status: under_review
-            information: This is subject to change.
-          $ref: '#/components/schemas/State.Protocol.Route.Flap'
-          x-field-uid: 3
-    State.Protocol.Route.Flap:
-      description: >-
-        Flaps the selected routes on the fly by continuously withdrawing and re-advertising them.
-      type: object
-      required:
-        - enable
-      properties:
-        enable:
-          description: >-
-            Enables or disables flapping of the selected routes.
-          type: boolean
-          x-field-uid: 1
-        up_time:
-          description: >-
-            The duration (in seconds) for which each route stays advertised in a flap cycle.
-          type: integer
-          format: uint32
-          x-field-uid: 2
-        down_time:
-          description: >-
-            The duration (in seconds) for which each route stays withdrawn in a flap cycle.
-          type: integer
-          format: uint32
-          x-field-uid: 3
     State.Protocol.Lacp:
       description: >-
         Sets state of configured LACP


### PR DESCRIPTION
Addresses #484

## What this adds
On-the-fly *flap* operations (start/stop while the session is up, no config change), per the requirements in #484:
- **`action.protocol.bgp.peer.flap`** — flap BGP peer sessions.
- **`action.protocol.bgp.route.flap`** — flap BGP route ranges.

## Design
Flapping is only supported on **BGP** peers and route ranges in IxNetwork; ISIS/OSPF route ranges have no flap fields (only a static `Active` flag). So both flap operations are modeled **BGP-scoped** under `Action.Protocol.Bgp`, alongside `notification` and `initiate_graceful_restart`:

- **`Action.Protocol.Bgp.Peer.Flap`** — `peer_names` (BGP peers), `enable`, `up_time`, `down_time`.
- **`Action.Protocol.Bgp.Route.Flap`** — `route_names` (BGP v4/v6 route ranges), `enable`, `up_time`, `down_time`, plus the extra route-range controls IxNetwork exposes:
  - `delay` — delay (seconds) before flapping begins.
  - `partial_flap` — flap only a subset of the routes within each range.
  - `flap_from_route_index` / `flap_to_route_index` — inclusive index window for the subset when `partial_flap` is enabled.

Flap is a triggered operation with timing, which fits the *action* scope per `control/readme.md` (states are representable purely by enums; actions are triggers). `x-field-uid`s are appended so existing fields are untouched. Both new operations are marked `x-status: under_review`.

### Note on scope (changed from the earlier revision of this PR)
Route flap was initially placed on the generic `State.Protocol.Route` (cross-protocol via its `x-constraint`). That advertised a flap capability for ISIS/OSPF that the backend can't honor, and the extra fields (`partial_flap`, `flap_from/to_route_index`) are BGP-route-range specific. It has been moved to `action.protocol.bgp.route.flap` and removed from `State.Protocol.Route` (which keeps `names` + `state` withdraw/advertise, honored by BGP/ISIS/OSPF via `Active`).

## Files
- `control/bgp.yaml`, `control/protocol.yaml` (source)
- `artifacts/openapi.yaml`, `artifacts/otg.proto` (regenerated via `build.py`)

## Testing
- `python build.py` passes (openapiart validation green).
